### PR TITLE
Fix overlay constraint crash

### DIFF
--- a/GhostPepper/UI/RecordingOverlay.swift
+++ b/GhostPepper/UI/RecordingOverlay.swift
@@ -32,8 +32,13 @@ class RecordingOverlayController {
         panel.ignoresMouseEvents = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
 
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 300, height: 60))
         let hosting = NSHostingView(rootView: OverlayPillView(message: message))
-        panel.contentView = hosting
+        hosting.sizingOptions = []
+        hosting.frame = container.bounds
+        hosting.autoresizingMask = [.width, .height]
+        container.addSubview(hosting)
+        panel.contentView = container
         self.hostingView = hosting
 
         if let screen = NSScreen.main {

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -1,6 +1,8 @@
 import XCTest
+import SwiftUI
 @testable import GhostPepper
 
+@MainActor
 final class GhostPepperTests: XCTestCase {
     func testAppStateInitialStatus() {
         // AppState is @MainActor so we test basic enum
@@ -8,5 +10,36 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(AppStatus.recording.rawValue, "Recording...")
         XCTAssertEqual(AppStatus.transcribing.rawValue, "Transcribing...")
         XCTAssertEqual(AppStatus.error.rawValue, "Error")
+    }
+
+    func testOverlayHostingViewDoesNotManageWindowSizingConstraints() {
+        let overlay = RecordingOverlayController()
+        overlay.show(message: .recording)
+        defer { overlay.dismiss() }
+
+        let panel: NSPanel? = unwrapPrivateOptional(named: "panel", from: overlay)
+        let hostingView: NSHostingView<OverlayPillView>? = unwrapPrivateOptional(
+            named: "hostingView",
+            from: overlay
+        )
+
+        XCTAssertNotNil(panel)
+        XCTAssertNotNil(hostingView)
+        XCTAssertEqual(hostingView?.sizingOptions, [])
+        XCTAssertFalse(panel?.contentView is NSHostingView<OverlayPillView>)
+    }
+
+    private func unwrapPrivateOptional<T>(named name: String, from object: Any) -> T? {
+        let mirror = Mirror(reflecting: object)
+        guard let child = mirror.children.first(where: { $0.label == name }) else {
+            return nil
+        }
+
+        let optionalMirror = Mirror(reflecting: child.value)
+        guard optionalMirror.displayStyle == .optional else {
+            return child.value as? T
+        }
+
+        return optionalMirror.children.first?.value as? T
     }
 }


### PR DESCRIPTION
## Summary
- stop using the recording overlay's `NSHostingView` as the panel's direct `contentView`
- disable `NSHostingView` sizing management for the overlay and embed it in a plain `NSView` container
- add a regression test that asserts the overlay hosting view no longer drives window sizing constraints

## Verification
- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Debug -derivedDataPath build/derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
- launched the built app and checked unified logs for the fresh process ID; no `NSGenericException`, `_crashOnException`, or `Update Constraints in Window` events were emitted during the smoke check