### PR TITLE
Add transcription stack core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,13 @@ Resources/models/
 # Logs
 *.log
 docs
+!docs/
+docs/*
+!docs/superpowers/
+docs/superpowers/*
+!docs/superpowers/specs/
+!docs/superpowers/specs/**
+!docs/superpowers/plans/
+!docs/superpowers/plans/**
 .superpowers/
+inspo/

--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -7,43 +7,82 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		056C454F3BD1A9795C6775A5 /* ScreenRecordingPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4B61BA7270EEC11A8AC69 /* ScreenRecordingPermissionController.swift */; };
+		0606E11E6F102BBB44ED08B6 /* ScreenRecordingPermissionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9ECBFE04804AA79262A07B /* ScreenRecordingPermissionControllerTests.swift */; };
 		0A1823314AE4FF4E17DCF627 /* sprite_frame_0.png in Resources */ = {isa = PBXBuildFile; fileRef = 2AF744C59EEAE51FC81BE6D6 /* sprite_frame_0.png */; };
 		0BC5D4645D21CA8AA000972E /* RecordingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3540C6212101C885EA22CD /* RecordingOverlay.swift */; };
+		17AF31EA19761CA8B7DF5F9A /* CleanupSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065F99395EEC3EB77997C2C /* CleanupSettings.swift */; };
+		1D533340C55B7F67AE1B4E94 /* CleanupPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 948064EDD38AFB0872A99BD6 /* CleanupPromptBuilder.swift */; };
 		1EF06A7EA54855634307E6A8 /* sprite_frame_4@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E0BBD0F5DD1B827D03F0F8F6 /* sprite_frame_4@2x.png */; };
+		2230B29BF920D15E5150B97E /* ChordAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E725F86E5430DC36EB03272 /* ChordAction.swift */; };
 		242A5D63A9F6E3FAD4E09F7D /* AudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960D35875D60655B17574DF8 /* AudioRecorderTests.swift */; };
+		2911F1771ED7BA232F973EC1 /* FrontmostWindowOCRService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC632CC6DD4F55F2FA05480 /* FrontmostWindowOCRService.swift */; };
+		2BEB4B4A879A749C8B92BE44 /* CorrectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D087A4D4CD5C6D3C293AE56 /* CorrectionStore.swift */; };
 		31E37E3EDDB8A0E5011BCA54 /* GhostPepperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9AE24266DDCCADE832CF33 /* GhostPepperApp.swift */; };
+		3512549BBD28CC74C0137FA3 /* CorrectionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350AC3A5A34A78F96226831C /* CorrectionStoreTests.swift */; };
 		361E7532F651C1BF7F0D0724 /* TextCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37863EC2F34067ED0C5B2B6F /* TextCleaner.swift */; };
 		38C7C0D8BB32CF7023CDE37B /* sprite_frame_2@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 029E36727193D8502C69FB38 /* sprite_frame_2@2x.png */; };
+		3E0533A0DF5754339BF5C410 /* DeterministicCorrectionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E2627BAB1434095C84F80A8 /* DeterministicCorrectionEngine.swift */; };
+		41C94A48B97D3A6861EA1E92 /* PostPasteLearningCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */; };
 		4CFBE4928A2B811D649B4140 /* TextCleanupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C0D4F04FFD2C13DEACA238 /* TextCleanupManager.swift */; };
 		4EAE492B8F7F4CB18D2E0FE9 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5407DA5D09555EDD69CA54 /* AudioRecorder.swift */; };
+		4F4C2206E3914B226A9DE4C0 /* PhysicalKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA57E9C267251FC86A8C8672 /* PhysicalKey.swift */; };
 		527B55EBCA9ACB4EC0FBC618 /* sprite_frame_0@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 79231C6829FD88741536FF4A /* sprite_frame_0@2x.png */; };
 		5473AA5B45F41F058B0503A0 /* sprite_frame_4.png in Resources */ = {isa = PBXBuildFile; fileRef = E02A8770518755585231EA8E /* sprite_frame_4.png */; };
 		5589DDF10DE9446993C99B6B /* MenuBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACCB8CD3CFA3BA1C91B5B87 /* MenuBarView.swift */; };
 		5651037151CFDA0813775EFF /* SoundEffects.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB769497B3910DF44EF911F /* SoundEffects.swift */; };
+		572FDC1B8744EECF73C0EA86 /* PasteSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934F425F25CCB580B8202127 /* PasteSession.swift */; };
+		58786AC40C6823691E15369C /* FocusedElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3575D1B5EA81CBB2CD1C2B /* FocusedElementLocator.swift */; };
 		5AB7257704509FD4BC36F69E /* TextPaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB2D492BFBDC803133A31 /* TextPaster.swift */; };
 		5AC883ADFD11721A8E9E4D37 /* ModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAE65A5741A98AEADF6498D /* ModelManager.swift */; };
+		5AFD58B50823656E71CF3AA9 /* OCRContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3BCEA6FF268C1759D1F20 /* OCRContext.swift */; };
 		637A68B05AD8479E0B5D52A7 /* HotkeyMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589AC554EEF132B519736D92 /* HotkeyMonitorTests.swift */; };
 		666D2339FC0689F41A3AE715 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 52CD995A5FADA02097BCD33F /* Sparkle */; };
+		6EA6ACF174AAA398586CC03A /* ChordEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518567C8CE0F7841ACE62BD1 /* ChordEngine.swift */; };
+		750B0226D3A035D24259B606 /* WindowCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F70F511A956DAB5778D430 /* WindowCaptureService.swift */; };
+		75509873255097FF99B8071F /* DebugLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB052D817F3005B509E9D479 /* DebugLogStore.swift */; };
+		77089185C9C0C0EDC4536F0A /* KeyChord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A54422D17879836781B7F71 /* KeyChord.swift */; };
 		780CB9207962633AEE3E69BD /* AudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF6390CFE5F526DD23C316D /* AudioDeviceManager.swift */; };
+		783179FB65E4B507B25CF691 /* ChordEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65270DAE5CA7F1A37B4D890B /* ChordEngineTests.swift */; };
 		78678A0067436B71C2C1C3C9 /* sprite_frame_1.png in Resources */ = {isa = PBXBuildFile; fileRef = 24362CABE7BBCAF53CB9B4A8 /* sprite_frame_1.png */; };
 		80C9E55FF57A1A03033DDDAE /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207AAC1CBC60052D1493D13D /* SettingsWindow.swift */; };
 		826FB25FE79E25F566EBEA68 /* sprite_frame_2.png in Resources */ = {isa = PBXBuildFile; fileRef = 4204197D6E98623EA69866C9 /* sprite_frame_2.png */; };
 		829C83DF25112D375A8DB767 /* UpdaterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F85AD0262D40047E6FCA3D8 /* UpdaterController.swift */; };
+		8990B2F77435E351A458EDD9 /* DebugLogWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2715D9117D8664700616D95A /* DebugLogWindow.swift */; };
 		8DB88CCDDA460DB0BE4DA5D9 /* WhisperTranscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05CA10D89E26492346D31E43 /* WhisperTranscriber.swift */; };
 		90F411F8E3564F1C5DDD1A5F /* TextPasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */; };
+		91B80C940C09B24CE80A4B81 /* ChordBindingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF767CF1AA15DB2C2B82A1C /* ChordBindingStoreTests.swift */; };
 		9965C422E2E6A1F48E717C28 /* LLM in Frameworks */ = {isa = PBXBuildFile; productRef = 985AD96FDE69D89C0B2DA245 /* LLM */; };
 		9BE17BC60B1F9CFD3747A844 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43A2B55CB980E02EC1E16BF2 /* Assets.xcassets */; };
 		9FF4377D176BB2AE30E4B08B /* sprite_frame_3@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FA48EF56983A55149A084D1B /* sprite_frame_3@2x.png */; };
 		A3183D30BAD0A1C2712E033F /* PermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1BDC9C549491AC003117EC /* PermissionChecker.swift */; };
+		A4826C92959DD203D5239B8E /* CleanupPromptBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36633332009332F588C183E /* CleanupPromptBuilderTests.swift */; };
 		A9E5AB4DC4D58FB4C50A1B23 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D4E875210CD0DADAF5D7E /* AppState.swift */; };
+		AB0AC6DC19EC0DB440F5B123 /* KeyChordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */; };
+		AF1DD5FE5059779E1D5D59C2 /* PostPasteLearningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE03E93B2A9E420B2C74CA /* PostPasteLearningCoordinator.swift */; };
+		B4F9DA24EDE1C2CCDDC80AE5 /* AppRelauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECE990F52DED36EC4C5458D /* AppRelauncher.swift */; };
+		B6F20B2AC3141F58C5CC59F5 /* MicPreviewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76A684AACE597180BC4B0169 /* MicPreviewControllerTests.swift */; };
+		BE7701382D2CC62C1CEBF29C /* ShortcutCaptureStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231812B1BF8E3F2D5E0209F3 /* ShortcutCaptureStateTests.swift */; };
 		BF329CF451CC34A3B74348CC /* HotkeyMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF88392E6B9F0168E43B8C51 /* HotkeyMonitor.swift */; };
 		C18E7F36CC6523A86671707D /* PromptEditorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B43697CC08695B8E8F8AD01 /* PromptEditorWindow.swift */; };
+		C4E8739F267E3096E97FBE71 /* DebugLogStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */; };
+		CBDE26BEEBD0419A73D09DFC /* OCRRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45DE13042196F9DF2445E66 /* OCRRequestFactory.swift */; };
+		CC795C47BAF8CEF62790BAFF /* LocalLLMCleanupBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE96F13974B4DC0EEB3C17E /* LocalLLMCleanupBackend.swift */; };
 		CE62853358A180E54150BCA4 /* OnboardingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EBA7ECAEFCAC714F83C2C5 /* OnboardingWindow.swift */; };
 		D0C9E92678ECFF9228D0B7F0 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 51FBB4B31E8E9293DC11143E /* WhisperKit */; };
+		D87DC24D05DAC4ED292C077B /* ShortcutCaptureState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01C000BF0DFBCCCF549921A /* ShortcutCaptureState.swift */; };
+		DA27C59BD3F0752E0E337813 /* CleanupBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8EC51C74573DD4A47E1CEB /* CleanupBackend.swift */; };
+		DBA25ED4D9D561452CE6EA50 /* ChordBindingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D91666EEE2CF7B4B78E3061 /* ChordBindingStore.swift */; };
+		E061E99A8C7A3977245EAEC5 /* TextCleanupManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 770403076BA384F3E35AA7A1 /* TextCleanupManagerTests.swift */; };
+		E06EAD2221790D5444E1F8E0 /* CleanupBackendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 886EA12D06680BB95FB78309 /* CleanupBackendTests.swift */; };
 		E1592D455869910E6FE13200 /* sprite_frame_1@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 8E41EBD0A6F249D987AE8853 /* sprite_frame_1@2x.png */; };
+		E5E590FA60691DA4B57DA7CB /* OCRContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */; };
+		EE25B297BB7834C3C90423B9 /* TextCleanerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49848DB685A19FBB6557B76E /* TextCleanerTests.swift */; };
+		F0598B5D027A5B31EF1B7664 /* FocusedElementLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC0D906FF181E91A758F58 /* FocusedElementLocatorTests.swift */; };
 		F3AF7560728D25C1A6B53F58 /* WhisperTranscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E515A7E5B9800C947AE8EC32 /* WhisperTranscriberTests.swift */; };
 		FAF9039162919F44252430A3 /* sprite_frame_3.png in Resources */ = {isa = PBXBuildFile; fileRef = DD3CB656299CBD7D3F6613F3 /* sprite_frame_3.png */; };
 		FC6AACB283BD40C4FBA78F3D /* GhostPepperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 363A3F98CDFC4CCAD927835C /* GhostPepperTests.swift */; };
+		FD94594085550A2A71F3F533 /* ShortcutRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C299194463F439E81D6BC /* ShortcutRecorderView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,43 +96,82 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0065F99395EEC3EB77997C2C /* CleanupSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupSettings.swift; sourceTree = "<group>"; };
 		029E36727193D8502C69FB38 /* sprite_frame_2@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_2@2x.png"; sourceTree = "<group>"; };
 		05CA10D89E26492346D31E43 /* WhisperTranscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperTranscriber.swift; sourceTree = "<group>"; };
+		0D91666EEE2CF7B4B78E3061 /* ChordBindingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordBindingStore.swift; sourceTree = "<group>"; };
+		0EDE03E93B2A9E420B2C74CA /* PostPasteLearningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPasteLearningCoordinator.swift; sourceTree = "<group>"; };
+		0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChordTests.swift; sourceTree = "<group>"; };
+		11E4B61BA7270EEC11A8AC69 /* ScreenRecordingPermissionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordingPermissionController.swift; sourceTree = "<group>"; };
+		17F70F511A956DAB5778D430 /* WindowCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureService.swift; sourceTree = "<group>"; };
+		1DC632CC6DD4F55F2FA05480 /* FrontmostWindowOCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmostWindowOCRService.swift; sourceTree = "<group>"; };
+		1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogStoreTests.swift; sourceTree = "<group>"; };
 		207AAC1CBC60052D1493D13D /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
+		231812B1BF8E3F2D5E0209F3 /* ShortcutCaptureStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureStateTests.swift; sourceTree = "<group>"; };
 		24362CABE7BBCAF53CB9B4A8 /* sprite_frame_1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_1.png; sourceTree = "<group>"; };
+		2715D9117D8664700616D95A /* DebugLogWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogWindow.swift; sourceTree = "<group>"; };
 		2ADE6885C71A11CEC8B2A50E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2AF744C59EEAE51FC81BE6D6 /* sprite_frame_0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_0.png; sourceTree = "<group>"; };
 		2B43697CC08695B8E8F8AD01 /* PromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptEditorWindow.swift; sourceTree = "<group>"; };
+		2F8EC51C74573DD4A47E1CEB /* CleanupBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupBackend.swift; sourceTree = "<group>"; };
 		338FDBA950D81CE2B3AC4EA0 /* GhostPepperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GhostPepperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		350AC3A5A34A78F96226831C /* CorrectionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionStoreTests.swift; sourceTree = "<group>"; };
 		363A3F98CDFC4CCAD927835C /* GhostPepperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostPepperTests.swift; sourceTree = "<group>"; };
 		37863EC2F34067ED0C5B2B6F /* TextCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleaner.swift; sourceTree = "<group>"; };
 		37C0D4F04FFD2C13DEACA238 /* TextCleanupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanupManager.swift; sourceTree = "<group>"; };
 		3A4D4E875210CD0DADAF5D7E /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		3E2627BAB1434095C84F80A8 /* DeterministicCorrectionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeterministicCorrectionEngine.swift; sourceTree = "<group>"; };
 		4204197D6E98623EA69866C9 /* sprite_frame_2.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_2.png; sourceTree = "<group>"; };
 		43A2B55CB980E02EC1E16BF2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		49848DB685A19FBB6557B76E /* TextCleanerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanerTests.swift; sourceTree = "<group>"; };
 		4A1EB2D492BFBDC803133A31 /* TextPaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPaster.swift; sourceTree = "<group>"; };
+		4E725F86E5430DC36EB03272 /* ChordAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordAction.swift; sourceTree = "<group>"; };
+		518567C8CE0F7841ACE62BD1 /* ChordEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordEngine.swift; sourceTree = "<group>"; };
 		52BCF852883B9E469B61B56B /* GhostPepper.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GhostPepper.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		589AC554EEF132B519736D92 /* HotkeyMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyMonitorTests.swift; sourceTree = "<group>"; };
 		5F85AD0262D40047E6FCA3D8 /* UpdaterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterController.swift; sourceTree = "<group>"; };
+		65270DAE5CA7F1A37B4D890B /* ChordEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordEngineTests.swift; sourceTree = "<group>"; };
 		6BAE65A5741A98AEADF6498D /* ModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManager.swift; sourceTree = "<group>"; };
+		6BF767CF1AA15DB2C2B82A1C /* ChordBindingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordBindingStoreTests.swift; sourceTree = "<group>"; };
+		76A684AACE597180BC4B0169 /* MicPreviewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicPreviewControllerTests.swift; sourceTree = "<group>"; };
+		770403076BA384F3E35AA7A1 /* TextCleanupManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanupManagerTests.swift; sourceTree = "<group>"; };
 		79231C6829FD88741536FF4A /* sprite_frame_0@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_0@2x.png"; sourceTree = "<group>"; };
+		886EA12D06680BB95FB78309 /* CleanupBackendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupBackendTests.swift; sourceTree = "<group>"; };
+		8D087A4D4CD5C6D3C293AE56 /* CorrectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionStore.swift; sourceTree = "<group>"; };
 		8E41EBD0A6F249D987AE8853 /* sprite_frame_1@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_1@2x.png"; sourceTree = "<group>"; };
 		8F5407DA5D09555EDD69CA54 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
+		934F425F25CCB580B8202127 /* PasteSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteSession.swift; sourceTree = "<group>"; };
+		948064EDD38AFB0872A99BD6 /* CleanupPromptBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupPromptBuilder.swift; sourceTree = "<group>"; };
 		94DD151A4D6F1474F4F138FD /* GhostPepper.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GhostPepper.entitlements; sourceTree = "<group>"; };
 		960D35875D60655B17574DF8 /* AudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderTests.swift; sourceTree = "<group>"; };
 		9A3540C6212101C885EA22CD /* RecordingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOverlay.swift; sourceTree = "<group>"; };
+		9A54422D17879836781B7F71 /* KeyChord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChord.swift; sourceTree = "<group>"; };
+		9C9ECBFE04804AA79262A07B /* ScreenRecordingPermissionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordingPermissionControllerTests.swift; sourceTree = "<group>"; };
+		9E3575D1B5EA81CBB2CD1C2B /* FocusedElementLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedElementLocator.swift; sourceTree = "<group>"; };
+		9FBC0D906FF181E91A758F58 /* FocusedElementLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedElementLocatorTests.swift; sourceTree = "<group>"; };
+		A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRContextTests.swift; sourceTree = "<group>"; };
+		A91C299194463F439E81D6BC /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		AACCB8CD3CFA3BA1C91B5B87 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
+		ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPasteLearningCoordinatorTests.swift; sourceTree = "<group>"; };
 		AC1BDC9C549491AC003117EC /* PermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChecker.swift; sourceTree = "<group>"; };
 		B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPasterTests.swift; sourceTree = "<group>"; };
+		BA57E9C267251FC86A8C8672 /* PhysicalKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalKey.swift; sourceTree = "<group>"; };
+		BB052D817F3005B509E9D479 /* DebugLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogStore.swift; sourceTree = "<group>"; };
+		BDE96F13974B4DC0EEB3C17E /* LocalLLMCleanupBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLLMCleanupBackend.swift; sourceTree = "<group>"; };
+		C01C000BF0DFBCCCF549921A /* ShortcutCaptureState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureState.swift; sourceTree = "<group>"; };
+		CDB3BCEA6FF268C1759D1F20 /* OCRContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRContext.swift; sourceTree = "<group>"; };
 		DD3CB656299CBD7D3F6613F3 /* sprite_frame_3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_3.png; sourceTree = "<group>"; };
 		DF9AE24266DDCCADE832CF33 /* GhostPepperApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostPepperApp.swift; sourceTree = "<group>"; };
 		DFB769497B3910DF44EF911F /* SoundEffects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundEffects.swift; sourceTree = "<group>"; };
 		E02A8770518755585231EA8E /* sprite_frame_4.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_4.png; sourceTree = "<group>"; };
 		E0BBD0F5DD1B827D03F0F8F6 /* sprite_frame_4@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_4@2x.png"; sourceTree = "<group>"; };
+		E45DE13042196F9DF2445E66 /* OCRRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRRequestFactory.swift; sourceTree = "<group>"; };
 		E515A7E5B9800C947AE8EC32 /* WhisperTranscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperTranscriberTests.swift; sourceTree = "<group>"; };
 		EAF6390CFE5F526DD23C316D /* AudioDeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDeviceManager.swift; sourceTree = "<group>"; };
 		F0EBA7ECAEFCAC714F83C2C5 /* OnboardingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindow.swift; sourceTree = "<group>"; };
+		F36633332009332F588C183E /* CleanupPromptBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupPromptBuilderTests.swift; sourceTree = "<group>"; };
 		FA48EF56983A55149A084D1B /* sprite_frame_3@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_3@2x.png"; sourceTree = "<group>"; };
+		FECE990F52DED36EC4C5458D /* AppRelauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRelauncher.swift; sourceTree = "<group>"; };
 		FF88392E6B9F0168E43B8C51 /* HotkeyMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyMonitor.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -114,6 +192,7 @@
 		1E7F0C5D7440C7594FBB5FB3 /* GhostPepper */ = {
 			isa = PBXGroup;
 			children = (
+				FECE990F52DED36EC4C5458D /* AppRelauncher.swift */,
 				3A4D4E875210CD0DADAF5D7E /* AppState.swift */,
 				43A2B55CB980E02EC1E16BF2 /* Assets.xcassets */,
 				94DD151A4D6F1474F4F138FD /* GhostPepper.entitlements */,
@@ -123,12 +202,22 @@
 				5F85AD0262D40047E6FCA3D8 /* UpdaterController.swift */,
 				BD13B12B603D3A9D89A5F2C4 /* Audio */,
 				6A2ED16C65A7A2047D1F84F6 /* Cleanup */,
+				D5A9C7455B7D779E3D316BB3 /* Context */,
+				1ECD5CE040C24B0A348523BF /* Debug */,
 				5A7262C13F0644663C842FA0 /* Input */,
 				4694A9A6CDA9C5FA6623F377 /* Resources */,
 				B242BF76D6E42784C2A05EB5 /* Transcription */,
 				50C964CA46111D1FD8AFE84B /* UI */,
 			);
 			path = GhostPepper;
+			sourceTree = "<group>";
+		};
+		1ECD5CE040C24B0A348523BF /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				BB052D817F3005B509E9D479 /* DebugLogStore.swift */,
+			);
+			path = Debug;
 			sourceTree = "<group>";
 		};
 		3705D6F7BCD01CB7D37DF812 /* Products */ = {
@@ -160,11 +249,14 @@
 		50C964CA46111D1FD8AFE84B /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				2715D9117D8664700616D95A /* DebugLogWindow.swift */,
 				AACCB8CD3CFA3BA1C91B5B87 /* MenuBarView.swift */,
 				F0EBA7ECAEFCAC714F83C2C5 /* OnboardingWindow.swift */,
 				2B43697CC08695B8E8F8AD01 /* PromptEditorWindow.swift */,
 				9A3540C6212101C885EA22CD /* RecordingOverlay.swift */,
+				11E4B61BA7270EEC11A8AC69 /* ScreenRecordingPermissionController.swift */,
 				207AAC1CBC60052D1493D13D /* SettingsWindow.swift */,
+				A91C299194463F439E81D6BC /* ShortcutRecorderView.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -172,7 +264,14 @@
 		5A7262C13F0644663C842FA0 /* Input */ = {
 			isa = PBXGroup;
 			children = (
+				4E725F86E5430DC36EB03272 /* ChordAction.swift */,
+				0D91666EEE2CF7B4B78E3061 /* ChordBindingStore.swift */,
+				518567C8CE0F7841ACE62BD1 /* ChordEngine.swift */,
 				FF88392E6B9F0168E43B8C51 /* HotkeyMonitor.swift */,
+				9A54422D17879836781B7F71 /* KeyChord.swift */,
+				934F425F25CCB580B8202127 /* PasteSession.swift */,
+				BA57E9C267251FC86A8C8672 /* PhysicalKey.swift */,
+				C01C000BF0DFBCCCF549921A /* ShortcutCaptureState.swift */,
 				4A1EB2D492BFBDC803133A31 /* TextPaster.swift */,
 			);
 			path = Input;
@@ -181,6 +280,13 @@
 		6A2ED16C65A7A2047D1F84F6 /* Cleanup */ = {
 			isa = PBXGroup;
 			children = (
+				2F8EC51C74573DD4A47E1CEB /* CleanupBackend.swift */,
+				948064EDD38AFB0872A99BD6 /* CleanupPromptBuilder.swift */,
+				0065F99395EEC3EB77997C2C /* CleanupSettings.swift */,
+				8D087A4D4CD5C6D3C293AE56 /* CorrectionStore.swift */,
+				3E2627BAB1434095C84F80A8 /* DeterministicCorrectionEngine.swift */,
+				BDE96F13974B4DC0EEB3C17E /* LocalLLMCleanupBackend.swift */,
+				0EDE03E93B2A9E420B2C74CA /* PostPasteLearningCoordinator.swift */,
 				37863EC2F34067ED0C5B2B6F /* TextCleaner.swift */,
 				37C0D4F04FFD2C13DEACA238 /* TextCleanupManager.swift */,
 			);
@@ -215,12 +321,39 @@
 			path = Audio;
 			sourceTree = "<group>";
 		};
+		D5A9C7455B7D779E3D316BB3 /* Context */ = {
+			isa = PBXGroup;
+			children = (
+				9E3575D1B5EA81CBB2CD1C2B /* FocusedElementLocator.swift */,
+				1DC632CC6DD4F55F2FA05480 /* FrontmostWindowOCRService.swift */,
+				CDB3BCEA6FF268C1759D1F20 /* OCRContext.swift */,
+				E45DE13042196F9DF2445E66 /* OCRRequestFactory.swift */,
+				17F70F511A956DAB5778D430 /* WindowCaptureService.swift */,
+			);
+			path = Context;
+			sourceTree = "<group>";
+		};
 		FD52C5E171D3EF7591022762 /* GhostPepperTests */ = {
 			isa = PBXGroup;
 			children = (
 				960D35875D60655B17574DF8 /* AudioRecorderTests.swift */,
+				6BF767CF1AA15DB2C2B82A1C /* ChordBindingStoreTests.swift */,
+				65270DAE5CA7F1A37B4D890B /* ChordEngineTests.swift */,
+				886EA12D06680BB95FB78309 /* CleanupBackendTests.swift */,
+				F36633332009332F588C183E /* CleanupPromptBuilderTests.swift */,
+				350AC3A5A34A78F96226831C /* CorrectionStoreTests.swift */,
+				1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */,
+				9FBC0D906FF181E91A758F58 /* FocusedElementLocatorTests.swift */,
 				363A3F98CDFC4CCAD927835C /* GhostPepperTests.swift */,
 				589AC554EEF132B519736D92 /* HotkeyMonitorTests.swift */,
+				0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */,
+				76A684AACE597180BC4B0169 /* MicPreviewControllerTests.swift */,
+				A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */,
+				ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */,
+				9C9ECBFE04804AA79262A07B /* ScreenRecordingPermissionControllerTests.swift */,
+				231812B1BF8E3F2D5E0209F3 /* ShortcutCaptureStateTests.swift */,
+				49848DB685A19FBB6557B76E /* TextCleanerTests.swift */,
+				770403076BA384F3E35AA7A1 /* TextCleanupManagerTests.swift */,
 				B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */,
 				E515A7E5B9800C947AE8EC32 /* WhisperTranscriberTests.swift */,
 			);
@@ -336,24 +469,48 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4F9DA24EDE1C2CCDDC80AE5 /* AppRelauncher.swift in Sources */,
 				A9E5AB4DC4D58FB4C50A1B23 /* AppState.swift in Sources */,
 				780CB9207962633AEE3E69BD /* AudioDeviceManager.swift in Sources */,
 				4EAE492B8F7F4CB18D2E0FE9 /* AudioRecorder.swift in Sources */,
+				2230B29BF920D15E5150B97E /* ChordAction.swift in Sources */,
+				DBA25ED4D9D561452CE6EA50 /* ChordBindingStore.swift in Sources */,
+				6EA6ACF174AAA398586CC03A /* ChordEngine.swift in Sources */,
+				DA27C59BD3F0752E0E337813 /* CleanupBackend.swift in Sources */,
+				1D533340C55B7F67AE1B4E94 /* CleanupPromptBuilder.swift in Sources */,
+				17AF31EA19761CA8B7DF5F9A /* CleanupSettings.swift in Sources */,
+				2BEB4B4A879A749C8B92BE44 /* CorrectionStore.swift in Sources */,
+				75509873255097FF99B8071F /* DebugLogStore.swift in Sources */,
+				8990B2F77435E351A458EDD9 /* DebugLogWindow.swift in Sources */,
+				3E0533A0DF5754339BF5C410 /* DeterministicCorrectionEngine.swift in Sources */,
+				58786AC40C6823691E15369C /* FocusedElementLocator.swift in Sources */,
+				2911F1771ED7BA232F973EC1 /* FrontmostWindowOCRService.swift in Sources */,
 				31E37E3EDDB8A0E5011BCA54 /* GhostPepperApp.swift in Sources */,
 				BF329CF451CC34A3B74348CC /* HotkeyMonitor.swift in Sources */,
+				77089185C9C0C0EDC4536F0A /* KeyChord.swift in Sources */,
+				CC795C47BAF8CEF62790BAFF /* LocalLLMCleanupBackend.swift in Sources */,
 				5589DDF10DE9446993C99B6B /* MenuBarView.swift in Sources */,
 				5AC883ADFD11721A8E9E4D37 /* ModelManager.swift in Sources */,
+				5AFD58B50823656E71CF3AA9 /* OCRContext.swift in Sources */,
+				CBDE26BEEBD0419A73D09DFC /* OCRRequestFactory.swift in Sources */,
 				CE62853358A180E54150BCA4 /* OnboardingWindow.swift in Sources */,
+				572FDC1B8744EECF73C0EA86 /* PasteSession.swift in Sources */,
 				A3183D30BAD0A1C2712E033F /* PermissionChecker.swift in Sources */,
+				4F4C2206E3914B226A9DE4C0 /* PhysicalKey.swift in Sources */,
+				AF1DD5FE5059779E1D5D59C2 /* PostPasteLearningCoordinator.swift in Sources */,
 				C18E7F36CC6523A86671707D /* PromptEditorWindow.swift in Sources */,
 				0BC5D4645D21CA8AA000972E /* RecordingOverlay.swift in Sources */,
+				056C454F3BD1A9795C6775A5 /* ScreenRecordingPermissionController.swift in Sources */,
 				80C9E55FF57A1A03033DDDAE /* SettingsWindow.swift in Sources */,
+				D87DC24D05DAC4ED292C077B /* ShortcutCaptureState.swift in Sources */,
+				FD94594085550A2A71F3F533 /* ShortcutRecorderView.swift in Sources */,
 				5651037151CFDA0813775EFF /* SoundEffects.swift in Sources */,
 				361E7532F651C1BF7F0D0724 /* TextCleaner.swift in Sources */,
 				4CFBE4928A2B811D649B4140 /* TextCleanupManager.swift in Sources */,
 				5AB7257704509FD4BC36F69E /* TextPaster.swift in Sources */,
 				829C83DF25112D375A8DB767 /* UpdaterController.swift in Sources */,
 				8DB88CCDDA460DB0BE4DA5D9 /* WhisperTranscriber.swift in Sources */,
+				750B0226D3A035D24259B606 /* WindowCaptureService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -362,8 +519,23 @@
 			buildActionMask = 2147483647;
 			files = (
 				242A5D63A9F6E3FAD4E09F7D /* AudioRecorderTests.swift in Sources */,
+				91B80C940C09B24CE80A4B81 /* ChordBindingStoreTests.swift in Sources */,
+				783179FB65E4B507B25CF691 /* ChordEngineTests.swift in Sources */,
+				E06EAD2221790D5444E1F8E0 /* CleanupBackendTests.swift in Sources */,
+				A4826C92959DD203D5239B8E /* CleanupPromptBuilderTests.swift in Sources */,
+				3512549BBD28CC74C0137FA3 /* CorrectionStoreTests.swift in Sources */,
+				C4E8739F267E3096E97FBE71 /* DebugLogStoreTests.swift in Sources */,
+				F0598B5D027A5B31EF1B7664 /* FocusedElementLocatorTests.swift in Sources */,
 				FC6AACB283BD40C4FBA78F3D /* GhostPepperTests.swift in Sources */,
 				637A68B05AD8479E0B5D52A7 /* HotkeyMonitorTests.swift in Sources */,
+				AB0AC6DC19EC0DB440F5B123 /* KeyChordTests.swift in Sources */,
+				B6F20B2AC3141F58C5CC59F5 /* MicPreviewControllerTests.swift in Sources */,
+				E5E590FA60691DA4B57DA7CB /* OCRContextTests.swift in Sources */,
+				41C94A48B97D3A6861EA1E92 /* PostPasteLearningCoordinatorTests.swift in Sources */,
+				0606E11E6F102BBB44ED08B6 /* ScreenRecordingPermissionControllerTests.swift in Sources */,
+				BE7701382D2CC62C1CEBF29C /* ShortcutCaptureStateTests.swift in Sources */,
+				EE25B297BB7834C3C90423B9 /* TextCleanerTests.swift in Sources */,
+				E061E99A8C7A3977245EAEC5 /* TextCleanupManagerTests.swift in Sources */,
 				90F411F8E3564F1C5DDD1A5F /* TextPasterTests.swift in Sources */,
 				F3AF7560728D25C1A6B53F58 /* WhisperTranscriberTests.swift in Sources */,
 			);

--- a/GhostPepper/AppRelauncher.swift
+++ b/GhostPepper/AppRelauncher.swift
@@ -1,0 +1,32 @@
+import AppKit
+
+protocol AppRelaunching {
+    @MainActor
+    func relaunch() throws
+}
+
+final class AppRelauncher: AppRelaunching {
+    private let bundleURL: URL
+    private let openApplication: (URL) throws -> Void
+
+    init(
+        bundleURL: URL = Bundle.main.bundleURL,
+        openApplication: @escaping (URL) throws -> Void = AppRelauncher.openApplication
+    ) {
+        self.bundleURL = bundleURL
+        self.openApplication = openApplication
+    }
+
+    @MainActor
+    func relaunch() throws {
+        try openApplication(bundleURL)
+        NSApplication.shared.terminate(nil)
+    }
+
+    private static func openApplication(bundleURL: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = ["-n", bundleURL.path]
+        try process.run()
+    }
+}

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -16,35 +16,183 @@ class AppState: ObservableObject {
     @Published var status: AppStatus = .loading
     @Published var isRecording: Bool = false
     @Published var errorMessage: String?
+    @Published var shortcutErrorMessage: String?
+    @Published var cleanupBackend: CleanupBackendOption {
+        didSet {
+            cleanupSettingsDefaults.set(cleanupBackend.rawValue, forKey: Self.cleanupBackendDefaultsKey)
+        }
+    }
+    @Published var frontmostWindowContextEnabled: Bool {
+        didSet {
+            cleanupSettingsDefaults.set(
+                frontmostWindowContextEnabled,
+                forKey: Self.frontmostWindowContextEnabledDefaultsKey
+            )
+        }
+    }
     @AppStorage("cleanupEnabled") var cleanupEnabled: Bool = true
     @AppStorage("cleanupPrompt") var cleanupPrompt: String = TextCleaner.defaultPrompt
+    @Published private(set) var pushToTalkChord: KeyChord
+    @Published private(set) var toggleToTalkChord: KeyChord
+    @Published var postPasteLearningEnabled: Bool {
+        didSet {
+            cleanupSettingsDefaults.set(
+                postPasteLearningEnabled,
+                forKey: Self.postPasteLearningEnabledDefaultsKey
+            )
+            postPasteLearningCoordinator.learningEnabled = postPasteLearningEnabled
+        }
+    }
 
     let modelManager = ModelManager()
     let audioRecorder = AudioRecorder()
     let transcriber: WhisperTranscriber
-    let textPaster = TextPaster()
+    let textPaster: TextPaster
     let soundEffects = SoundEffects()
-    let hotkeyMonitor = HotkeyMonitor()
+    let hotkeyMonitor: HotkeyMonitoring
     let overlay = RecordingOverlayController()
-    let textCleanupManager = TextCleanupManager()
+    let textCleanupManager: TextCleanupManager
+    let frontmostWindowOCRService: FrontmostWindowOCRService
+    let cleanupPromptBuilder: CleanupPromptBuilder
+    let correctionStore: CorrectionStore
     let textCleaner: TextCleaner
+    let chordBindingStore: ChordBindingStore
+    let postPasteLearningCoordinator: PostPasteLearningCoordinator
+    let debugLogStore: DebugLogStore
+    let appRelauncher: AppRelaunching
 
     var isReady: Bool {
         status == .ready
     }
 
-    private var cleanupStateObserver: Any?
+    private var cleanupStateObserver: Any? = nil
+    private let cleanupSettingsDefaults: UserDefaults
+    private let inputMonitoringChecker: () -> Bool
+    private let inputMonitoringPrompter: () -> Void
+    private var hotkeyMonitorStarted = false
 
-    init() {
+    private static let cleanupBackendDefaultsKey = "cleanupBackend"
+    private static let frontmostWindowContextEnabledDefaultsKey = "frontmostWindowContextEnabled"
+    private static let postPasteLearningEnabledDefaultsKey = "postPasteLearningEnabled"
+
+    nonisolated static let defaultPushToTalkChord = KeyChord(keys: Set([
+        PhysicalKey(keyCode: 54),
+        PhysicalKey(keyCode: 61)
+    ]))!
+
+    nonisolated static let defaultToggleToTalkChord = KeyChord(keys: Set([
+        PhysicalKey(keyCode: 54),
+        PhysicalKey(keyCode: 61),
+        PhysicalKey(keyCode: 49)
+    ]))!
+
+    nonisolated static let defaultShortcutBindings: [ChordAction: KeyChord] = [
+        .pushToTalk: defaultPushToTalkChord,
+        .toggleToTalk: defaultToggleToTalkChord
+    ]
+
+    init(
+        hotkeyMonitor: HotkeyMonitoring = HotkeyMonitor(bindings: AppState.defaultShortcutBindings),
+        chordBindingStore: ChordBindingStore = ChordBindingStore(),
+        cleanupSettingsDefaults: UserDefaults = .standard,
+        textCleanupManager: TextCleanupManager? = nil,
+        frontmostWindowOCRService: FrontmostWindowOCRService = FrontmostWindowOCRService(),
+        cleanupPromptBuilder: CleanupPromptBuilder = CleanupPromptBuilder(),
+        correctionStore: CorrectionStore? = nil,
+        textPaster: TextPaster = TextPaster(),
+        debugLogStore: DebugLogStore = DebugLogStore(),
+        appRelauncher: AppRelaunching? = nil,
+        inputMonitoringChecker: @escaping () -> Bool = PermissionChecker.checkInputMonitoring,
+        inputMonitoringPrompter: @escaping () -> Void = PermissionChecker.promptInputMonitoring
+    ) {
+        self.hotkeyMonitor = hotkeyMonitor
+        self.chordBindingStore = chordBindingStore
+        self.cleanupSettingsDefaults = cleanupSettingsDefaults
+        self.textPaster = textPaster
+        self.debugLogStore = debugLogStore
+        self.appRelauncher = appRelauncher ?? AppRelauncher()
+        self.inputMonitoringChecker = inputMonitoringChecker
+        self.inputMonitoringPrompter = inputMonitoringPrompter
+        self.pushToTalkChord = chordBindingStore.binding(for: .pushToTalk) ?? AppState.defaultPushToTalkChord
+        self.toggleToTalkChord = chordBindingStore.binding(for: .toggleToTalk) ?? AppState.defaultToggleToTalkChord
+        self.textCleanupManager = textCleanupManager ?? TextCleanupManager(defaults: cleanupSettingsDefaults)
+        self.frontmostWindowOCRService = frontmostWindowOCRService
+        self.cleanupPromptBuilder = cleanupPromptBuilder
+        self.correctionStore = correctionStore ?? CorrectionStore(defaults: cleanupSettingsDefaults)
+        let storedCleanupBackend = CleanupBackendOption(
+            rawValue: cleanupSettingsDefaults.string(forKey: Self.cleanupBackendDefaultsKey) ?? ""
+        ) ?? .localModels
+        let storedFrontmostWindowContextEnabled = cleanupSettingsDefaults.bool(
+            forKey: Self.frontmostWindowContextEnabledDefaultsKey
+        )
+        let storedPostPasteLearningEnabled: Bool
+        if cleanupSettingsDefaults.object(forKey: Self.postPasteLearningEnabledDefaultsKey) == nil {
+            storedPostPasteLearningEnabled = true
+        } else {
+            storedPostPasteLearningEnabled = cleanupSettingsDefaults.bool(
+                forKey: Self.postPasteLearningEnabledDefaultsKey
+            )
+        }
+        self.cleanupBackend = storedCleanupBackend
+        self.frontmostWindowContextEnabled = storedFrontmostWindowContextEnabled
+        self.postPasteLearningEnabled = storedPostPasteLearningEnabled
         self.transcriber = WhisperTranscriber(modelManager: modelManager)
-        self.textCleaner = TextCleaner(cleanupManager: textCleanupManager)
+        self.textCleaner = TextCleaner(
+            cleanupManager: self.textCleanupManager,
+            correctionStore: self.correctionStore
+        )
+        self.postPasteLearningCoordinator = PostPasteLearningCoordinator(
+            correctionStore: self.correctionStore,
+            learningEnabled: storedPostPasteLearningEnabled,
+            revisit: { [correctionStore = self.correctionStore] session in
+                await PostPasteLearningObservationProvider.captureObservation(
+                    for: session,
+                    customWords: correctionStore.preferredOCRCustomWords
+                )
+            }
+        )
 
         // Forward cleanup manager state changes to trigger menu bar icon refresh
-        cleanupStateObserver = textCleanupManager.objectWillChange.sink { [weak self] _ in
+        cleanupStateObserver = self.textCleanupManager.objectWillChange.sink { [weak self] _ in
             Task { @MainActor in
                 self?.objectWillChange.send()
             }
         }
+
+        cleanupSettingsDefaults.set(storedCleanupBackend.rawValue, forKey: Self.cleanupBackendDefaultsKey)
+        cleanupSettingsDefaults.set(
+            storedFrontmostWindowContextEnabled,
+            forKey: Self.frontmostWindowContextEnabledDefaultsKey
+        )
+        cleanupSettingsDefaults.set(
+            storedPostPasteLearningEnabled,
+            forKey: Self.postPasteLearningEnabledDefaultsKey
+        )
+        persistShortcutBindingsIfNeeded()
+        hotkeyMonitor.updateBindings(shortcutBindings)
+        self.textPaster.onPaste = { [postPasteLearningCoordinator = self.postPasteLearningCoordinator] session in
+            postPasteLearningCoordinator.handlePaste(session)
+        }
+        let componentDebugLogger: (DebugLogCategory, String) -> Void = { [weak debugLogStore] category, message in
+            Task { @MainActor in
+                debugLogStore?.record(category: category, message: message)
+            }
+        }
+        let sensitiveComponentDebugLogger: (DebugLogCategory, String) -> Void = { [weak debugLogStore] category, message in
+            Task { @MainActor in
+                debugLogStore?.recordSensitive(category: category, message: message)
+            }
+        }
+        if let hotkeyMonitor = hotkeyMonitor as? HotkeyMonitor {
+            hotkeyMonitor.debugLogger = componentDebugLogger
+        }
+        self.textCleanupManager.debugLogger = componentDebugLogger
+        self.frontmostWindowOCRService.debugLogger = componentDebugLogger
+        self.frontmostWindowOCRService.sensitiveDebugLogger = sensitiveComponentDebugLogger
+        self.textCleaner.debugLogger = componentDebugLogger
+        self.textCleaner.sensitiveDebugLogger = sensitiveComponentDebugLogger
+        self.postPasteLearningCoordinator.debugLogger = componentDebugLogger
+        self.modelManager.debugLogger = componentDebugLogger
     }
 
     func initialize(skipPermissionPrompts: Bool = false) async {
@@ -71,6 +219,7 @@ class AppState: ObservableObject {
         if showOverlay {
             overlay.show(message: .modelLoading)
         }
+        debugLogStore.record(category: .model, message: "App initialization started.")
         if !modelManager.isReady {
             await modelManager.loadModel()
         }
@@ -86,34 +235,71 @@ class AppState: ObservableObject {
 
         await startHotkeyMonitor()
 
-        if cleanupEnabled {
-            Task {
-                await textCleanupManager.loadModel()
-                // Force menu bar icon refresh
-                objectWillChange.send()
-            }
+        await refreshCleanupModelState()
+    }
+
+    func relaunchApp() {
+        do {
+            try appRelauncher.relaunch()
+        } catch {
+            errorMessage = "Failed to relaunch Ghost Pepper: \(error.localizedDescription)"
         }
     }
 
     func startHotkeyMonitor() async {
-        hotkeyMonitor.onRecordingStart = { [weak self] in
+        hotkeyMonitor.onRecordingStart = nil
+        hotkeyMonitor.onRecordingStop = nil
+
+        hotkeyMonitor.onPushToTalkStart = { [weak self] in
             Task { @MainActor in
                 self?.startRecording()
             }
         }
-        hotkeyMonitor.onRecordingStop = { [weak self] in
+        hotkeyMonitor.onPushToTalkStop = { [weak self] in
+            Task { @MainActor in
+                await self?.stopRecordingAndTranscribe()
+            }
+        }
+        hotkeyMonitor.onToggleToTalkStart = { [weak self] in
+            Task { @MainActor in
+                self?.startRecording()
+            }
+        }
+        hotkeyMonitor.onToggleToTalkStop = { [weak self] in
             Task { @MainActor in
                 await self?.stopRecordingAndTranscribe()
             }
         }
 
+        hotkeyMonitor.updateBindings(shortcutBindings)
+
+        if hotkeyMonitorStarted {
+            debugLogStore.record(category: .hotkey, message: "Hotkey monitor start skipped because it is already active.")
+            if status != .error {
+                status = .ready
+                errorMessage = nil
+            }
+            return
+        }
+
+        if !inputMonitoringChecker() {
+            inputMonitoringPrompter()
+            errorMessage = "Input Monitoring access required — grant permission then click Retry"
+            status = .error
+            debugLogStore.record(category: .hotkey, message: errorMessage ?? "Input Monitoring access required.")
+            return
+        }
+
         if hotkeyMonitor.start() {
+            hotkeyMonitorStarted = true
             status = .ready
             errorMessage = nil
+            debugLogStore.record(category: .hotkey, message: "Hotkey monitor is ready.")
         } else {
             PermissionChecker.promptAccessibility()
             errorMessage = "Accessibility access required — grant permission then click Retry"
             status = .error
+            debugLogStore.record(category: .hotkey, message: errorMessage ?? "Accessibility access required.")
         }
     }
 
@@ -131,6 +317,7 @@ class AppState: ObservableObject {
 
         do {
             try audioRecorder.startRecording()
+            debugLogStore.record(category: .hotkey, message: "Recording started.")
             soundEffects.playStart()
             overlay.show(message: .recording)
             isRecording = true
@@ -144,6 +331,7 @@ class AppState: ObservableObject {
     private func stopRecordingAndTranscribe() async {
         guard status == .recording else { return }
 
+        debugLogStore.record(category: .hotkey, message: "Recording stopped. Starting transcription.")
         let buffer = await audioRecorder.stopRecording()
         soundEffects.playStop()
         isRecording = false
@@ -151,38 +339,30 @@ class AppState: ObservableObject {
         overlay.show(message: .transcribing)
 
         if let text = await transcriber.transcribe(audioBuffer: buffer) {
-            let finalText: String
-            if cleanupEnabled && textCleanupManager.isReady {
+            var windowContext: OCRContext?
+            if cleanupEnabled && canAttemptCleanup {
                 status = .cleaningUp
                 overlay.show(message: .cleaningUp)
-                finalText = await textCleaner.clean(text: text, prompt: cleanupPrompt)
-            } else {
-                finalText = text
-            }
 
-            // Append to log for debugging
-            let timestamp = ISO8601DateFormatter().string(from: Date())
-            let logEntry = """
-            [\(timestamp)]
-            --- RAW TRANSCRIPTION ---
-            \(text)
-            --- CLEANUP: enabled=\(cleanupEnabled), ready=\(textCleanupManager.isReady) ---
-            --- PROMPT ---
-            \(cleanupPrompt)
-            --- CLEANED OUTPUT ---
-            \(finalText)
-            --- END ---\n\n
-            """
-            let logDir = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent(".ghostpepper/logs")
-            let logFile = logDir.appendingPathComponent("transcript.log")
-            try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
-            if let handle = try? FileHandle(forWritingTo: logFile) {
-                handle.seekToEndOfFile()
-                handle.write(logEntry.data(using: .utf8)!)
-                handle.closeFile()
-            } else {
-                try? logEntry.write(to: logFile, atomically: true, encoding: .utf8)
+                if frontmostWindowContextEnabled {
+                    windowContext = await frontmostWindowOCRService.captureContext(customWords: ocrCustomWords)
+                    if windowContext == nil {
+                        debugLogStore.record(category: .ocr, message: "No frontmost-window OCR context was captured.")
+                    }
+                }
             }
+            let cleanupResult = await cleanedTranscriptionResult(text, windowContext: windowContext)
+            let finalText = cleanupResult.text
+            let activeCleanupPrompt = cleanupResult.prompt
+
+            recordCleanupDebugSnapshot(
+                rawTranscription: text,
+                basePrompt: cleanupPrompt,
+                windowContext: windowContext,
+                resolvedPrompt: activeCleanupPrompt,
+                cleanedOutput: finalText,
+                attemptedCleanup: cleanupResult.attemptedCleanup
+            )
 
             overlay.dismiss()
             textPaster.paste(text: finalText)
@@ -190,10 +370,16 @@ class AppState: ObservableObject {
             overlay.dismiss()
             showInputCheckAlert()
             status = .ready
+            debugLogStore.record(category: .model, message: "Transcription returned no text.")
             return
         }
 
         status = .ready
+    }
+
+    func cleanedTranscription(_ text: String) async -> String {
+        let result = await cleanedTranscriptionResult(text, windowContext: nil)
+        return result.text
     }
 
     private func showInputCheckAlert() {
@@ -206,9 +392,186 @@ class AppState: ObservableObject {
 
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
-            settingsController.show(appState: self)
+            showSettings()
         }
     }
 
     private let settingsController = SettingsWindowController()
+    private let promptEditorController = PromptEditorController()
+    private let debugLogWindowController = DebugLogWindowController()
+
+    func showSettings() {
+        settingsController.show(appState: self)
+    }
+
+    func showPromptEditor() {
+        promptEditorController.show(appState: self)
+    }
+
+    func showDebugLog() {
+        debugLogWindowController.show(debugLogStore: debugLogStore)
+    }
+
+    private var shortcutBindings: [ChordAction: KeyChord] {
+        [
+            .pushToTalk: pushToTalkChord,
+            .toggleToTalk: toggleToTalkChord
+        ]
+    }
+
+    private func persistShortcutBindingsIfNeeded() {
+        try? chordBindingStore.setBinding(pushToTalkChord, for: .pushToTalk)
+        try? chordBindingStore.setBinding(toggleToTalkChord, for: .toggleToTalk)
+    }
+
+    private var canAttemptCleanup: Bool {
+        textCleanupManager.isReady
+    }
+
+    var shouldLoadLocalCleanupModels: Bool {
+        cleanupEnabled
+    }
+
+    private func cleanedTranscriptionResult(
+        _ text: String,
+        windowContext: OCRContext?
+    ) async -> (text: String, prompt: String, attemptedCleanup: Bool) {
+        guard cleanupEnabled else {
+            return (text: text, prompt: cleanupPrompt, attemptedCleanup: false)
+        }
+
+        let activeCleanupPrompt: String
+        if canAttemptCleanup {
+            activeCleanupPrompt = cleanupPromptBuilder.buildPrompt(
+                basePrompt: cleanupPrompt,
+                windowContext: windowContext,
+                preferredTranscriptions: correctionStore.preferredTranscriptions,
+                commonlyMisheard: correctionStore.commonlyMisheard,
+                includeWindowContext: frontmostWindowContextEnabled
+            )
+        } else {
+            activeCleanupPrompt = cleanupPrompt
+        }
+
+        let cleanedText = await textCleaner.clean(text: text, prompt: activeCleanupPrompt)
+        return (text: cleanedText, prompt: activeCleanupPrompt, attemptedCleanup: canAttemptCleanup)
+    }
+
+    var ocrCustomWords: [String] {
+        correctionStore.preferredOCRCustomWords
+    }
+
+    func recordCleanupDebugSnapshot(
+        rawTranscription: String,
+        basePrompt: String,
+        windowContext: OCRContext?,
+        resolvedPrompt: String,
+        cleanedOutput: String,
+        attemptedCleanup: Bool
+    ) {
+        let windowContents = windowContext?.windowContents ?? "(none)"
+        debugLogStore.recordSensitive(
+            category: .cleanup,
+            message: """
+            Raw transcription:
+            \(rawTranscription)
+            """
+        )
+        debugLogStore.recordSensitive(
+            category: .cleanup,
+            message: "cleanupEnabled=\(cleanupEnabled) attemptedCleanup=\(attemptedCleanup) backend=\(cleanupBackend.rawValue)"
+        )
+        debugLogStore.recordSensitive(
+            category: .cleanup,
+            message: """
+            Base cleanup prompt:
+            \(basePrompt)
+            """
+        )
+        debugLogStore.recordSensitive(
+            category: .cleanup,
+            message: """
+            OCR window contents:
+            \(windowContents)
+            """
+        )
+        debugLogStore.recordSensitive(
+            category: .cleanup,
+            message: """
+            Resolved cleanup prompt:
+            \(resolvedPrompt)
+            """
+        )
+        debugLogStore.recordSensitive(
+            category: .cleanup,
+            message: """
+            Final cleaned output:
+            \(cleanedOutput)
+            """
+        )
+    }
+
+    func updateShortcut(_ chord: KeyChord, for action: ChordAction) {
+        let previousPushChord = pushToTalkChord
+        let previousToggleChord = toggleToTalkChord
+
+        do {
+            try chordBindingStore.setBinding(chord, for: action)
+            shortcutErrorMessage = nil
+
+            switch action {
+            case .pushToTalk:
+                pushToTalkChord = chord
+            case .toggleToTalk:
+                toggleToTalkChord = chord
+            }
+
+            hotkeyMonitor.updateBindings(shortcutBindings)
+        } catch {
+            pushToTalkChord = previousPushChord
+            toggleToTalkChord = previousToggleChord
+            shortcutErrorMessage = "That shortcut is already in use."
+        }
+    }
+
+    func setShortcutCaptureActive(_ isActive: Bool) {
+        hotkeyMonitor.setSuspended(isActive)
+    }
+
+    func setCleanupEnabled(_ enabled: Bool) {
+        cleanupEnabled = enabled
+        Task {
+            await refreshCleanupModelState()
+        }
+    }
+
+    func updateCleanupBackend(_ backend: CleanupBackendOption) {
+        cleanupBackend = backend
+        Task {
+            await refreshCleanupModelState()
+        }
+    }
+
+    private func refreshCleanupModelState() async {
+        guard cleanupEnabled else {
+            debugLogStore.record(category: .model, message: "Cleanup disabled; unloading local cleanup models.")
+            textCleanupManager.unloadModel()
+            objectWillChange.send()
+            return
+        }
+
+        let shouldLoadLocalModels = shouldLoadLocalCleanupModels
+        debugLogStore.record(
+            category: .model,
+            message: "Cleanup backend is \(cleanupBackend.rawValue). shouldLoadLocalModels=\(shouldLoadLocalModels)"
+        )
+
+        if shouldLoadLocalModels {
+            await textCleanupManager.loadModel()
+        } else {
+            textCleanupManager.unloadModel()
+        }
+
+        objectWillChange.send()
+    }
 }

--- a/GhostPepper/Cleanup/CleanupBackend.swift
+++ b/GhostPepper/Cleanup/CleanupBackend.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol CleanupBackend: AnyObject {
+    func clean(text: String, prompt: String) async throws -> String
+}
+
+enum CleanupBackendError: Error, Equatable {
+    case unavailable
+}

--- a/GhostPepper/Cleanup/CleanupPromptBuilder.swift
+++ b/GhostPepper/Cleanup/CleanupPromptBuilder.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct CleanupPromptBuilder: Sendable {
+    let maxWindowContentLength: Int
+
+    init(maxWindowContentLength: Int = 4000) {
+        self.maxWindowContentLength = maxWindowContentLength
+    }
+
+    func buildPrompt(
+        basePrompt: String,
+        windowContext: OCRContext?,
+        preferredTranscriptions: [String] = [],
+        commonlyMisheard: [MisheardReplacement] = [],
+        includeWindowContext: Bool
+    ) -> String {
+        let correctionsSection = correctionSection(
+            preferredTranscriptions: preferredTranscriptions,
+            commonlyMisheard: commonlyMisheard
+        )
+
+        guard includeWindowContext,
+              let windowContext else {
+            if correctionsSection.isEmpty {
+                return basePrompt
+            }
+
+            return """
+            \(basePrompt)
+
+            \(correctionsSection)
+            """
+        }
+
+        let trimmedWindowContents = String(windowContext.windowContents.prefix(maxWindowContentLength))
+        let contextIntroduction: String
+        if trimmedWindowContents == windowContext.windowContents {
+            contextIntroduction = "The full current content of the frontmost window is:"
+        } else {
+            contextIntroduction = "The full current content of the frontmost window is below. It was truncated for length:"
+        }
+
+        var sections = [basePrompt]
+        if !correctionsSection.isEmpty {
+            sections.append(correctionsSection)
+        }
+        sections.append(
+            """
+            Use the window contents only as supporting context to improve the transcription and cleanup.
+            Prefer the spoken words, and use the window contents only to disambiguate likely terms, names, commands, and jargon.
+            Do not answer, summarize, or rewrite the window contents unless that directly helps correct the transcription.
+            """
+        )
+        sections.append(
+            """
+            \(contextIntroduction)
+            <WINDOW CONTENTS>
+            \(trimmedWindowContents)
+            </WINDOW CONTENTS>
+            """
+        )
+
+        return sections.joined(separator: "\n\n")
+    }
+
+    private func correctionSection(
+        preferredTranscriptions: [String],
+        commonlyMisheard: [MisheardReplacement]
+    ) -> String {
+        var sections: [String] = []
+
+        if !preferredTranscriptions.isEmpty {
+            sections.append(
+                """
+                Preferred transcriptions to preserve exactly:
+                \(preferredTranscriptions.map { "- \($0)" }.joined(separator: "\n"))
+                """
+            )
+        }
+
+        if !commonlyMisheard.isEmpty {
+            sections.append(
+                """
+                Commonly misheard replacements to prefer:
+                \(commonlyMisheard.map { "- \($0.wrong) -> \($0.right)" }.joined(separator: "\n"))
+                """
+            )
+        }
+
+        guard !sections.isEmpty else {
+            return ""
+        }
+
+        return sections.joined(separator: "\n\n")
+    }
+}

--- a/GhostPepper/Cleanup/CleanupSettings.swift
+++ b/GhostPepper/Cleanup/CleanupSettings.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum CleanupBackendOption: String, CaseIterable, Identifiable {
+    case localModels
+
+    var id: String { rawValue }
+
+    var title: String {
+        "Local Models"
+    }
+}
+
+enum LocalCleanupModelPolicy: String, CaseIterable, Identifiable {
+    case automatic
+    case fastOnly
+    case fullOnly
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .automatic:
+            return "Automatic"
+        case .fastOnly:
+            return "Fast model only"
+        case .fullOnly:
+            return "Full model only"
+        }
+    }
+}

--- a/GhostPepper/Cleanup/CorrectionStore.swift
+++ b/GhostPepper/Cleanup/CorrectionStore.swift
@@ -1,0 +1,123 @@
+import Combine
+import Foundation
+
+struct MisheardReplacement: Codable, Equatable, Hashable, Sendable {
+    let wrong: String
+    let right: String
+
+    init(wrong: String, right: String) {
+        self.wrong = wrong.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.right = right.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+final class CorrectionStore: ObservableObject {
+    @Published private(set) var preferredTranscriptions: [String]
+    @Published private(set) var commonlyMisheard: [MisheardReplacement]
+    @Published private(set) var preferredTranscriptionsDraft: String
+    @Published private(set) var commonlyMisheardDraft: String
+
+    var preferredOCRCustomWords: [String] {
+        preferredTranscriptions
+    }
+
+    var preferredTranscriptionsText: String {
+        get { preferredTranscriptionsDraft }
+        set { updatePreferredTranscriptions(from: newValue) }
+    }
+
+    var commonlyMisheardText: String {
+        get { commonlyMisheardDraft }
+        set { updateCommonlyMisheard(from: newValue) }
+    }
+
+    private static let preferredTranscriptionsDefaultsKey = "preferredTranscriptionsDraft"
+    private static let commonlyMisheardDefaultsKey = "commonlyMisheardDraft"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        let preferredDraft = defaults.string(forKey: Self.preferredTranscriptionsDefaultsKey) ?? ""
+        let commonlyMisheardDraft = defaults.string(forKey: Self.commonlyMisheardDefaultsKey) ?? ""
+
+        self.defaults = defaults
+        self.preferredTranscriptionsDraft = preferredDraft
+        self.commonlyMisheardDraft = commonlyMisheardDraft
+        self.preferredTranscriptions = Self.parsePreferredTranscriptions(from: preferredDraft)
+        self.commonlyMisheard = Self.parseCommonlyMisheard(from: commonlyMisheardDraft)
+    }
+
+    func updatePreferredTranscriptions(from text: String) {
+        preferredTranscriptionsDraft = text
+        preferredTranscriptions = Self.parsePreferredTranscriptions(from: text)
+        persistPreferredTranscriptions()
+    }
+
+    func updateCommonlyMisheard(from text: String) {
+        commonlyMisheardDraft = text
+        commonlyMisheard = Self.parseCommonlyMisheard(from: text)
+        persistCommonlyMisheard()
+    }
+
+    func appendCommonlyMisheard(_ replacement: MisheardReplacement) {
+        guard !replacement.wrong.isEmpty,
+              !replacement.right.isEmpty,
+              !commonlyMisheard.contains(replacement) else {
+            return
+        }
+
+        let line = "\(replacement.wrong) -> \(replacement.right)"
+        let separator = commonlyMisheardDraft.isEmpty || commonlyMisheardDraft.hasSuffix("\n") ? "" : "\n"
+        updateCommonlyMisheard(from: commonlyMisheardDraft + separator + line)
+    }
+
+    private func persistPreferredTranscriptions() {
+        defaults.set(preferredTranscriptionsDraft, forKey: Self.preferredTranscriptionsDefaultsKey)
+    }
+
+    private func persistCommonlyMisheard() {
+        defaults.set(commonlyMisheardDraft, forKey: Self.commonlyMisheardDefaultsKey)
+    }
+
+    private static func parsePreferredTranscriptions(from text: String) -> [String] {
+        uniqueValues(
+            text
+                .components(separatedBy: .newlines)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        )
+    }
+
+    private static func parseCommonlyMisheard(from text: String) -> [MisheardReplacement] {
+        let replacements = text
+            .components(separatedBy: .newlines)
+            .compactMap { line -> MisheardReplacement? in
+                let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmedLine.isEmpty else {
+                    return nil
+                }
+
+                let parts = trimmedLine.components(separatedBy: "->")
+                guard parts.count == 2 else {
+                    return nil
+                }
+
+                let replacement = MisheardReplacement(
+                    wrong: parts[0],
+                    right: parts[1]
+                )
+                guard !replacement.wrong.isEmpty, !replacement.right.isEmpty else {
+                    return nil
+                }
+
+                return replacement
+            }
+
+        return uniqueValues(replacements)
+    }
+
+    private static func uniqueValues<T: Hashable>(_ values: [T]) -> [T] {
+        var seen = Set<T>()
+        return values.filter { seen.insert($0).inserted }
+    }
+}

--- a/GhostPepper/Cleanup/DeterministicCorrectionEngine.swift
+++ b/GhostPepper/Cleanup/DeterministicCorrectionEngine.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+struct DeterministicCorrectionEngine: Sendable {
+    let preferredTranscriptions: [String]
+    let commonlyMisheard: [MisheardReplacement]
+
+    func applyPreCleanupCorrections(to text: String) -> String {
+        let protectedText = protectPreferredTranscriptions(in: text)
+        var correctedText = protectedText.text
+
+        for replacement in sortedMisheardReplacements {
+            correctedText = replacingPhrase(
+                replacement.wrong,
+                in: correctedText,
+                with: replacement.right
+            )
+        }
+
+        return restorePreferredTranscriptions(in: correctedText, replacements: protectedText.replacements)
+    }
+
+    func applyPostCleanupCorrections(to text: String) -> String {
+        sortedPreferredTranscriptions.reduce(text) { partialResult, preferredTranscription in
+            replacingPreferredPhrase(preferredTranscription, in: partialResult)
+        }
+    }
+
+    private var sortedPreferredTranscriptions: [String] {
+        preferredTranscriptions.sorted { $0.count > $1.count }
+    }
+
+    private var sortedMisheardReplacements: [MisheardReplacement] {
+        commonlyMisheard.sorted { $0.wrong.count > $1.wrong.count }
+    }
+
+    private func protectPreferredTranscriptions(in text: String) -> ProtectedText {
+        var protectedText = text
+        var replacements: [String: String] = [:]
+
+        for preferredTranscription in sortedPreferredTranscriptions {
+            guard let expression = phraseExpression(for: preferredTranscription) else {
+                continue
+            }
+
+            var searchRange = NSRange(protectedText.startIndex..<protectedText.endIndex, in: protectedText)
+
+            while let match = expression.firstMatch(in: protectedText, options: [], range: searchRange),
+                  let range = Range(match.range, in: protectedText) {
+                let token = "@@__GHOSTPEPPER_PREFERRED_\(replacements.count)__@@"
+                protectedText.replaceSubrange(range, with: token)
+                replacements[token] = preferredTranscription
+
+                guard let tokenRange = protectedText.range(of: token) else {
+                    break
+                }
+
+                searchRange = NSRange(tokenRange.upperBound..<protectedText.endIndex, in: protectedText)
+            }
+        }
+
+        return ProtectedText(text: protectedText, replacements: replacements)
+    }
+
+    private func restorePreferredTranscriptions(in text: String, replacements: [String: String]) -> String {
+        replacements.reduce(text) { partialResult, replacement in
+            partialResult.replacingOccurrences(of: replacement.key, with: replacement.value)
+        }
+    }
+
+    private func replacingPhrase(_ phrase: String, in text: String, with replacement: String) -> String {
+        guard let expression = phraseExpression(for: phrase) else {
+            return text
+        }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return expression.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: NSRegularExpression.escapedTemplate(for: replacement)
+        )
+    }
+
+    private func replacingPreferredPhrase(_ phrase: String, in text: String) -> String {
+        guard let expression = preferredPhraseExpression(for: phrase) else {
+            return text
+        }
+
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return expression.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: NSRegularExpression.escapedTemplate(for: phrase)
+        )
+    }
+
+    private func phraseExpression(for phrase: String) -> NSRegularExpression? {
+        let trimmedPhrase = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPhrase.isEmpty else {
+            return nil
+        }
+
+        let escapedPhrase = NSRegularExpression.escapedPattern(for: trimmedPhrase)
+        let startsWithWordCharacter = trimmedPhrase.unicodeScalars.first.map(CharacterSet.alphanumerics.contains) ?? false
+        let endsWithWordCharacter = trimmedPhrase.unicodeScalars.last.map(CharacterSet.alphanumerics.contains) ?? false
+        let prefix = startsWithWordCharacter ? "(?<![\\p{L}\\p{N}])" : ""
+        let suffix = endsWithWordCharacter ? "(?![\\p{L}\\p{N}])" : ""
+
+        return try? NSRegularExpression(
+            pattern: prefix + escapedPhrase + suffix,
+            options: [.caseInsensitive]
+        )
+    }
+
+    private func preferredPhraseExpression(for phrase: String) -> NSRegularExpression? {
+        let trimmedPhrase = phrase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedPhrase.isEmpty else {
+            return nil
+        }
+
+        let components = trimmedPhrase.components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+
+        guard components.count > 1 else {
+            return phraseExpression(for: trimmedPhrase)
+        }
+
+        let escapedComponents = components.map(NSRegularExpression.escapedPattern(for:))
+        let pattern = "(?<![\\p{L}\\p{N}])"
+            + escapedComponents.joined(separator: "[\\s\\p{P}\\p{S}_]*")
+            + "(?![\\p{L}\\p{N}])"
+
+        return try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+    }
+}
+
+private struct ProtectedText {
+    let text: String
+    let replacements: [String: String]
+}

--- a/GhostPepper/Cleanup/LocalLLMCleanupBackend.swift
+++ b/GhostPepper/Cleanup/LocalLLMCleanupBackend.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final class LocalLLMCleanupBackend: CleanupBackend {
+    private let cleanupManager: TextCleaningManaging
+
+    init(cleanupManager: TextCleaningManaging) {
+        self.cleanupManager = cleanupManager
+    }
+
+    func clean(text: String, prompt: String) async throws -> String {
+        guard let cleaned = await cleanupManager.clean(text: text, prompt: prompt) else {
+            throw CleanupBackendError.unavailable
+        }
+
+        return cleaned
+    }
+}

--- a/GhostPepper/Cleanup/PostPasteLearningCoordinator.swift
+++ b/GhostPepper/Cleanup/PostPasteLearningCoordinator.swift
@@ -1,0 +1,282 @@
+import CoreGraphics
+import Foundation
+
+struct PostPasteLearningObservation: Equatable, Sendable {
+    let recognizedText: String
+    let confidence: Double
+}
+
+final class PostPasteLearningCoordinator {
+    typealias Scheduler = @Sendable (TimeInterval, @escaping @Sendable () -> Void) -> Void
+    typealias Revisit = @Sendable (PasteSession) async -> PostPasteLearningObservation?
+
+    static let learningDelay: TimeInterval = 15
+    private static let minimumConfidence = 0.95
+    private static let maximumReplacementWordCount = 4
+
+    var learningEnabled: Bool
+
+    private let correctionStore: CorrectionStore
+    private let scheduler: Scheduler
+    private let revisit: Revisit
+
+    var debugLogger: ((DebugLogCategory, String) -> Void)?
+
+    init(
+        correctionStore: CorrectionStore,
+        learningEnabled: Bool = true,
+        scheduler: @escaping Scheduler = { delay, work in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        },
+        revisit: @escaping Revisit
+    ) {
+        self.correctionStore = correctionStore
+        self.learningEnabled = learningEnabled
+        self.scheduler = scheduler
+        self.revisit = revisit
+    }
+
+    func handlePaste(_ session: PasteSession) {
+        guard learningEnabled else {
+            debugLogger?(.cleanup, "Post-paste learning skipped because it is disabled.")
+            return
+        }
+
+        debugLogger?(.cleanup, "Scheduled post-paste learning revisit.")
+        scheduler(Self.learningDelay) {
+            Task {
+                await self.learn(from: session)
+            }
+        }
+    }
+
+    private func learn(from session: PasteSession) async {
+        guard learningEnabled else {
+            debugLogger?(.cleanup, "Post-paste learning skipped because it is disabled.")
+            return
+        }
+
+        debugLogger?(.cleanup, "Post-paste learning revisit started.")
+
+        guard let observation = await revisit(session) else {
+            debugLogger?(.cleanup, "Post-paste learning skipped because no OCR revisit observation was captured.")
+            return
+        }
+
+        guard observation.confidence >= Self.minimumConfidence else {
+            debugLogger?(.cleanup, "Post-paste learning skipped because OCR confidence \(observation.confidence) was below threshold.")
+            return
+        }
+
+        guard let replacement = Self.inferredReplacement(
+            from: session.pastedText,
+            to: observation.recognizedText
+        ) else {
+            debugLogger?(.cleanup, "Post-paste learning skipped because no narrow correction could be inferred.")
+            return
+        }
+
+        guard learningEnabled else {
+            debugLogger?(.cleanup, "Post-paste learning skipped because it was disabled before storing.")
+            return
+        }
+
+        await MainActor.run {
+            guard self.learningEnabled else {
+                self.debugLogger?(.cleanup, "Post-paste learning skipped because it was disabled before storing.")
+                return
+            }
+
+            self.store(replacement)
+        }
+    }
+
+    private func store(_ replacement: MisheardReplacement) {
+        correctionStore.appendCommonlyMisheard(replacement)
+        debugLogger?(.cleanup, "Post-paste learning learned replacement: \(replacement.wrong) -> \(replacement.right)")
+    }
+
+    private static func inferredReplacement(from original: String, to observed: String) -> MisheardReplacement? {
+        let trimmedOriginal = original.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedObserved = observed.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedOriginal.isEmpty,
+              !trimmedObserved.isEmpty,
+              trimmedOriginal.caseInsensitiveCompare(trimmedObserved) != .orderedSame else {
+            return nil
+        }
+
+        let originalWords = words(in: trimmedOriginal)
+        let observedWords = words(in: trimmedObserved)
+        let sharedPrefixCount = sharedPrefixLength(between: originalWords, and: observedWords)
+        let sharedSuffixCount = sharedSuffixLength(
+            between: originalWords,
+            and: observedWords,
+            excludingPrefix: sharedPrefixCount
+        )
+
+        guard sharedPrefixCount > 0 || sharedSuffixCount > 0 else {
+            return nil
+        }
+
+        let originalEndIndex = originalWords.count - sharedSuffixCount
+        let observedEndIndex = observedWords.count - sharedSuffixCount
+        let wrong = originalWords[sharedPrefixCount..<originalEndIndex].joined(separator: " ")
+        let right = observedWords[sharedPrefixCount..<observedEndIndex].joined(separator: " ")
+
+        guard !wrong.isEmpty,
+              !right.isEmpty,
+              wordCount(in: wrong) <= maximumReplacementWordCount,
+              wordCount(in: right) <= maximumReplacementWordCount else {
+            return nil
+        }
+
+        return MisheardReplacement(wrong: wrong, right: right)
+    }
+
+    private static func sharedPrefixLength(between lhs: [String], and rhs: [String]) -> Int {
+        let limit = min(lhs.count, rhs.count)
+        var index = 0
+        while index < limit && stringsMatch(lhs[index], rhs[index]) {
+            index += 1
+        }
+        return index
+    }
+
+    private static func sharedSuffixLength(
+        between lhs: [String],
+        and rhs: [String],
+        excludingPrefix prefixLength: Int
+    ) -> Int {
+        let limit = min(lhs.count, rhs.count) - prefixLength
+        guard limit > 0 else {
+            return 0
+        }
+
+        var count = 0
+        while count < limit &&
+                stringsMatch(lhs[lhs.count - count - 1], rhs[rhs.count - count - 1]) {
+            count += 1
+        }
+        return count
+    }
+
+    private static func stringsMatch(_ lhs: String, _ rhs: String) -> Bool {
+        lhs.caseInsensitiveCompare(rhs) == .orderedSame
+    }
+
+    private static func words(in text: String) -> [String] {
+        text.split(whereSeparator: \.isWhitespace).map(String.init)
+    }
+
+    private static func wordCount(in text: String) -> Int {
+        words(in: text).count
+    }
+}
+
+enum PostPasteLearningObservationProvider {
+    static func captureObservation(
+        for session: PasteSession,
+        customWords: [String],
+        locator: FocusedElementLocator = FocusedElementLocator(),
+        windowCaptureService: WindowCaptureServing = WindowCaptureService(),
+        requestFactory: OCRRequestFactory = OCRRequestFactory()
+    ) async -> PostPasteLearningObservation? {
+        guard PermissionChecker.hasScreenRecordingPermission(),
+              locator.frontmostApplicationBundleIdentifier() == session.frontmostAppBundleIdentifier,
+              let currentWindow = locator.frontmostWindowReference(),
+              currentWindow.windowID == session.frontmostWindowID,
+              let image = try? await windowCaptureService.captureFrontmostWindowImage() else {
+            return nil
+        }
+
+        let currentFocusedFrame = locator.focusedElementFrame()
+        let focusedCrop = focusedCropImage(
+            from: image,
+            currentWindowFrame: currentWindow.frame,
+            session: session,
+            currentFocusedFrame: currentFocusedFrame
+        )
+        let targetImage = focusedCrop ?? image
+
+        guard let result = try? requestFactory.recognizeDetailedText(
+            in: targetImage,
+            customWords: customWords
+        ) else {
+            return nil
+        }
+
+        return PostPasteLearningObservation(
+            recognizedText: result.text,
+            confidence: result.confidence
+        )
+    }
+
+    private static func focusedCropImage(
+        from image: CGImage,
+        currentWindowFrame: CGRect,
+        session: PasteSession,
+        currentFocusedFrame: CGRect?
+    ) -> CGImage? {
+        guard let sessionFocusedFrame = session.focusedElementFrame,
+              let currentFocusedFrame,
+              currentFocusedFrame.height > 0,
+              currentFocusedFrame.width > 0,
+              framesApproximatelyMatch(sessionFocusedFrame, currentFocusedFrame) else {
+            return nil
+        }
+
+        return crop(
+            image: image,
+            windowFrame: currentWindowFrame,
+            targetFrame: currentFocusedFrame
+        )
+    }
+
+    private static func framesApproximatelyMatch(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+        let allowableDeltaX = max(24, lhs.width * 0.2)
+        let allowableDeltaY = max(24, lhs.height * 0.2)
+        let allowableWidthDelta = max(24, lhs.width * 0.2)
+        let allowableHeightDelta = max(24, lhs.height * 0.2)
+
+        return abs(lhs.minX - rhs.minX) <= allowableDeltaX &&
+            abs(lhs.minY - rhs.minY) <= allowableDeltaY &&
+            abs(lhs.width - rhs.width) <= allowableWidthDelta &&
+            abs(lhs.height - rhs.height) <= allowableHeightDelta
+    }
+
+    private static func crop(
+        image: CGImage,
+        windowFrame: CGRect,
+        targetFrame: CGRect
+    ) -> CGImage? {
+        guard windowFrame.width > 0, windowFrame.height > 0 else {
+            return nil
+        }
+
+        let normalizedRect = CGRect(
+            x: (targetFrame.minX - windowFrame.minX) / windowFrame.width,
+            y: (targetFrame.minY - windowFrame.minY) / windowFrame.height,
+            width: targetFrame.width / windowFrame.width,
+            height: targetFrame.height / windowFrame.height
+        ).intersection(CGRect(x: 0, y: 0, width: 1, height: 1))
+
+        guard !normalizedRect.isNull,
+              normalizedRect.width > 0,
+              normalizedRect.height > 0 else {
+            return nil
+        }
+
+        let cropRect = CGRect(
+            x: normalizedRect.minX * CGFloat(image.width),
+            y: (1 - normalizedRect.maxY) * CGFloat(image.height),
+            width: normalizedRect.width * CGFloat(image.width),
+            height: normalizedRect.height * CGFloat(image.height)
+        ).integral
+
+        guard cropRect.width > 0, cropRect.height > 0 else {
+            return nil
+        }
+
+        return image.cropping(to: cropRect)
+    }
+}

--- a/GhostPepper/Cleanup/TextCleaner.swift
+++ b/GhostPepper/Cleanup/TextCleaner.swift
@@ -1,8 +1,14 @@
 import Foundation
-import LLM
 
 final class TextCleaner {
-    private let cleanupManager: TextCleanupManager
+    private static let thinkBlockExpression = try? NSRegularExpression(
+        pattern: #"(?is)<think\b[^>]*>.*?</think>"#
+    )
+
+    private let localBackend: CleanupBackend
+    private let correctionStore: CorrectionStore
+    var debugLogger: ((DebugLogCategory, String) -> Void)?
+    var sensitiveDebugLogger: ((DebugLogCategory, String) -> Void)?
 
     static let defaultPrompt = """
     You are an echo machine. Repeat back EVERYTHING the user says. Your ONLY allowed edits are:
@@ -30,63 +36,131 @@ final class TextCleaner {
     Output: I've been working on this and I'm stuck. Any ideas?
     """
 
-    private static let timeoutSeconds: TimeInterval = 15.0
+    init(
+        localBackend: CleanupBackend,
+        correctionStore: CorrectionStore = CorrectionStore()
+    ) {
+        self.localBackend = localBackend
+        self.correctionStore = correctionStore
+    }
 
-    init(cleanupManager: TextCleanupManager) {
-        self.cleanupManager = cleanupManager
+    convenience init(
+        cleanupManager: TextCleaningManaging,
+        correctionStore: CorrectionStore = CorrectionStore()
+    ) {
+        self.init(
+            localBackend: LocalLLMCleanupBackend(cleanupManager: cleanupManager),
+            correctionStore: correctionStore
+        )
     }
 
     @MainActor
     func clean(text: String, prompt: String? = nil) async -> String {
-        let wordCount = text.split(separator: " ").count
-        let isQuestion = text.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix("?")
-        // Use full model for questions (1.5B tries to answer them) and longer text
-        let useFullModel = isQuestion || wordCount > TextCleanupManager.shortInputThreshold
-        let llm: LLM
-        if useFullModel {
-            guard let model = cleanupManager.fullLLM ?? cleanupManager.fastLLM else { return text }
-            llm = model
+        let activePrompt = prompt ?? Self.defaultPrompt
+        let correctionEngine = DeterministicCorrectionEngine(
+            preferredTranscriptions: correctionStore.preferredTranscriptions,
+            commonlyMisheard: correctionStore.commonlyMisheard
+        )
+        let correctedText = correctionEngine.applyPreCleanupCorrections(to: text)
+        if correctedText == text {
+            sensitiveDebugLogger?(.cleanup, "Pre-cleanup corrections: no changes applied.")
         } else {
-            guard let model = cleanupManager.model(for: wordCount) else { return text }
-            llm = model
+            sensitiveDebugLogger?(
+                .cleanup,
+                """
+                Pre-cleanup corrections:
+                input:
+                \(text)
+
+                output:
+                \(correctedText)
+                """
+            )
         }
 
-        // Update template with current prompt
-        let activePrompt = prompt ?? Self.defaultPrompt
-        llm.template = Template.chatML(activePrompt)
-        llm.history = []
-
-        let start = Date()
         do {
-            let result = try await withTimeout(seconds: Self.timeoutSeconds) {
-                await llm.respond(to: text)
-                return llm.output
+            sensitiveDebugLogger?(
+                .cleanup,
+                """
+                Cleanup prompt:
+                \(activePrompt)
+                """
+            )
+            sensitiveDebugLogger?(
+                .cleanup,
+                """
+                Cleanup LLM input:
+                \(correctedText)
+                """
+            )
+            let cleanedText = try await localBackend.clean(text: correctedText, prompt: activePrompt)
+            sensitiveDebugLogger?(
+                .cleanup,
+                """
+                Cleanup LLM raw output:
+                \(cleanedText)
+                """
+            )
+
+            let sanitizedText = sanitizeCleanupOutput(cleanedText)
+
+            if sanitizedText != cleanedText {
+                debugLogger?(.cleanup, "Stripped model reasoning tags from cleanup output.")
+                sensitiveDebugLogger?(
+                    .cleanup,
+                    """
+                    Cleanup LLM sanitized output:
+                    \(sanitizedText)
+                    """
+                )
             }
-            let elapsed = Date().timeIntervalSince(start)
-            let cleaned = result.trimmingCharacters(in: .whitespacesAndNewlines)
-            try? "elapsed=\(elapsed)s, output=\(cleaned)".write(toFile: "/tmp/whispercat-llm.log", atomically: true, encoding: .utf8)
-            // LLM.swift returns "..." when output is empty — treat as failure
-            if cleaned.isEmpty || cleaned == "..." {
-                return text
+
+            let finalText = correctionEngine.applyPostCleanupCorrections(to: sanitizedText)
+            if finalText == sanitizedText {
+                sensitiveDebugLogger?(.cleanup, "Post-cleanup corrections: no changes applied.")
+            } else {
+                sensitiveDebugLogger?(
+                    .cleanup,
+                    """
+                    Post-cleanup corrections:
+                    input:
+                    \(sanitizedText)
+
+                    output:
+                    \(finalText)
+                    """
+                )
             }
-            return cleaned
+            return finalText
         } catch {
-            let elapsed = Date().timeIntervalSince(start)
-            try? "TIMEOUT after \(elapsed)s, error=\(error)".write(toFile: "/tmp/whispercat-llm.log", atomically: true, encoding: .utf8)
-            return text
+            debugLogger?(.cleanup, "Cleanup backend unavailable, returning deterministic corrections only.")
+            let finalText = correctionEngine.applyPostCleanupCorrections(to: correctedText)
+            if finalText == correctedText {
+                sensitiveDebugLogger?(.cleanup, "Post-cleanup corrections: no changes applied.")
+            } else {
+                sensitiveDebugLogger?(
+                    .cleanup,
+                    """
+                    Post-cleanup corrections:
+                    input:
+                    \(correctedText)
+
+                    output:
+                    \(finalText)
+                    """
+                )
+            }
+            return finalText
         }
     }
 
-    private func withTimeout<T>(seconds: TimeInterval, operation: @escaping @Sendable () async -> T) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask { await operation() }
-            group.addTask {
-                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                throw CancellationError()
-            }
-            let result = try await group.next()!
-            group.cancelAll()
-            return result
+    private func sanitizeCleanupOutput(_ text: String) -> String {
+        guard let expression = Self.thinkBlockExpression else {
+            return text.trimmingCharacters(in: .whitespacesAndNewlines)
         }
+
+        let range = NSRange(text.startIndex..., in: text)
+        let sanitizedText = expression.stringByReplacingMatches(in: text, range: range, withTemplate: "")
+        return sanitizedText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -9,10 +9,27 @@ enum CleanupModelState: Equatable {
     case error
 }
 
+protocol TextCleaningManaging: AnyObject {
+    func clean(text: String, prompt: String?) async -> String?
+}
+
+enum LocalCleanupModelKind: Equatable {
+    case fast
+    case full
+}
+
 @MainActor
-final class TextCleanupManager: ObservableObject {
+final class TextCleanupManager: ObservableObject, TextCleaningManaging {
     @Published private(set) var state: CleanupModelState = .idle
     @Published private(set) var errorMessage: String?
+    @Published var localModelPolicy: LocalCleanupModelPolicy {
+        didSet {
+            defaults.set(localModelPolicy.rawValue, forKey: Self.localModelPolicyDefaultsKey)
+            updateReadyStateForCurrentPolicy()
+        }
+    }
+
+    var debugLogger: ((DebugLogCategory, String) -> Void)?
 
     /// Fast model for short inputs (< 15 words)
     private(set) var fastLLM: LLM?
@@ -28,13 +45,67 @@ final class TextCleanupManager: ObservableObject {
     static let shortInputThreshold = 15
 
     var isReady: Bool { state == .ready }
-
-    /// Returns the appropriate model based on word count.
-    func model(for wordCount: Int) -> LLM? {
-        if wordCount <= Self.shortInputThreshold {
-            return fastLLM ?? fullLLM
+    var hasUsableModelForCurrentPolicy: Bool {
+        switch localModelPolicy {
+        case .automatic:
+            return hasFastModel || hasFullModel
+        case .fastOnly:
+            return hasFastModel
+        case .fullOnly:
+            return hasFullModel
         }
-        return fullLLM
+    }
+
+    private static let timeoutSeconds: TimeInterval = 15.0
+    private static let localModelPolicyDefaultsKey = "cleanupLocalModelPolicy"
+
+    private let defaults: UserDefaults
+    private let fastModelAvailabilityOverride: Bool?
+    private let fullModelAvailabilityOverride: Bool?
+
+    init(
+        defaults: UserDefaults = .standard,
+        localModelPolicy: LocalCleanupModelPolicy? = nil,
+        fastModelAvailabilityOverride: Bool? = nil,
+        fullModelAvailabilityOverride: Bool? = nil
+    ) {
+        self.defaults = defaults
+        self.fastModelAvailabilityOverride = fastModelAvailabilityOverride
+        self.fullModelAvailabilityOverride = fullModelAvailabilityOverride
+
+        let storedPolicy = LocalCleanupModelPolicy(
+            rawValue: defaults.string(forKey: Self.localModelPolicyDefaultsKey) ?? ""
+        ) ?? .automatic
+        let initialPolicy = localModelPolicy ?? storedPolicy
+        self.localModelPolicy = initialPolicy
+        defaults.set(initialPolicy.rawValue, forKey: Self.localModelPolicyDefaultsKey)
+    }
+
+    func selectedModelKind(wordCount: Int, isQuestion: Bool) -> LocalCleanupModelKind? {
+        switch localModelPolicy {
+        case .automatic:
+            if isQuestion || wordCount > Self.shortInputThreshold {
+                if hasFullModel {
+                    return .full
+                }
+                if hasFastModel {
+                    return .fast
+                }
+                return nil
+            }
+
+            if hasFastModel {
+                return .fast
+            }
+            if hasFullModel {
+                return .full
+            }
+            return nil
+        case .fastOnly:
+            return hasFastModel ? .fast : nil
+        case .fullOnly:
+            return hasFullModel ? .full : nil
+        }
     }
 
     var statusText: String {
@@ -62,11 +133,54 @@ final class TextCleanupManager: ObservableObject {
         modelsDirectory.appendingPathComponent(fileName)
     }
 
+    func clean(text: String, prompt: String? = nil) async -> String? {
+        let wordCount = text.split(separator: " ").count
+        let isQuestion = text.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix("?")
+
+        guard let llm = selectedModel(wordCount: wordCount, isQuestion: isQuestion) else {
+            debugLogger?(
+                .cleanup,
+                "Skipped local cleanup because no usable model was ready for policy \(localModelPolicy.rawValue)."
+            )
+            return nil
+        }
+
+        let activePrompt = prompt ?? TextCleaner.defaultPrompt
+        llm.template = Template.chatML(activePrompt)
+        llm.history = []
+
+        let start = Date()
+        do {
+            let result = try await withTimeout(seconds: Self.timeoutSeconds) {
+                await llm.respond(to: text)
+                return llm.output
+            }
+            let elapsed = Date().timeIntervalSince(start)
+            let cleaned = result.trimmingCharacters(in: .whitespacesAndNewlines)
+            debugLogger?(
+                .cleanup,
+                "Local cleanup finished in \(String(format: "%.2f", elapsed))s using \(llm === fastLLM ? "fast" : "full") model."
+            )
+            if cleaned.isEmpty || cleaned == "..." {
+                return nil
+            }
+            return cleaned
+        } catch {
+            let elapsed = Date().timeIntervalSince(start)
+            debugLogger?(
+                .cleanup,
+                "Local cleanup failed after \(String(format: "%.2f", elapsed))s: \(error.localizedDescription)"
+            )
+            return nil
+        }
+    }
+
     func loadModel() async {
         guard state == .idle || state == .error else { return }
 
         errorMessage = nil
         try? FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+        debugLogger?(.model, "Loading local cleanup models for policy \(localModelPolicy.rawValue).")
 
         // Download both models if needed
         let fastPath = modelPath(for: Self.fastModelFileName)
@@ -87,6 +201,7 @@ final class TextCleanupManager: ObservableObject {
             } catch {
                 self.errorMessage = "Failed to download cleanup model: \(error.localizedDescription)"
                 self.state = .error
+                debugLogger?(.model, self.errorMessage ?? "Failed to download cleanup model.")
                 return
             }
         }
@@ -110,17 +225,13 @@ final class TextCleanupManager: ObservableObject {
             return LLM(from: fullPath, template: Template.chatML(TextCleaner.defaultPrompt), maxTokenCount: 4096)
         }.value
 
-        guard let full = full else {
-            self.errorMessage = "Failed to load cleanup model"
-            self.state = .error
-            return
+        if let full = full {
+            full.temp = 0.1
+            full.update = { (_: String?) in }
+            full.postprocess = { (_: String) in }
+            self.fullLLM = full
         }
-
-        full.temp = 0.1
-        full.update = { (_: String?) in }
-        full.postprocess = { (_: String) in }
-        self.fullLLM = full
-        self.state = .ready
+        updateReadyStateForCurrentPolicy()
     }
 
     func unloadModel() {
@@ -128,6 +239,7 @@ final class TextCleanupManager: ObservableObject {
         fullLLM = nil
         state = .idle
         errorMessage = nil
+        debugLogger?(.model, "Unloaded local cleanup models.")
     }
 
     private func downloadModel(url urlString: String, to destination: URL, progressOffset: Double, progressScale: Double) async throws {
@@ -144,6 +256,61 @@ final class TextCleanupManager: ObservableObject {
         let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
         let (tempURL, _) = try await session.download(from: url)
         try FileManager.default.moveItem(at: tempURL, to: destination)
+    }
+
+    private var hasFastModel: Bool {
+        fastModelAvailabilityOverride ?? (fastLLM != nil)
+    }
+
+    private var hasFullModel: Bool {
+        fullModelAvailabilityOverride ?? (fullLLM != nil)
+    }
+
+    private func selectedModel(wordCount: Int, isQuestion: Bool) -> LLM? {
+        switch selectedModelKind(wordCount: wordCount, isQuestion: isQuestion) {
+        case .fast:
+            return fastLLM
+        case .full:
+            return fullLLM
+        case nil:
+            return nil
+        }
+    }
+
+    private func withTimeout<T>(seconds: TimeInterval, operation: @escaping @Sendable () async -> T) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { await operation() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw CancellationError()
+            }
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private func updateReadyStateForCurrentPolicy() {
+        if hasUsableModelForCurrentPolicy {
+            state = .ready
+            errorMessage = nil
+            debugLogger?(
+                .model,
+                "Local cleanup models ready. fastLoaded=\(hasFastModel) fullLoaded=\(hasFullModel) policy=\(localModelPolicy.rawValue)."
+            )
+            return
+        }
+
+        guard fastLLM != nil || fullLLM != nil || state == .loadingModel else {
+            return
+        }
+
+        errorMessage = "Failed to load the selected cleanup model."
+        state = .error
+        debugLogger?(
+            .model,
+            "Local cleanup models unavailable for policy \(localModelPolicy.rawValue). fastLoaded=\(hasFastModel) fullLoaded=\(hasFullModel)."
+        )
     }
 }
 

--- a/GhostPepper/Context/FocusedElementLocator.swift
+++ b/GhostPepper/Context/FocusedElementLocator.swift
@@ -1,0 +1,137 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+struct FrontmostWindowReference: Equatable, Sendable {
+    let windowID: UInt32
+    let frame: CGRect
+}
+
+final class FocusedElementLocator {
+    func capturePasteSession(for text: String, at date: Date = Date()) -> PasteSession? {
+        guard let application = NSWorkspace.shared.frontmostApplication else {
+            return nil
+        }
+
+        let windowReference = frontmostWindowReference(for: application.processIdentifier)
+        return PasteSession(
+            pastedText: text,
+            pastedAt: date,
+            frontmostAppBundleIdentifier: application.bundleIdentifier,
+            frontmostWindowID: windowReference?.windowID,
+            frontmostWindowFrame: windowReference?.frame,
+            focusedElementFrame: focusedElementFrame(for: application.processIdentifier)
+        )
+    }
+
+    func frontmostApplicationBundleIdentifier() -> String? {
+        NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    }
+
+    func frontmostWindowReference() -> FrontmostWindowReference? {
+        guard let application = NSWorkspace.shared.frontmostApplication else {
+            return nil
+        }
+
+        return frontmostWindowReference(for: application.processIdentifier)
+    }
+
+    func focusedElementFrame() -> CGRect? {
+        guard let application = NSWorkspace.shared.frontmostApplication else {
+            return nil
+        }
+
+        return focusedElementFrame(for: application.processIdentifier)
+    }
+
+    private func focusedElementFrame(for processID: pid_t) -> CGRect? {
+        let applicationElement = AXUIElementCreateApplication(processID)
+        var focusedElementValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            applicationElement,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedElementValue
+        ) == .success,
+        let focusedElementValue,
+        CFGetTypeID(focusedElementValue) == AXUIElementGetTypeID() else {
+            return nil
+        }
+
+        let focusedElement = unsafeBitCast(focusedElementValue, to: AXUIElement.self)
+        return frame(for: focusedElement)
+    }
+
+    private func frame(for element: AXUIElement) -> CGRect? {
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXPositionAttribute as CFString,
+            &positionValue
+        ) == .success,
+        AXUIElementCopyAttributeValue(
+            element,
+            kAXSizeAttribute as CFString,
+            &sizeValue
+        ) == .success,
+        let positionValue,
+        let sizeValue,
+        CFGetTypeID(positionValue) == AXValueGetTypeID(),
+        CFGetTypeID(sizeValue) == AXValueGetTypeID() else {
+            return nil
+        }
+
+        let positionAXValue = unsafeBitCast(positionValue, to: AXValue.self)
+        let sizeAXValue = unsafeBitCast(sizeValue, to: AXValue.self)
+
+        var origin = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetType(positionAXValue) == .cgPoint,
+              AXValueGetValue(positionAXValue, .cgPoint, &origin),
+              AXValueGetType(sizeAXValue) == .cgSize,
+              AXValueGetValue(sizeAXValue, .cgSize, &size) else {
+            return nil
+        }
+
+        return CGRect(origin: origin, size: size)
+    }
+
+    private func frontmostWindowReference(for processID: pid_t) -> FrontmostWindowReference? {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return nil
+        }
+
+        return windowReference(in: windowList, for: processID)
+    }
+
+    func windowReference(in windowList: [[String: Any]], for processID: pid_t) -> FrontmostWindowReference? {
+        for windowInfo in windowList {
+            let ownerProcessID = (windowInfo[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value
+            guard ownerProcessID == processID else {
+                continue
+            }
+
+            let layer = (windowInfo[kCGWindowLayer as String] as? NSNumber)?.intValue
+                ?? (windowInfo[kCGWindowLayer as String] as? Int)
+                ?? 0
+            let alpha = (windowInfo[kCGWindowAlpha as String] as? NSNumber)?.doubleValue
+                ?? (windowInfo[kCGWindowAlpha as String] as? Double)
+                ?? 1
+            guard layer == 0, alpha > 0,
+                  let windowNumber = windowInfo[kCGWindowNumber as String] as? NSNumber,
+                  let boundsDictionary = windowInfo[kCGWindowBounds as String] as? NSDictionary,
+                  let frame = CGRect(dictionaryRepresentation: boundsDictionary) else {
+                continue
+            }
+
+            return FrontmostWindowReference(
+                windowID: windowNumber.uint32Value,
+                frame: frame
+            )
+        }
+
+        return nil
+    }
+}

--- a/GhostPepper/Context/FrontmostWindowOCRService.swift
+++ b/GhostPepper/Context/FrontmostWindowOCRService.swift
@@ -1,0 +1,57 @@
+import CoreGraphics
+import Foundation
+
+final class FrontmostWindowOCRService {
+    typealias PermissionProvider = @Sendable () -> Bool
+    typealias TextRecognizer = @Sendable (CGImage, [String]) async throws -> String?
+
+    private let permissionProvider: PermissionProvider
+    private let windowCaptureService: WindowCaptureServing
+    private let recognizeText: TextRecognizer
+
+    var debugLogger: ((DebugLogCategory, String) -> Void)?
+    var sensitiveDebugLogger: ((DebugLogCategory, String) -> Void)?
+
+    init(
+        permissionProvider: @escaping PermissionProvider = PermissionChecker.hasScreenRecordingPermission,
+        windowCaptureService: WindowCaptureServing = WindowCaptureService(),
+        requestFactory: OCRRequestFactory = OCRRequestFactory()
+    ) {
+        self.permissionProvider = permissionProvider
+        self.windowCaptureService = windowCaptureService
+        self.recognizeText = { image, customWords in
+            try requestFactory.recognizeText(in: image, customWords: customWords)
+        }
+    }
+
+    init(
+        permissionProvider: @escaping PermissionProvider,
+        windowCaptureService: WindowCaptureServing,
+        recognizeText: @escaping TextRecognizer
+    ) {
+        self.permissionProvider = permissionProvider
+        self.windowCaptureService = windowCaptureService
+        self.recognizeText = recognizeText
+    }
+
+    func captureContext(customWords: [String]) async -> OCRContext? {
+        do {
+            guard let image = try await windowCaptureService.captureFrontmostWindowImage(),
+                  let text = try await recognizeText(image, customWords) else {
+                debugLogger?(.ocr, "Frontmost-window OCR produced no text.")
+                return nil
+            }
+
+            debugLogger?(.ocr, "Frontmost-window OCR captured text.")
+            sensitiveDebugLogger?(.ocr, "Frontmost-window OCR text:\n\(text)")
+            return OCRContext(windowContents: text)
+        } catch {
+            if !permissionProvider() {
+                debugLogger?(.ocr, "Frontmost-window OCR failed while Screen Recording permission appears unavailable: \(error.localizedDescription)")
+            } else {
+                debugLogger?(.ocr, "Frontmost-window OCR failed: \(error.localizedDescription)")
+            }
+            return nil
+        }
+    }
+}

--- a/GhostPepper/Context/OCRContext.swift
+++ b/GhostPepper/Context/OCRContext.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct OCRContext: Equatable, Sendable {
+    let windowContents: String
+}

--- a/GhostPepper/Context/OCRRequestFactory.swift
+++ b/GhostPepper/Context/OCRRequestFactory.swift
@@ -1,0 +1,76 @@
+import CoreGraphics
+import Foundation
+import Vision
+
+struct OCRRecognitionResult: Equatable, Sendable {
+    let text: String
+    let confidence: Double
+}
+
+struct OCRRequestFactory: Sendable {
+    func makeRequest(
+        customWords: [String],
+        completionHandler: VNRequestCompletionHandler? = nil
+    ) -> VNRecognizeTextRequest {
+        let request: VNRecognizeTextRequest
+        if let completionHandler {
+            request = VNRecognizeTextRequest(completionHandler: completionHandler)
+        } else {
+            request = VNRecognizeTextRequest()
+        }
+
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = true
+        request.customWords = customWords
+        request.revision = VNRecognizeTextRequestRevision3
+        return request
+    }
+
+    func recognizeText(in image: CGImage, customWords: [String]) throws -> String? {
+        try recognizeDetailedText(in: image, customWords: customWords)?.text
+    }
+
+    func recognizeDetailedText(in image: CGImage, customWords: [String]) throws -> OCRRecognitionResult? {
+        var observations: [(boundingBox: CGRect, candidate: VNRecognizedText)] = []
+        let request = makeRequest(customWords: customWords) { request, error in
+            guard error == nil,
+                  let results = request.results as? [VNRecognizedTextObservation] else {
+                return
+            }
+
+            observations = results.compactMap { observation in
+                guard let candidate = observation.topCandidates(1).first else {
+                    return nil
+                }
+
+                return (observation.boundingBox, candidate)
+            }
+        }
+
+        let handler = VNImageRequestHandler(cgImage: image, options: [:])
+        try handler.perform([request])
+
+        let sortedObservations = observations.sorted { lhs, rhs in
+            if abs(lhs.boundingBox.midY - rhs.boundingBox.midY) > 0.02 {
+                return lhs.boundingBox.midY > rhs.boundingBox.midY
+            }
+            return lhs.boundingBox.midX < rhs.boundingBox.midX
+        }
+
+        let recognizedText = sortedObservations
+            .map(\.candidate.string)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !recognizedText.isEmpty else {
+            return nil
+        }
+
+        let averageConfidence = sortedObservations
+            .map { Double($0.candidate.confidence) }
+            .reduce(0, +) / Double(sortedObservations.count)
+        return OCRRecognitionResult(
+            text: recognizedText,
+            confidence: averageConfidence
+        )
+    }
+}

--- a/GhostPepper/Context/WindowCaptureService.swift
+++ b/GhostPepper/Context/WindowCaptureService.swift
@@ -1,0 +1,60 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+protocol WindowCaptureServing {
+    func captureFrontmostWindowImage() async throws -> CGImage?
+}
+
+final class WindowCaptureService: WindowCaptureServing {
+    func captureFrontmostWindowImage() async throws -> CGImage? {
+        guard let frontmostApplication = NSWorkspace.shared.frontmostApplication,
+              let windowID = frontmostWindowID(for: frontmostApplication.processIdentifier) else {
+            return nil
+        }
+
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
+            return nil
+        }
+
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        let configuration = SCStreamConfiguration()
+        configuration.width = max(Int(window.frame.width * 2), 1)
+        configuration.height = max(Int(window.frame.height * 2), 1)
+        configuration.scalesToFit = false
+        configuration.showsCursor = false
+
+        return try await SCScreenshotManager.captureImage(
+            contentFilter: filter,
+            configuration: configuration
+        )
+    }
+
+    private func frontmostWindowID(for processID: pid_t) -> UInt32? {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return nil
+        }
+
+        for windowInfo in windowList {
+            guard let ownerProcessID = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
+                  ownerProcessID == processID else {
+                continue
+            }
+
+            let layer = windowInfo[kCGWindowLayer as String] as? Int ?? 0
+            let alpha = windowInfo[kCGWindowAlpha as String] as? Double ?? 1
+            guard layer == 0, alpha > 0 else {
+                continue
+            }
+
+            if let windowNumber = windowInfo[kCGWindowNumber as String] as? NSNumber {
+                return windowNumber.uint32Value
+            }
+        }
+
+        return nil
+    }
+}

--- a/GhostPepper/Debug/DebugLogStore.swift
+++ b/GhostPepper/Debug/DebugLogStore.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Combine
+
+enum DebugLogCategory: String {
+    case hotkey = "Hotkey"
+    case ocr = "OCR"
+    case cleanup = "Cleanup"
+    case model = "Model"
+}
+
+struct DebugLogEntry: Identifiable, Equatable {
+    let id = UUID()
+    let timestamp: Date
+    let category: DebugLogCategory
+    let message: String
+}
+
+final class DebugLogStore: ObservableObject {
+    @Published private(set) var entries: [DebugLogEntry] = []
+
+    private let maxEntries: Int
+    private let formatter: DateFormatter
+    private var liveViewerCount = 0
+
+    init(maxEntries: Int = 250) {
+        self.maxEntries = maxEntries
+        self.formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+    }
+
+    var formattedText: String {
+        entries.map { entry in
+            "[\(formatter.string(from: entry.timestamp))] [\(entry.category.rawValue)] \(entry.message)"
+        }
+        .joined(separator: "\n\n")
+    }
+
+    func record(category: DebugLogCategory, message: String) {
+        entries.append(
+            DebugLogEntry(
+                timestamp: Date(),
+                category: category,
+                message: message
+            )
+        )
+
+        if entries.count > maxEntries {
+            entries.removeFirst(entries.count - maxEntries)
+        }
+    }
+
+    func beginLiveViewing() {
+        liveViewerCount += 1
+    }
+
+    func endLiveViewing() {
+        liveViewerCount = max(0, liveViewerCount - 1)
+    }
+
+    func recordSensitive(category: DebugLogCategory, message: String) {
+        guard liveViewerCount > 0 else {
+            return
+        }
+
+        record(category: category, message: message)
+    }
+
+    func clear() {
+        entries.removeAll()
+    }
+}

--- a/GhostPepper/GhostPepper.entitlements
+++ b/GhostPepper/GhostPepper.entitlements
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/GhostPepper/Info.plist
+++ b/GhostPepper/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleName</key>
     <string>Ghost Pepper</string>
     <key>CFBundleIdentifier</key>

--- a/GhostPepper/Input/ChordAction.swift
+++ b/GhostPepper/Input/ChordAction.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum ChordAction: String, CaseIterable, Codable {
+    case pushToTalk
+    case toggleToTalk
+}

--- a/GhostPepper/Input/ChordBindingStore.swift
+++ b/GhostPepper/Input/ChordBindingStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+final class ChordBindingStore {
+    enum StoreError: Error, Equatable {
+        case duplicateBinding
+    }
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func binding(for action: ChordAction) -> KeyChord? {
+        guard let data = defaults.data(forKey: defaultsKey(for: action)) else { return nil }
+        return try? decoder.decode(KeyChord.self, from: data)
+    }
+
+    func setBinding(_ chord: KeyChord?, for action: ChordAction) throws {
+        if let chord {
+            for otherAction in ChordAction.allCases where otherAction != action {
+                if binding(for: otherAction) == chord {
+                    throw StoreError.duplicateBinding
+                }
+            }
+
+            defaults.set(try encoder.encode(chord), forKey: defaultsKey(for: action))
+            return
+        }
+
+        defaults.removeObject(forKey: defaultsKey(for: action))
+    }
+
+    private func defaultsKey(for action: ChordAction) -> String {
+        "chordBinding.\(action.rawValue)"
+    }
+}

--- a/GhostPepper/Input/ChordEngine.swift
+++ b/GhostPepper/Input/ChordEngine.swift
@@ -1,0 +1,114 @@
+struct ChordEngine {
+    enum InputEvent: Equatable {
+        case flagsChanged(PhysicalKey)
+        case keyDown(PhysicalKey)
+        case keyUp(PhysicalKey)
+    }
+
+    enum Effect: Equatable {
+        case startRecording
+        case stopRecording
+    }
+
+    private let bindings: [ChordAction: KeyChord]
+    private(set) var pressedKeys: Set<PhysicalKey> = []
+    private(set) var activeRecordingAction: ChordAction?
+
+    init(bindings: [ChordAction: KeyChord]) {
+        self.bindings = bindings
+    }
+
+    mutating func handle(_ inputEvent: InputEvent) -> [Effect] {
+        guard updatePressedKeys(for: inputEvent) else { return [] }
+        return evaluateStateTransition()
+    }
+
+    mutating func syncPressedKeys(_ pressedKeys: Set<PhysicalKey>) -> [Effect] {
+        guard self.pressedKeys != pressedKeys else { return [] }
+        self.pressedKeys = pressedKeys
+        return evaluateStateTransition()
+    }
+
+    private mutating func evaluateStateTransition() -> [Effect] {
+        
+        switch activeRecordingAction {
+        case .pushToTalk:
+            if matchResult() == .exact(.toggleToTalk) {
+                activeRecordingAction = .toggleToTalk
+                return []
+            }
+
+            guard let pushChord = bindings[.pushToTalk] else {
+                activeRecordingAction = nil
+                return []
+            }
+
+            if !pressedKeys.isSuperset(of: pushChord.keys) {
+                activeRecordingAction = nil
+                return [.stopRecording]
+            }
+
+            return []
+
+        case .toggleToTalk:
+            if matchResult() == .exact(.toggleToTalk) {
+                activeRecordingAction = nil
+                return [.stopRecording]
+            }
+
+            return []
+
+        case nil:
+            switch matchResult() {
+            case .exact(let action):
+                activeRecordingAction = action
+                return [.startRecording]
+            case .none, .prefix:
+                return []
+            }
+        }
+    }
+
+    mutating func reset() {
+        pressedKeys.removeAll()
+        activeRecordingAction = nil
+    }
+
+    func matchResult() -> ChordMatchResult {
+        guard !pressedKeys.isEmpty else { return .none }
+
+        for (action, chord) in bindings where chord.keys == pressedKeys {
+            return .exact(action)
+        }
+
+        if bindings.values.contains(where: { pressedKeys.isSubset(of: $0.keys) && pressedKeys != $0.keys }) {
+            return .prefix
+        }
+
+        return .none
+    }
+
+    private mutating func updatePressedKeys(for inputEvent: InputEvent) -> Bool {
+        switch inputEvent {
+        case .flagsChanged(let key):
+            if pressedKeys.contains(key) {
+                pressedKeys.remove(key)
+                return true
+            }
+
+            pressedKeys.insert(key)
+            return true
+
+        case .keyDown(let key):
+            return pressedKeys.insert(key).inserted
+        case .keyUp(let key):
+            return pressedKeys.remove(key) != nil
+        }
+    }
+}
+
+enum ChordMatchResult: Equatable {
+    case none
+    case prefix
+    case exact(ChordAction)
+}

--- a/GhostPepper/Input/HotkeyMonitor.swift
+++ b/GhostPepper/Input/HotkeyMonitor.swift
@@ -1,139 +1,531 @@
 import Cocoa
 import CoreGraphics
+import IOKit.hidsystem
 
-/// Monitors Control key press/release for hold-to-talk functionality using CGEvent tap.
+protocol HotkeyMonitoring: AnyObject {
+    var onRecordingStart: (() -> Void)? { get set }
+    var onRecordingStop: (() -> Void)? { get set }
+    var onPushToTalkStart: (() -> Void)? { get set }
+    var onPushToTalkStop: (() -> Void)? { get set }
+    var onToggleToTalkStart: (() -> Void)? { get set }
+    var onToggleToTalkStop: (() -> Void)? { get set }
+
+    func start() -> Bool
+    func stop()
+    func updateBindings(_ bindings: [ChordAction: KeyChord])
+    func setSuspended(_ suspended: Bool)
+}
+
+/// Monitors configured key chords for hold-to-talk and toggle-to-talk using a CGEvent tap.
 /// Requires Accessibility permission to create the event tap.
-final class HotkeyMonitor {
+final class HotkeyMonitor: NSObject, HotkeyMonitoring {
+    typealias EventProcessor = (@escaping @Sendable () -> Void) -> Void
 
-    // MARK: - Constants
+    private struct HandlingResult {
+        let logMessage: String?
+        let startAction: ChordAction?
+        let stopAction: ChordAction?
+    }
 
-    private static let minimumHoldDuration: TimeInterval = 0.3
+    fileprivate struct EventSnapshot {
+        let type: CGEventType
+        let key: PhysicalKey
+        let flags: CGEventFlags
+    }
 
     // MARK: - Callbacks
 
     var onRecordingStart: (() -> Void)?
     var onRecordingStop: (() -> Void)?
+    var onPushToTalkStart: (() -> Void)?
+    var onPushToTalkStop: (() -> Void)?
+    var onToggleToTalkStart: (() -> Void)?
+    var onToggleToTalkStop: (() -> Void)?
 
     // MARK: - State
 
     fileprivate var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
-    private var holdTimer: DispatchSourceTimer?
-    private var isRecording = false
-    private var controlPressed = false
+    private var eventThread: HotkeyMonitorThread?
+    private var bindings: [ChordAction: KeyChord]
+    private var monitoredKeys: Set<PhysicalKey>
+    private var nonModifierBindingPrefixes: [Set<PhysicalKey>]
+    private var chordEngine: ChordEngine
+    private let keyStateProvider: (PhysicalKey) -> Bool
+    private let modifierFlagsProvider: () -> CGEventFlags
+    private let eventProcessor: EventProcessor
+    private var isSuspended = false
+    private var requiresAllKeysReleased = false
+    private let stateLock = NSLock()
+
+    var debugLogger: ((DebugLogCategory, String) -> Void)?
+
+    init(
+        bindings: [ChordAction: KeyChord] = [:],
+        keyStateProvider: @escaping (PhysicalKey) -> Bool = { key in
+            CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(key.keyCode))
+        },
+        modifierFlagsProvider: @escaping () -> CGEventFlags = {
+            CGEventSource.flagsState(.combinedSessionState)
+        },
+        eventProcessor: EventProcessor? = nil
+    ) {
+        let queue = DispatchQueue(label: "GhostPepper.HotkeyMonitor.events")
+        self.bindings = bindings
+        monitoredKeys = bindings.values.reduce(into: Set<PhysicalKey>()) { keys, chord in
+            keys.formUnion(chord.keys)
+        }
+        nonModifierBindingPrefixes = Self.nonModifierBindingPrefixes(from: bindings)
+        chordEngine = ChordEngine(bindings: bindings)
+        self.keyStateProvider = keyStateProvider
+        self.modifierFlagsProvider = modifierFlagsProvider
+        self.eventProcessor = eventProcessor ?? { work in
+            queue.async(execute: work)
+        }
+    }
+
+    func updateBindings(_ bindings: [ChordAction: KeyChord]) {
+        stateLock.lock()
+        self.bindings = bindings
+        monitoredKeys = bindings.values.reduce(into: Set<PhysicalKey>()) { keys, chord in
+            keys.formUnion(chord.keys)
+        }
+        nonModifierBindingPrefixes = Self.nonModifierBindingPrefixes(from: bindings)
+        chordEngine = ChordEngine(bindings: bindings)
+        stateLock.unlock()
+        let bindingsDescription = bindings
+            .sorted { $0.key.rawValue < $1.key.rawValue }
+            .map { "\($0.key.rawValue)=\($0.value.displayString)" }
+            .joined(separator: ", ")
+        debugLogger?(.hotkey, "Updated bindings: \(bindingsDescription)")
+    }
+
+    func setSuspended(_ suspended: Bool) {
+        stateLock.lock()
+        isSuspended = suspended
+        chordEngine.reset()
+        requiresAllKeysReleased = !suspended && !currentPressedKeys().isEmpty
+        stateLock.unlock()
+        debugLogger?(.hotkey, "Shortcut capture suspension changed to \(suspended).")
+    }
 
     // MARK: - Public API
 
-    /// Starts monitoring for Control key events.
+    /// Starts monitoring for key chord events.
     /// - Returns: `false` if Accessibility permission is denied (event tap creation fails).
     func start() -> Bool {
-        let eventMask: CGEventMask = (1 << CGEventType.flagsChanged.rawValue)
-            | (1 << CGEventType.keyDown.rawValue)
+        stateLock.lock()
+        if eventTap != nil {
+            stateLock.unlock()
+            debugLogger?(.hotkey, "Hotkey monitor start skipped because the event tap is already active.")
+            return true
+        }
+        stateLock.unlock()
 
-        guard let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .headInsertEventTap,
-            options: .defaultTap,
-            eventsOfInterest: eventMask,
-            callback: hotkeyCallback,
-            userInfo: Unmanaged.passUnretained(self).toOpaque()
-        ) else {
+        let thread = HotkeyMonitorThread()
+        thread.name = "GhostPepper Hotkey Monitor"
+        thread.start()
+        thread.waitUntilReady()
+
+        let request = HotkeyTapInstallRequest()
+        perform(#selector(installEventTap(_:)), on: thread, with: request, waitUntilDone: true)
+
+        guard request.succeeded else {
+            perform(#selector(uninstallEventTapAndStopRunLoop), on: thread, with: nil, waitUntilDone: true)
+            debugLogger?(.hotkey, "Hotkey monitor failed to start because Accessibility permission is unavailable.")
             return false
         }
 
-        eventTap = tap
-        runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
+        stateLock.lock()
+        eventThread = thread
+        stateLock.unlock()
+        debugLogger?(.hotkey, "Hotkey monitor event tap started.")
         return true
     }
 
     /// Stops monitoring and cleans up the event tap.
     func stop() {
-        cancelHoldTimer()
-        if let tap = eventTap {
-            CGEvent.tapEnable(tap: tap, enable: false)
+        stateLock.lock()
+        let thread = eventThread
+        stateLock.unlock()
+
+        if let thread {
+            perform(#selector(uninstallEventTapAndStopRunLoop), on: thread, with: nil, waitUntilDone: true)
         }
-        if let source = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
-        }
-        eventTap = nil
-        runLoopSource = nil
-        isRecording = false
-        controlPressed = false
-    }
 
-    // MARK: - Static Helpers
-
-    /// Returns `true` if only the Control modifier is active (no Cmd, Shift, Alt, etc.).
-    static func isControlOnly(flags: CGEventFlags) -> Bool {
-        let modifierMask: CGEventFlags = [.maskControl, .maskCommand, .maskShift, .maskAlternate]
-        let activeModifiers = flags.intersection(modifierMask)
-        return activeModifiers == .maskControl
-    }
-
-    /// Returns `true` if the given duration meets the minimum hold threshold (0.3s).
-    func isHoldLongEnough(duration: TimeInterval) -> Bool {
-        return duration >= HotkeyMonitor.minimumHoldDuration
+        stateLock.lock()
+        eventThread = nil
+        chordEngine.reset()
+        isSuspended = false
+        requiresAllKeysReleased = false
+        stateLock.unlock()
+        debugLogger?(.hotkey, "Hotkey monitor stopped.")
     }
 
     // MARK: - Event Handling
 
-    fileprivate func handleEvent(_ type: CGEventType, event: CGEvent) {
-        switch type {
-        case .flagsChanged:
-            handleFlagsChanged(event)
-        case .keyDown:
-            handleKeyDown()
-        default:
-            break
+    func handleEvent(_ type: CGEventType, event: CGEvent) {
+        guard let snapshot = EventSnapshot(type: type, event: event) else {
+            return
+        }
+
+        eventProcessor { [weak self] in
+            self?.processCapturedEvent(snapshot)
         }
     }
 
-    private func handleFlagsChanged(_ event: CGEvent) {
-        let flags = event.flags
+    func handleInput(_ inputEvent: ChordEngine.InputEvent, authoritativePressedKeys: Set<PhysicalKey>? = nil) {
+        stateLock.lock()
+        let result = handleInputLocked(inputEvent, authoritativePressedKeys: authoritativePressedKeys)
+        stateLock.unlock()
+        apply(result)
+    }
 
-        if HotkeyMonitor.isControlOnly(flags: flags) && !controlPressed {
-            // Control just pressed alone
-            controlPressed = true
-            startHoldTimer()
-        } else if controlPressed && !flags.contains(.maskControl) {
-            // Control released
-            controlPressed = false
-            cancelHoldTimer()
-            if isRecording {
-                isRecording = false
-                onRecordingStop?()
+    private func processCapturedEvent(_ snapshot: EventSnapshot) {
+        let result: HandlingResult?
+
+        stateLock.lock()
+        switch snapshot.type {
+        case .flagsChanged:
+            let pressedKeys = trackedNonModifierPressedKeys().union(modifierPressedKeys(from: snapshot.flags))
+            result = handleInputLocked(.flagsChanged(snapshot.key), authoritativePressedKeys: pressedKeys)
+        case .keyDown:
+            guard shouldProcessNonModifierEvents(with: snapshot.flags) else {
+                stateLock.unlock()
+                return
+            }
+            let pressedKeys = trackedNonModifierPressedKeys()
+                .union(modifierPressedKeys(from: snapshot.flags))
+                .union([snapshot.key])
+            result = handleInputLocked(.keyDown(snapshot.key), authoritativePressedKeys: pressedKeys)
+        case .keyUp:
+            guard shouldProcessNonModifierEvents(with: snapshot.flags) else {
+                stateLock.unlock()
+                return
+            }
+            var pressedKeys = trackedNonModifierPressedKeys()
+            pressedKeys.remove(snapshot.key)
+            pressedKeys.formUnion(modifierPressedKeys(from: snapshot.flags))
+            result = handleInputLocked(.keyUp(snapshot.key), authoritativePressedKeys: pressedKeys)
+        default:
+            result = nil
+        }
+        stateLock.unlock()
+        apply(result)
+    }
+
+    private func handleInputLocked(
+        _ inputEvent: ChordEngine.InputEvent,
+        authoritativePressedKeys: Set<PhysicalKey>? = nil
+    ) -> HandlingResult? {
+        let inputKey: PhysicalKey
+        switch inputEvent {
+        case .flagsChanged(let key), .keyDown(let key), .keyUp(let key):
+            inputKey = key
+        }
+
+        guard monitoredKeys.contains(inputKey) else {
+            return nil
+        }
+
+        if isSuspended {
+            return HandlingResult(
+                logMessage: "Ignored \(describe(inputEvent)) because shortcut capture is active.",
+                startAction: nil,
+                stopAction: nil
+            )
+        }
+
+        let physicalPressedKeys = authoritativePressedKeys ?? currentPressedKeys()
+
+        if requiresAllKeysReleased {
+            if physicalPressedKeys.isEmpty {
+                requiresAllKeysReleased = false
+                return HandlingResult(
+                    logMessage: "All keys released after shortcut capture; matching re-enabled.",
+                    startAction: nil,
+                    stopAction: nil
+                )
+            }
+
+            switch inputEvent {
+            case .flagsChanged(let key) where physicalPressedKeys == Set([key]):
+                requiresAllKeysReleased = false
+                return HandlingResult(
+                    logMessage: "Shortcut capture release recovery completed on a fresh modifier press; matching re-enabled.",
+                    startAction: nil,
+                    stopAction: nil
+                )
+            case .keyDown(let key) where physicalPressedKeys == Set([key]):
+                requiresAllKeysReleased = false
+                return HandlingResult(
+                    logMessage: "Shortcut capture release recovery completed on a fresh key press; matching re-enabled.",
+                    startAction: nil,
+                    stopAction: nil
+                )
+            default:
+                return nil
+            }
+        }
+
+        let previousAction = chordEngine.activeRecordingAction
+        let effects: [ChordEngine.Effect]
+        if let authoritativePressedKeys {
+            effects = chordEngine.syncPressedKeys(authoritativePressedKeys)
+        } else {
+            var nextEffects = chordEngine.handle(inputEvent)
+            let recoveredPressedKeys = chordEngine.pressedKeys.union(physicalPressedKeys)
+            if nextEffects.isEmpty,
+               recoveredPressedKeys != chordEngine.pressedKeys,
+               currentStateReflectsCurrentEvent(inputEvent, pressedKeys: physicalPressedKeys) {
+                // Polling is only trusted to recover missing key-down edges. Partial snapshots
+                // are too noisy to erase keys that event history says are still pressed.
+                nextEffects = chordEngine.syncPressedKeys(recoveredPressedKeys)
+            }
+            effects = nextEffects
+        }
+        if effects.contains(.stopRecording), physicalPressedKeys.isEmpty {
+            chordEngine.reset()
+        }
+        let currentAction = chordEngine.activeRecordingAction
+        let effectDescription = effects.map {
+            switch $0 {
+            case .startRecording:
+                "start"
+            case .stopRecording:
+                "stop"
+            }
+        }.joined(separator: ", ")
+        let actionDescription = currentAction?.rawValue ?? "none"
+        let pressedDescription = physicalPressedKeys.map(\.displayName).sorted().joined(separator: " + ")
+        let logMessage = "Event \(describe(inputEvent)); pressed=\(pressedDescription.isEmpty ? "none" : pressedDescription); activeAction=\(actionDescription); effects=\(effectDescription.isEmpty ? "none" : effectDescription)"
+
+        let startAction = effects.contains(.startRecording) ? currentAction : nil
+        let stopAction = effects.contains(.stopRecording) ? previousAction : nil
+        return HandlingResult(logMessage: logMessage, startAction: startAction, stopAction: stopAction)
+    }
+
+    private func currentPressedKeys() -> Set<PhysicalKey> {
+        currentNonModifierPressedKeys().union(modifierPressedKeys(from: modifierFlagsProvider()))
+    }
+
+    private func trackedNonModifierPressedKeys() -> Set<PhysicalKey> {
+        chordEngine.pressedKeys.filter { !$0.isModifierKey }
+    }
+
+    private func currentNonModifierPressedKeys() -> Set<PhysicalKey> {
+        monitoredKeys.filter { !$0.isModifierKey && keyStateProvider($0) }
+    }
+
+    private func shouldProcessNonModifierEvents(with flags: CGEventFlags) -> Bool {
+        guard !nonModifierBindingPrefixes.isEmpty else {
+            return false
+        }
+
+        let activeModifiers = modifierPressedKeys(from: flags)
+        return nonModifierBindingPrefixes.contains { prefix in
+            prefix.isEmpty || activeModifiers.isSuperset(of: prefix)
+        }
+    }
+
+    private func modifierPressedKeys(from flags: CGEventFlags) -> Set<PhysicalKey> {
+        monitoredKeys.filter { key in
+            guard let modifierMaskRawValue = key.modifierMaskRawValue else {
+                return false
+            }
+
+            return flags.rawValue & modifierMaskRawValue == modifierMaskRawValue
+        }
+    }
+
+    private func currentStateReflectsCurrentEvent(
+        _ inputEvent: ChordEngine.InputEvent,
+        pressedKeys: Set<PhysicalKey>
+    ) -> Bool {
+        switch inputEvent {
+        case .flagsChanged(let key), .keyDown(let key), .keyUp(let key):
+            return pressedKeys.contains(key) == chordEngine.pressedKeys.contains(key)
+        }
+    }
+
+    private func describe(_ inputEvent: ChordEngine.InputEvent) -> String {
+        switch inputEvent {
+        case .flagsChanged(let key):
+            return "flagsChanged(\(key.displayName))"
+        case .keyDown(let key):
+            return "keyDown(\(key.displayName))"
+        case .keyUp(let key):
+            return "keyUp(\(key.displayName))"
+        }
+    }
+
+    private func apply(_ result: HandlingResult?) {
+        guard let result else {
+            return
+        }
+
+        if let logMessage = result.logMessage {
+            debugLogger?(.hotkey, logMessage)
+        }
+
+        if let startAction = result.startAction {
+            switch startAction {
+            case .pushToTalk:
+                if let onPushToTalkStart {
+                    onPushToTalkStart()
+                } else {
+                    onRecordingStart?()
+                }
+            case .toggleToTalk:
+                if let onToggleToTalkStart {
+                    onToggleToTalkStart()
+                } else {
+                    onRecordingStart?()
+                }
+            }
+        }
+
+        if let stopAction = result.stopAction {
+            switch stopAction {
+            case .pushToTalk:
+                if let onPushToTalkStop {
+                    onPushToTalkStop()
+                } else {
+                    onRecordingStop?()
+                }
+            case .toggleToTalk:
+                if let onToggleToTalkStop {
+                    onToggleToTalkStop()
+                } else {
+                    onRecordingStop?()
+                }
             }
         }
     }
 
-    private func handleKeyDown() {
-        // Another key pressed while Control is held — cancel the timer
-        if controlPressed && !isRecording {
-            cancelHoldTimer()
-            controlPressed = false
+    private static func nonModifierBindingPrefixes(from bindings: [ChordAction: KeyChord]) -> [Set<PhysicalKey>] {
+        bindings.values.compactMap { chord in
+            guard chord.keys.contains(where: { !$0.isModifierKey }) else {
+                return nil
+            }
+
+            return chord.keys.filter(\.isModifierKey)
         }
     }
 
-    // MARK: - Timer
+    @objc private func installEventTap(_ request: HotkeyTapInstallRequest) {
+        let eventMask: CGEventMask = (1 << CGEventType.flagsChanged.rawValue)
+            | (1 << CGEventType.keyDown.rawValue)
+            | (1 << CGEventType.keyUp.rawValue)
 
-    private func startHoldTimer() {
-        cancelHoldTimer()
-        let timer = DispatchSource.makeTimerSource(queue: .main)
-        timer.schedule(deadline: .now() + HotkeyMonitor.minimumHoldDuration)
-        timer.setEventHandler { [weak self] in
-            guard let self, self.controlPressed else { return }
-            self.isRecording = true
-            self.onRecordingStart?()
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .tailAppendEventTap,
+            options: .listenOnly,
+            eventsOfInterest: eventMask,
+            callback: hotkeyCallback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            request.succeeded = false
+            return
         }
-        timer.resume()
-        holdTimer = timer
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+
+        stateLock.lock()
+        eventTap = tap
+        runLoopSource = source
+        stateLock.unlock()
+        request.succeeded = true
     }
 
-    private func cancelHoldTimer() {
-        holdTimer?.cancel()
-        holdTimer = nil
+    @objc private func uninstallEventTapAndStopRunLoop() {
+        stateLock.lock()
+        let tap = eventTap
+        let source = runLoopSource
+        eventTap = nil
+        runLoopSource = nil
+        stateLock.unlock()
+
+        if let tap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+        if let source {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+
+        CFRunLoopStop(CFRunLoopGetCurrent())
+    }
+}
+
+private final class HotkeyMonitorThread: Thread {
+    private let readySemaphore = DispatchSemaphore(value: 0)
+    private let keepAlivePort = Port()
+
+    override func main() {
+        autoreleasepool {
+            RunLoop.current.add(keepAlivePort, forMode: .default)
+            readySemaphore.signal()
+            CFRunLoopRun()
+        }
+    }
+
+    func waitUntilReady() {
+        readySemaphore.wait()
+    }
+}
+
+private final class HotkeyTapInstallRequest: NSObject {
+    var succeeded = false
+}
+
+private extension HotkeyMonitor.EventSnapshot {
+    init?(type: CGEventType, event: CGEvent) {
+        switch type {
+        case .flagsChanged, .keyDown, .keyUp:
+            self.init(
+                type: type,
+                key: PhysicalKey(keyCode: UInt16(event.getIntegerValueField(.keyboardEventKeycode))),
+                flags: event.flags
+            )
+        default:
+            return nil
+        }
+    }
+}
+
+private extension PhysicalKey {
+    var isModifierKey: Bool {
+        modifierMaskRawValue != nil
+    }
+
+    var modifierMaskRawValue: UInt64? {
+        switch keyCode {
+        case 54:
+            UInt64(NX_DEVICERCMDKEYMASK | NX_COMMANDMASK)
+        case 55:
+            UInt64(NX_DEVICELCMDKEYMASK | NX_COMMANDMASK)
+        case 56:
+            UInt64(NX_DEVICELSHIFTKEYMASK | NX_SHIFTMASK)
+        case 57:
+            CGEventFlags.maskAlphaShift.rawValue
+        case 58:
+            UInt64(NX_DEVICELALTKEYMASK | NX_ALTERNATEMASK)
+        case 59:
+            UInt64(NX_DEVICELCTLKEYMASK | NX_CONTROLMASK)
+        case 60:
+            UInt64(NX_DEVICERSHIFTKEYMASK | NX_SHIFTMASK)
+        case 61:
+            UInt64(NX_DEVICERALTKEYMASK | NX_ALTERNATEMASK)
+        case 62:
+            UInt64(NX_DEVICERCTLKEYMASK | NX_CONTROLMASK)
+        case 63:
+            CGEventFlags.maskSecondaryFn.rawValue
+        default:
+            nil
+        }
     }
 }
 
@@ -145,7 +537,7 @@ private func hotkeyCallback(
     event: CGEvent,
     userInfo: UnsafeMutableRawPointer?
 ) -> Unmanaged<CGEvent>? {
-    guard let userInfo else { return Unmanaged.passRetained(event) }
+    guard let userInfo else { return Unmanaged.passUnretained(event) }
 
     // Re-enable tap if it was disabled by the system
     if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
@@ -153,10 +545,11 @@ private func hotkeyCallback(
         if let tap = monitor.eventTap {
             CGEvent.tapEnable(tap: tap, enable: true)
         }
-        return Unmanaged.passRetained(event)
+        monitor.debugLogger?(.hotkey, "Hotkey event tap was disabled and has been re-enabled.")
+        return Unmanaged.passUnretained(event)
     }
 
     let monitor = Unmanaged<HotkeyMonitor>.fromOpaque(userInfo).takeUnretainedValue()
     monitor.handleEvent(type, event: event)
-    return Unmanaged.passRetained(event)
+    return Unmanaged.passUnretained(event)
 }

--- a/GhostPepper/Input/KeyChord.swift
+++ b/GhostPepper/Input/KeyChord.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+struct KeyChord: Codable, Hashable {
+    let keys: Set<PhysicalKey>
+
+    private enum CodingKeys: String, CodingKey {
+        case keys
+    }
+
+    init?(keys: Set<PhysicalKey>) {
+        guard !keys.isEmpty else { return nil }
+        self.keys = keys
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let keys = try container.decode(Set<PhysicalKey>.self, forKey: .keys)
+
+        guard !keys.isEmpty else {
+            throw DecodingError.dataCorruptedError(forKey: .keys, in: container, debugDescription: "Key chords cannot be empty.")
+        }
+
+        self.keys = keys
+    }
+
+    var displayString: String {
+        keys
+            .sorted {
+                if $0.sortOrder == $1.sortOrder {
+                    if $0.displayName == $1.displayName {
+                        return $0.keyCode < $1.keyCode
+                    }
+
+                    return $0.displayName < $1.displayName
+                }
+
+                return $0.sortOrder < $1.sortOrder
+            }
+            .map(\.displayName)
+            .joined(separator: " + ")
+    }
+
+    var shortcutRecorderDisplayString: String {
+        keys
+            .sorted {
+                if $0.sortOrder == $1.sortOrder {
+                    if $0.displayName == $1.displayName {
+                        return $0.keyCode < $1.keyCode
+                    }
+
+                    return $0.displayName < $1.displayName
+                }
+
+                return $0.sortOrder < $1.sortOrder
+            }
+            .map(\.shortcutRecorderDisplayName)
+            .joined(separator: " + ")
+    }
+}

--- a/GhostPepper/Input/PasteSession.swift
+++ b/GhostPepper/Input/PasteSession.swift
@@ -1,0 +1,11 @@
+import CoreGraphics
+import Foundation
+
+struct PasteSession: Equatable, Sendable {
+    let pastedText: String
+    let pastedAt: Date
+    let frontmostAppBundleIdentifier: String?
+    let frontmostWindowID: UInt32?
+    let frontmostWindowFrame: CGRect?
+    let focusedElementFrame: CGRect?
+}

--- a/GhostPepper/Input/PhysicalKey.swift
+++ b/GhostPepper/Input/PhysicalKey.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+struct PhysicalKey: Codable, Hashable {
+    let keyCode: UInt16
+
+    var displayName: String {
+        switch keyCode {
+        case 36:
+            "Return"
+        case 48:
+            "Tab"
+        case 49:
+            "Space"
+        case 51:
+            "Delete"
+        case 53:
+            "Escape"
+        case 54:
+            "Right Command"
+        case 55:
+            "Left Command"
+        case 56:
+            "Left Shift"
+        case 57:
+            "Caps Lock"
+        case 58:
+            "Left Option"
+        case 59:
+            "Left Control"
+        case 60:
+            "Right Shift"
+        case 61:
+            "Right Option"
+        case 62:
+            "Right Control"
+        case 63:
+            "Fn / Globe"
+        default:
+            "Key Code \(keyCode)"
+        }
+    }
+
+    var sortOrder: Int {
+        switch keyCode {
+        case 54, 55:
+            0
+        case 58, 61:
+            1
+        case 59, 62:
+            2
+        case 56, 60:
+            3
+        case 63:
+            4
+        default:
+            100
+        }
+    }
+
+    var shortcutRecorderDisplayName: String {
+        switch keyCode {
+        case 54:
+            "⌘ʳ"
+        case 55:
+            "⌘ˡ"
+        case 56:
+            "⇧ˡ"
+        case 58:
+            "⌥ˡ"
+        case 59:
+            "⌃ˡ"
+        case 60:
+            "⇧ʳ"
+        case 61:
+            "⌥ʳ"
+        case 62:
+            "⌃ʳ"
+        default:
+            displayName
+        }
+    }
+}

--- a/GhostPepper/Input/ShortcutCaptureState.swift
+++ b/GhostPepper/Input/ShortcutCaptureState.swift
@@ -1,0 +1,42 @@
+struct ShortcutCaptureState {
+    private(set) var pressedKeys: Set<PhysicalKey> = []
+    private(set) var capturedKeys: Set<PhysicalKey> = []
+
+    mutating func handle(_ inputEvent: ChordEngine.InputEvent) -> KeyChord? {
+        switch inputEvent {
+        case .flagsChanged(let key):
+            if pressedKeys.contains(key) {
+                pressedKeys.remove(key)
+                return finishIfNeeded()
+            }
+
+            pressedKeys.insert(key)
+            capturedKeys.insert(key)
+            return nil
+
+        case .keyDown(let key):
+            pressedKeys.insert(key)
+            capturedKeys.insert(key)
+            return nil
+
+        case .keyUp(let key):
+            pressedKeys.remove(key)
+            return finishIfNeeded()
+        }
+    }
+
+    mutating func reset() {
+        pressedKeys = []
+        capturedKeys = []
+    }
+
+    private mutating func finishIfNeeded() -> KeyChord? {
+        guard pressedKeys.isEmpty else {
+            return nil
+        }
+
+        let chord = KeyChord(keys: capturedKeys)
+        reset()
+        return chord
+    }
+}

--- a/GhostPepper/Input/TextPaster.swift
+++ b/GhostPepper/Input/TextPaster.swift
@@ -10,6 +10,7 @@ struct ClipboardState {
 /// Saves and restores the clipboard around the paste operation to avoid clobbering user data.
 /// Requires Accessibility permission for CGEvent posting.
 final class TextPaster {
+    typealias PasteSessionProvider = @Sendable (String, Date) -> PasteSession?
 
     // MARK: - Timing Constants
 
@@ -22,6 +23,17 @@ final class TextPaster {
     // MARK: - Virtual Key Codes
 
     private static let vKeyCode: CGKeyCode = 0x09
+    var onPaste: ((PasteSession) -> Void)?
+
+    private let pasteSessionProvider: PasteSessionProvider
+
+    init(
+        pasteSessionProvider: @escaping PasteSessionProvider = { text, date in
+            FocusedElementLocator().capturePasteSession(for: text, at: date)
+        }
+    ) {
+        self.pasteSessionProvider = pasteSessionProvider
+    }
 
     // MARK: - Clipboard Operations
 
@@ -81,6 +93,7 @@ final class TextPaster {
     /// - Parameter text: The text to paste.
     func paste(text: String) {
         let savedState = saveClipboard()
+        let pasteSession = pasteSessionProvider(text, Date())
 
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -88,6 +101,9 @@ final class TextPaster {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.preKeystrokeDelay) { [weak self] in
             self?.simulateCmdV()
+            if let pasteSession {
+                self?.onPaste?(pasteSession)
+            }
 
             DispatchQueue.main.asyncAfter(deadline: .now() + Self.postKeystrokeDelay) { [weak self] in
                 if let savedState = savedState {

--- a/GhostPepper/PermissionChecker.swift
+++ b/GhostPepper/PermissionChecker.swift
@@ -1,5 +1,7 @@
 import Cocoa
 import AVFoundation
+import CoreGraphics
+import IOKit.hidsystem
 
 class PermissionChecker {
 
@@ -33,6 +35,35 @@ class PermissionChecker {
 
     static func openMicrophoneSettings() {
         if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    static func checkInputMonitoring() -> Bool {
+        IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted
+    }
+
+    static func promptInputMonitoring() {
+        IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
+    }
+
+    static func openInputMonitoringSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    static func hasScreenRecordingPermission() -> Bool {
+        CGPreflightScreenCaptureAccess()
+    }
+
+    @discardableResult
+    static func requestScreenRecordingPermission() -> Bool {
+        CGRequestScreenCaptureAccess()
+    }
+
+    static func openScreenRecordingSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
             NSWorkspace.shared.open(url)
         }
     }

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -16,6 +16,8 @@ final class ModelManager: ObservableObject {
     /// Any error encountered during model setup.
     @Published private(set) var error: Error?
 
+    var debugLogger: ((DebugLogCategory, String) -> Void)?
+
     /// Whether the model is loaded and ready for transcription.
     var isReady: Bool {
         state == .ready
@@ -32,6 +34,7 @@ final class ModelManager: ObservableObject {
 
         state = .loading
         error = nil
+        debugLogger?(.model, "Loading Whisper model \(modelName).")
 
         do {
             let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -50,9 +53,11 @@ final class ModelManager: ObservableObject {
             let kit = try await WhisperKit(config)
             self.whisperKit = kit
             self.state = .ready
+            debugLogger?(.model, "Whisper model \(modelName) loaded successfully.")
         } catch {
             self.error = error
             self.state = .error
+            debugLogger?(.model, "Whisper model \(modelName) failed to load: \(error.localizedDescription)")
         }
     }
 }

--- a/GhostPepper/UI/DebugLogWindow.swift
+++ b/GhostPepper/UI/DebugLogWindow.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+import AppKit
+
+final class DebugLogWindowController: NSObject, NSWindowDelegate {
+    private var window: NSPanel?
+    private weak var debugLogStore: DebugLogStore?
+    private var isLiveViewing = false
+
+    func show(debugLogStore: DebugLogStore) {
+        if let window = window {
+            self.debugLogStore = debugLogStore
+            beginLiveViewingIfNeeded()
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable, .resizable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Ghost Pepper Debug Log"
+        window.delegate = self
+        window.isReleasedWhenClosed = false
+        window.isFloatingPanel = true
+        window.level = .floating
+        window.hidesOnDeactivate = false
+        window.contentViewController = NSHostingController(
+            rootView: DebugLogWindowView(debugLogStore: debugLogStore)
+        )
+        self.debugLogStore = debugLogStore
+        beginLiveViewingIfNeeded()
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        endLiveViewingIfNeeded()
+        sender.orderOut(nil)
+        return false
+    }
+
+    private func beginLiveViewingIfNeeded() {
+        guard !isLiveViewing else {
+            return
+        }
+
+        debugLogStore?.beginLiveViewing()
+        isLiveViewing = true
+    }
+
+    private func endLiveViewingIfNeeded() {
+        guard isLiveViewing else {
+            return
+        }
+
+        debugLogStore?.endLiveViewing()
+        isLiveViewing = false
+    }
+}
+
+private struct DebugLogWindowView: View {
+    @ObservedObject var debugLogStore: DebugLogStore
+    @State private var shouldFollowTail = true
+
+    private let bottomAnchorID = "debug-log-bottom"
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Button("Copy Log") {
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString(debugLogStore.formattedText, forType: .string)
+                }
+                .disabled(debugLogStore.entries.isEmpty)
+
+                Button("Clear") {
+                    debugLogStore.clear()
+                }
+                .disabled(debugLogStore.entries.isEmpty)
+
+                Spacer()
+            }
+
+            ScrollViewReader { proxy in
+                GeometryReader { outer in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 12) {
+                            if debugLogStore.entries.isEmpty {
+                                Text("No debug events yet.")
+                                    .font(.system(.caption, design: .monospaced))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .textSelection(.enabled)
+                            } else {
+                                ForEach(debugLogStore.entries) { entry in
+                                    Text(formattedText(for: entry))
+                                        .font(.system(.caption, design: .monospaced))
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                        .textSelection(.enabled)
+                                        .id(entry.id)
+                                }
+                            }
+
+                            Color.clear
+                                .frame(height: 1)
+                                .id(bottomAnchorID)
+                                .background(
+                                    GeometryReader { geometry in
+                                        Color.clear.preference(
+                                            key: DebugLogBottomOffsetPreferenceKey.self,
+                                            value: geometry.frame(in: .named("debug-log-scroll")).maxY
+                                        )
+                                    }
+                                )
+                        }
+                    }
+                    .coordinateSpace(name: "debug-log-scroll")
+                    .onAppear {
+                        scrollToBottom(with: proxy)
+                    }
+                    .onChange(of: debugLogStore.entries.count) { _, _ in
+                        guard shouldFollowTail else {
+                            return
+                        }
+                        scrollToBottom(with: proxy)
+                    }
+                    .onPreferenceChange(DebugLogBottomOffsetPreferenceKey.self) { bottomOffset in
+                        shouldFollowTail = bottomOffset - outer.size.height <= 32
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding()
+        .frame(minWidth: 640, minHeight: 420)
+    }
+
+    private func formattedText(for entry: DebugLogEntry) -> String {
+        "[\(formattedTime(for: entry.timestamp))] [\(entry.category.rawValue)] \(entry.message)"
+    }
+
+    private func formattedTime(for timestamp: Date) -> String {
+        Self.timeFormatter.string(from: timestamp)
+    }
+
+    private func scrollToBottom(with proxy: ScrollViewProxy) {
+        DispatchQueue.main.async {
+            proxy.scrollTo(bottomAnchorID, anchor: .bottom)
+        }
+    }
+}
+
+private struct DebugLogBottomOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}

--- a/GhostPepper/UI/MenuBarView.swift
+++ b/GhostPepper/UI/MenuBarView.swift
@@ -5,12 +5,15 @@ import ServiceManagement
 struct MenuBarView: View {
     @ObservedObject var appState: AppState
     let updaterController: UpdaterController
-    private let settingsController = SettingsWindowController()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             Button("Settings...") {
-                settingsController.show(appState: appState)
+                appState.showSettings()
+            }
+
+            Button("Debug Log...") {
+                appState.showDebugLog()
             }
 
             Text("Ghost Pepper v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")")
@@ -39,6 +42,14 @@ struct MenuBarView: View {
                     .foregroundStyle(.red)
                     .padding(.horizontal, 14)
 
+                if error.contains("Input Monitoring") {
+                    Button("Open Input Monitoring Settings") {
+                        PermissionChecker.openInputMonitoringSettings()
+                    }
+                    Button("Retry") {
+                        Task { await appState.startHotkeyMonitor() }
+                    }
+                }
                 if error.contains("Accessibility") {
                     Button("Open Accessibility Settings") {
                         PermissionChecker.openAccessibilitySettings()

--- a/GhostPepper/UI/OnboardingWindow.swift
+++ b/GhostPepper/UI/OnboardingWindow.swift
@@ -194,14 +194,15 @@ struct SetupStep: View {
     @State private var micGranted = false
     @State private var micDenied = false
     @State private var accessibilityGranted = false
-    @State private var accessibilityTimer: Timer?
+    @State private var permissionTimer: Timer?
     @State private var modelLoadStarted = false
     @State private var inputDevices: [AudioInputDevice] = []
     @State private var selectedDeviceID: AudioDeviceID = 0
     @StateObject private var micLevel = MicLevelMonitor()
+    @StateObject private var screenRecordingPermission = ScreenRecordingPermissionController()
 
     private var allComplete: Bool {
-        micGranted && accessibilityGranted && modelManager.isReady
+        micGranted && accessibilityGranted && screenRecordingPermission.isGranted && modelManager.isReady
     }
 
     var body: some View {
@@ -293,7 +294,7 @@ struct SetupStep: View {
                 SetupRow(
                     icon: "keyboard.fill",
                     title: "Accessibility",
-                    subtitle: "For the Control key hotkey & pasting",
+                    subtitle: "For keyboard shortcuts & pasting",
                     isComplete: accessibilityGranted
                 ) {
                     if !accessibilityGranted {
@@ -304,6 +305,30 @@ struct SetupStep: View {
                         .tint(.orange)
                         .controlSize(.small)
                     }
+                }
+
+                SetupRow(
+                    icon: "rectangle.on.rectangle",
+                    title: "Screen Recording",
+                    subtitle: "For OCR context & learning",
+                    isComplete: screenRecordingPermission.isGranted
+                ) {
+                    if !screenRecordingPermission.isGranted {
+                        Button("Grant") {
+                            screenRecordingPermission.requestAccess()
+                            PermissionChecker.openScreenRecordingSettings()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.orange)
+                        .controlSize(.small)
+                    }
+                }
+
+                if !screenRecordingPermission.isGranted {
+                    Text("Grant Screen Recording access in System Settings, then return here.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 4)
                 }
 
                 VStack(spacing: 8) {
@@ -353,7 +378,7 @@ struct SetupStep: View {
 
             if allComplete {
                 Button(action: {
-                    stopAccessibilityPolling()
+                    stopPermissionPolling()
                     onContinue()
                 }) {
                     Text("Continue")
@@ -397,27 +422,34 @@ struct SetupStep: View {
                 Task { await modelManager.loadModel() }
             }
 
-            startAccessibilityPolling()
+            startPermissionPolling()
         }
         .onDisappear {
-            stopAccessibilityPolling()
+            stopPermissionPolling()
             micLevel.stop()
         }
     }
 
-    private func startAccessibilityPolling() {
-        accessibilityTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
-            let granted = PermissionChecker.checkAccessibility()
-            if granted {
+    private func startPermissionPolling() {
+        guard permissionTimer == nil else { return }
+
+        permissionTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
+            let accessibilityGrantedNow = PermissionChecker.checkAccessibility()
+            if accessibilityGrantedNow {
                 accessibilityGranted = true
-                stopAccessibilityPolling()
+            }
+
+            screenRecordingPermission.refresh()
+
+            if accessibilityGrantedNow && screenRecordingPermission.isGranted {
+                stopPermissionPolling()
             }
         }
     }
 
-    private func stopAccessibilityPolling() {
-        accessibilityTimer?.invalidate()
-        accessibilityTimer = nil
+    private func stopPermissionPolling() {
+        permissionTimer?.invalidate()
+        permissionTimer = nil
     }
 }
 
@@ -470,15 +502,22 @@ class TryItController: ObservableObject {
     @Published var transcribedText: String?
     @Published var monitorStartFailed = false
 
-    private var hotkeyMonitor: HotkeyMonitor?
+    private var hotkeyMonitor: HotkeyMonitoring?
     private var audioRecorder: AudioRecorder?
     private var hasAdvanced = false
     private var retryCount = 0
     private let maxRetries = 5
     private let transcriber: WhisperTranscriber
+    private let hotkeyMonitorFactory: ([ChordAction: KeyChord]) -> HotkeyMonitoring
 
-    init(transcriber: WhisperTranscriber) {
+    init(
+        transcriber: WhisperTranscriber,
+        hotkeyMonitorFactory: @escaping ([ChordAction: KeyChord]) -> HotkeyMonitoring = { bindings in
+            HotkeyMonitor(bindings: bindings)
+        }
+    ) {
         self.transcriber = transcriber
+        self.hotkeyMonitorFactory = hotkeyMonitorFactory
     }
 
     func start(onAdvance: @escaping () -> Void) {
@@ -486,7 +525,9 @@ class TryItController: ObservableObject {
         recorder.prewarm()
         self.audioRecorder = recorder
 
-        let monitor = HotkeyMonitor()
+        let monitor = hotkeyMonitorFactory([
+            .pushToTalk: AppState.defaultPushToTalkChord
+        ])
         monitor.onRecordingStart = { [weak self] in
             Task { @MainActor in
                 guard let self else { return }
@@ -531,7 +572,7 @@ class TryItController: ObservableObject {
         audioRecorder = nil
     }
 
-    private func retryStartMonitor(monitor: HotkeyMonitor) {
+    private func retryStartMonitor(monitor: HotkeyMonitoring) {
         guard retryCount < maxRetries else {
             monitorStartFailed = true
             return
@@ -564,15 +605,13 @@ struct TryItStep: View {
                 .font(.system(size: 24, weight: .bold))
                 .padding(.top, 24)
 
-            Text("Hold the **Control** key and say something")
+            Text("Hold **Right Command + Right Option** and say something")
                 .font(.callout)
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 6) {
-                KeyCap(label: "fn", highlighted: false)
-                KeyCap(label: "⌃ control", highlighted: true, isActive: controller.isRecording)
-                KeyCap(label: "⌥", highlighted: false)
-                KeyCap(label: "⌘", highlighted: false)
+                KeyCap(label: "⌘ right", highlighted: true, isActive: controller.isRecording)
+                KeyCap(label: "⌥ right", highlighted: true, isActive: controller.isRecording)
             }
             .padding(.vertical, 8)
 
@@ -619,7 +658,7 @@ struct TryItStep: View {
                         .foregroundStyle(.red)
                         .multilineTextAlignment(.center)
                 } else {
-                    Text("Waiting for you to hold Control...")
+                    Text("Waiting for you to hold Right Command + Right Option...")
                         .foregroundStyle(.secondary)
                 }
             }
@@ -734,6 +773,7 @@ struct DoneStep: View {
                     .font(.callout)
                     .foregroundStyle(.secondary)
                 BulletPoint("Switch your microphone")
+                BulletPoint("Change your recording shortcuts")
                 BulletPoint("Toggle text cleanup on/off")
                 BulletPoint("Edit the cleanup prompt")
                 BulletPoint("Check for updates")

--- a/GhostPepper/UI/PromptEditorWindow.swift
+++ b/GhostPepper/UI/PromptEditorWindow.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 import AppKit
 
-class PromptEditorController {
+final class PromptEditorController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
 
     func show(appState: AppState) {
-        // Always recreate the window to get fresh bindings
-        dismiss()
+        if let window = window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
 
         let editor = PromptEditorView(appState: appState, onClose: { [weak self] in
             self?.dismiss()
@@ -19,7 +22,9 @@ class PromptEditorController {
             defer: false
         )
         window.title = "Edit Cleanup Prompt"
-        window.contentView = NSHostingView(rootView: editor)
+        window.delegate = self
+        window.isReleasedWhenClosed = false
+        window.contentViewController = NSHostingController(rootView: editor)
         window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -28,8 +33,19 @@ class PromptEditorController {
     }
 
     func dismiss() {
-        window?.close()
-        window = nil
+        if let window {
+            hide(window)
+        }
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        hide(sender)
+        return false
+    }
+
+    private func hide(_ window: NSWindow) {
+        window.makeFirstResponder(nil)
+        window.orderOut(nil)
     }
 }
 

--- a/GhostPepper/UI/RecordingOverlay.swift
+++ b/GhostPepper/UI/RecordingOverlay.swift
@@ -38,7 +38,9 @@ class RecordingOverlayController {
         hosting.frame = container.bounds
         hosting.autoresizingMask = [.width, .height]
         container.addSubview(hosting)
-        panel.contentView = container
+        let contentViewController = NSViewController()
+        contentViewController.view = container
+        panel.contentViewController = contentViewController
         self.hostingView = hosting
 
         if let screen = NSScreen.main {

--- a/GhostPepper/UI/ScreenRecordingPermissionController.swift
+++ b/GhostPepper/UI/ScreenRecordingPermissionController.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+@MainActor
+final class ScreenRecordingPermissionController: ObservableObject {
+    @Published private(set) var isGranted: Bool
+
+    private let hasPermission: () -> Bool
+    private let requestPermission: () -> Void
+
+    init(
+        hasPermission: @escaping () -> Bool = PermissionChecker.hasScreenRecordingPermission,
+        requestPermission: @escaping () -> Void = {
+            _ = PermissionChecker.requestScreenRecordingPermission()
+        }
+    ) {
+        self.hasPermission = hasPermission
+        self.requestPermission = requestPermission
+        self.isGranted = hasPermission()
+    }
+
+    func refresh() {
+        isGranted = hasPermission()
+    }
+
+    func requestAccess() {
+        requestPermission()
+        refresh()
+    }
+}

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -4,7 +4,7 @@ import CoreAudio
 import ServiceManagement
 import AVFoundation
 
-class SettingsWindowController {
+final class SettingsWindowController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
 
     func show(appState: AppState) {
@@ -17,25 +17,38 @@ class SettingsWindowController {
         let view = SettingsView(appState: appState)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 580),
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 700),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
         )
         window.title = "Ghost Pepper Settings"
-        window.contentView = NSHostingView(rootView: view)
+        window.delegate = self
+        window.isReleasedWhenClosed = false
+        window.contentViewController = NSHostingController(rootView: view)
         window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
         self.window = window
     }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        sender.orderOut(nil)
+        return false
+    }
 }
 
 // MARK: - Mic Level Monitor for Settings
 
+protocol MicLevelMonitoring: AnyObject {
+    func start()
+    func stop()
+    func restart()
+}
+
 @MainActor
-class SettingsMicMonitor: ObservableObject {
+class SettingsMicMonitor: ObservableObject, MicLevelMonitoring {
     @Published var level: Float = 0
     private var engine: AVAudioEngine?
     private var isRunning = false
@@ -84,6 +97,33 @@ class SettingsMicMonitor: ObservableObject {
     }
 }
 
+@MainActor
+final class MicPreviewController: ObservableObject {
+    @Published private(set) var isPreviewing = false
+
+    private let monitor: MicLevelMonitoring
+
+    init(monitor: MicLevelMonitoring) {
+        self.monitor = monitor
+    }
+
+    func setPreviewing(_ previewing: Bool) {
+        guard previewing != isPreviewing else { return }
+
+        isPreviewing = previewing
+        if previewing {
+            monitor.start()
+        } else {
+            monitor.stop()
+        }
+    }
+
+    func restartIfNeeded() {
+        guard isPreviewing else { return }
+        monitor.restart()
+    }
+}
+
 // MARK: - Settings View
 
 struct SettingsView: View {
@@ -91,11 +131,49 @@ struct SettingsView: View {
     @State private var inputDevices: [AudioInputDevice] = []
     @State private var selectedDeviceID: AudioDeviceID = 0
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
-    @StateObject private var micMonitor = SettingsMicMonitor()
-    private let promptEditor = PromptEditorController()
+    @State private var hasScreenRecordingPermission = PermissionChecker.hasScreenRecordingPermission()
+    @StateObject private var micMonitor: SettingsMicMonitor
+    @StateObject private var micPreviewController: MicPreviewController
+
+    init(appState: AppState) {
+        self.appState = appState
+        let micMonitor = SettingsMicMonitor()
+        _micMonitor = StateObject(wrappedValue: micMonitor)
+        _micPreviewController = StateObject(wrappedValue: MicPreviewController(monitor: micMonitor))
+    }
 
     var body: some View {
         Form {
+            Section {
+                ShortcutRecorderView(
+                    title: "Hold to Record",
+                    chord: appState.pushToTalkChord,
+                    onRecordingStateChange: appState.setShortcutCaptureActive
+                ) { chord in
+                    appState.updateShortcut(chord, for: .pushToTalk)
+                }
+
+                ShortcutRecorderView(
+                    title: "Toggle Recording",
+                    chord: appState.toggleToTalkChord,
+                    onRecordingStateChange: appState.setShortcutCaptureActive
+                ) { chord in
+                    appState.updateShortcut(chord, for: .toggleToTalk)
+                }
+
+                if let shortcutErrorMessage = appState.shortcutErrorMessage {
+                    Text(shortcutErrorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            } header: {
+                Text("Shortcuts")
+            } footer: {
+                Text("Push to talk records while the hold chord stays down. Toggle recording starts and stops when you press the full toggle chord.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Input") {
                 Picker("Microphone", selection: $selectedDeviceID) {
                     ForEach(inputDevices) { device in
@@ -104,8 +182,16 @@ struct SettingsView: View {
                 }
                 .onChange(of: selectedDeviceID) { _, newValue in
                     AudioDeviceManager.setDefaultInputDevice(newValue)
-                    micMonitor.restart()
+                    micPreviewController.restartIfNeeded()
                 }
+
+                Toggle(
+                    "Live mic level preview",
+                    isOn: Binding(
+                        get: { micPreviewController.isPreviewing },
+                        set: { micPreviewController.setPreviewing($0) }
+                    )
+                )
 
                 // Mic level meter
                 HStack(spacing: 6) {
@@ -129,23 +215,36 @@ struct SettingsView: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }
+
+                Text("Microphone preview is off by default so Ghost Pepper only keeps the mic active while recording or while you explicitly preview levels here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section {
-                Toggle("Enable cleanup", isOn: $appState.cleanupEnabled)
-                    .onChange(of: appState.cleanupEnabled) { _, enabled in
-                        Task {
-                            if enabled {
-                                await appState.textCleanupManager.loadModel()
-                            } else {
-                                appState.textCleanupManager.unloadModel()
-                            }
+                Toggle(
+                    "Enable cleanup",
+                    isOn: Binding(
+                        get: { appState.cleanupEnabled },
+                        set: { appState.setCleanupEnabled($0) }
+                    )
+                )
+
+                if appState.cleanupEnabled {
+                    Picker(
+                        "Cleanup model",
+                        selection: Binding(
+                            get: { appState.textCleanupManager.localModelPolicy },
+                            set: { appState.textCleanupManager.localModelPolicy = $0 }
+                        )
+                    ) {
+                        ForEach(LocalCleanupModelPolicy.allCases) { policy in
+                            Text(policy.title).tag(policy)
                         }
                     }
 
-                if appState.cleanupEnabled {
                     Button("Edit Cleanup Prompt...") {
-                        promptEditor.show(appState: appState)
+                        appState.showPromptEditor()
                     }
 
                     if appState.textCleanupManager.state == .error {
@@ -157,7 +256,73 @@ struct SettingsView: View {
             } header: {
                 Text("Cleanup")
             } footer: {
-                Text("When enabled, a local AI model cleans up your transcriptions — removing filler words like \"um\" and \"uh\", and handling self-corrections.")
+                Text("When enabled, Ghost Pepper cleans up your transcriptions with the selected local model policy.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Toggle(
+                    "Use frontmost window OCR context",
+                    isOn: Binding(
+                        get: { appState.frontmostWindowContextEnabled },
+                        set: { appState.frontmostWindowContextEnabled = $0 }
+                    )
+                )
+
+                if appState.frontmostWindowContextEnabled && !hasScreenRecordingPermission {
+                    ScreenRecordingRecoveryView {
+                        _ = PermissionChecker.requestScreenRecordingPermission()
+                        PermissionChecker.openScreenRecordingSettings()
+                        refreshScreenRecordingPermission()
+                    }
+                }
+            } header: {
+                Text("Context")
+            } footer: {
+                Text("Ghost Pepper uses high-quality OCR on the frontmost window and adds the result to the cleanup prompt.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Toggle(
+                    "Learn from manual corrections after paste",
+                    isOn: Binding(
+                        get: { appState.postPasteLearningEnabled },
+                        set: { appState.postPasteLearningEnabled = $0 }
+                    )
+                )
+
+                if appState.postPasteLearningEnabled && !hasScreenRecordingPermission {
+                    ScreenRecordingRecoveryView {
+                        _ = PermissionChecker.requestScreenRecordingPermission()
+                        PermissionChecker.openScreenRecordingSettings()
+                        refreshScreenRecordingPermission()
+                    }
+                }
+
+                CorrectionsEditor(
+                    title: "Preferred transcriptions",
+                    text: Binding(
+                        get: { appState.correctionStore.preferredTranscriptionsText },
+                        set: { appState.correctionStore.preferredTranscriptionsText = $0 }
+                    ),
+                    prompt: "One preferred word or phrase per line"
+                )
+
+                CorrectionsEditor(
+                    title: "Commonly misheard",
+                    text: Binding(
+                        get: { appState.correctionStore.commonlyMisheardText },
+                        set: { appState.correctionStore.commonlyMisheardText = $0 }
+                    ),
+                    prompt: "One replacement per line using probably wrong -> probably right"
+                )
+            } header: {
+                Text("Corrections")
+            } footer: {
+                Text("Preferred transcriptions are preserved in cleanup and forwarded into OCR custom words. Commonly misheard replacements run deterministically before cleanup. When learning is enabled, Ghost Pepper does a high-quality OCR check about 15 seconds after paste and only keeps narrow, high-confidence corrections.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -176,7 +341,6 @@ struct SettingsView: View {
                         }
                     }
             }
-
             Section {
                 ModelStatusRow(
                     name: "WhisperKit (speech-to-text)",
@@ -217,14 +381,36 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
-        .frame(width: 420, height: 580)
+        .frame(width: 420, height: 700)
         .onAppear {
             inputDevices = AudioDeviceManager.listInputDevices()
             selectedDeviceID = AudioDeviceManager.defaultInputDeviceID() ?? 0
-            micMonitor.start()
+            refreshScreenRecordingPermission()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshScreenRecordingPermission()
         }
         .onDisappear {
-            micMonitor.stop()
+            micPreviewController.setPreviewing(false)
+        }
+    }
+
+    private func refreshScreenRecordingPermission() {
+        hasScreenRecordingPermission = PermissionChecker.hasScreenRecordingPermission()
+    }
+}
+
+private struct ScreenRecordingRecoveryView: View {
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Ghost Pepper needs Screen Recording access. Grant it in System Settings, then return to Ghost Pepper.")
+                .font(.caption)
+                .foregroundStyle(.red)
+
+            Button("Open Screen Recording Settings", action: onOpenSettings)
+            .controlSize(.small)
         }
     }
 }
@@ -258,5 +444,27 @@ struct ModelStatusRow: View {
                 }
             }
         }
+    }
+}
+
+private struct CorrectionsEditor: View {
+    let title: String
+    let text: Binding<String>
+    let prompt: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.subheadline.weight(.medium))
+
+            TextEditor(text: text)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 72)
+
+            Text(prompt)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
     }
 }

--- a/GhostPepper/UI/ShortcutRecorderView.swift
+++ b/GhostPepper/UI/ShortcutRecorderView.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import AppKit
+import CoreGraphics
+
+struct ShortcutRecorderView: View {
+    let title: String
+    let chord: KeyChord
+    let onRecordingStateChange: (Bool) -> Void
+    let onChange: (KeyChord) -> Void
+
+    @State private var isRecording = false
+    @State private var captureState = ShortcutCaptureState()
+    @State private var localMonitor: Any?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(title)
+                Spacer()
+                if isRecording {
+                    Button(action: toggleRecording) {
+                        Text(buttonLabel)
+                            .monospaced()
+                    }
+                    .buttonStyle(BorderedProminentButtonStyle())
+                    .tint(.orange)
+                } else {
+                    Button(action: toggleRecording) {
+                        Text(buttonLabel)
+                            .monospaced()
+                    }
+                    .buttonStyle(BorderedButtonStyle())
+                    .tint(.orange)
+                }
+            }
+
+            if isRecording {
+                Text("Press the full chord, then release. Press Escape to cancel.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onDisappear {
+            stopRecording(commit: false)
+        }
+    }
+
+    private var buttonLabel: String {
+        if isRecording {
+            if let preview = KeyChord(keys: captureState.capturedKeys) {
+                return preview.shortcutRecorderDisplayString
+            }
+
+            return "Press Shortcut"
+        }
+
+        return chord.shortcutRecorderDisplayString
+    }
+
+    private func toggleRecording() {
+        if isRecording {
+            stopRecording(commit: false)
+        } else {
+            startRecording()
+        }
+    }
+
+    private func startRecording() {
+        stopRecording(commit: false)
+        onRecordingStateChange(true)
+        isRecording = true
+        captureState.reset()
+
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown, .keyUp]) { event in
+            handle(event)
+        }
+    }
+
+    private func stopRecording(commit: Bool) {
+        stopRecording(commit: commit, capturedChord: nil)
+    }
+
+    private func stopRecording(commit: Bool, capturedChord: KeyChord?) {
+        let wasRecording = isRecording || localMonitor != nil
+
+        if let localMonitor {
+            NSEvent.removeMonitor(localMonitor)
+            self.localMonitor = nil
+        }
+
+        let committedChord = capturedChord ?? KeyChord(keys: captureState.capturedKeys)
+        isRecording = false
+        captureState.reset()
+        if wasRecording {
+            onRecordingStateChange(false)
+        }
+
+        if commit, let committedChord {
+            onChange(committedChord)
+        }
+    }
+
+    private func handle(_ event: NSEvent) -> NSEvent? {
+        switch event.type {
+        case .flagsChanged:
+            let key = PhysicalKey(keyCode: UInt16(event.keyCode))
+            if let chord = captureState.handle(.flagsChanged(key)) {
+                stopRecording(commit: true, capturedChord: chord)
+            }
+            return nil
+
+        case .keyDown:
+            let key = PhysicalKey(keyCode: UInt16(event.keyCode))
+            if key.keyCode == 53, captureState.capturedKeys.isEmpty {
+                stopRecording(commit: false)
+                return nil
+            }
+
+            _ = captureState.handle(.keyDown(key))
+            return nil
+
+        case .keyUp:
+            let key = PhysicalKey(keyCode: UInt16(event.keyCode))
+            if let chord = captureState.handle(.keyUp(key)) {
+                stopRecording(commit: true, capturedChord: chord)
+            }
+            return nil
+
+        default:
+            return event
+        }
+    }
+}

--- a/GhostPepperTests/ChordBindingStoreTests.swift
+++ b/GhostPepperTests/ChordBindingStoreTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import GhostPepper
+
+final class ChordBindingStoreTests: XCTestCase {
+    private let suiteName = "ChordBindingStoreTests"
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testBindingStorePersistsPushAndToggleChords() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let store = ChordBindingStore(defaults: defaults)
+        let pushChord = try XCTUnwrap(KeyChord(keys: Set([PhysicalKey(keyCode: 54), PhysicalKey(keyCode: 61)])))
+        let toggleChord = try XCTUnwrap(KeyChord(keys: Set([PhysicalKey(keyCode: 54), PhysicalKey(keyCode: 61), PhysicalKey(keyCode: 49)])))
+
+        try store.setBinding(pushChord, for: .pushToTalk)
+        try store.setBinding(toggleChord, for: .toggleToTalk)
+
+        let restoredStore = ChordBindingStore(defaults: defaults)
+
+        XCTAssertEqual(restoredStore.binding(for: .pushToTalk), pushChord)
+        XCTAssertEqual(restoredStore.binding(for: .toggleToTalk), toggleChord)
+    }
+
+    func testBindingStoreRejectsDuplicateBindings() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let store = ChordBindingStore(defaults: defaults)
+        let chord = try XCTUnwrap(KeyChord(keys: Set([PhysicalKey(keyCode: 54), PhysicalKey(keyCode: 61)])))
+
+        try store.setBinding(chord, for: .pushToTalk)
+
+        XCTAssertThrowsError(try store.setBinding(chord, for: .toggleToTalk))
+    }
+}

--- a/GhostPepperTests/ChordEngineTests.swift
+++ b/GhostPepperTests/ChordEngineTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import GhostPepper
+
+final class ChordEngineTests: XCTestCase {
+    private let rightCommand = PhysicalKey(keyCode: 54)
+    private let rightOption = PhysicalKey(keyCode: 61)
+    private let space = PhysicalKey(keyCode: 49)
+    private let leftCommand = PhysicalKey(keyCode: 55)
+
+    func testPushToTalkStartsWhenChordMatchesEvenIfToggleExtendsIt() throws {
+        var engine = ChordEngine(bindings: [
+            .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption]))),
+            .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [.startRecording])
+        XCTAssertEqual(engine.activeRecordingAction, .pushToTalk)
+    }
+
+    func testPushToTalkPromotesToToggleWithoutRestarting() throws {
+        var engine = ChordEngine(bindings: [
+            .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption]))),
+            .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [.startRecording])
+        XCTAssertEqual(engine.activeRecordingAction, .pushToTalk)
+
+        XCTAssertEqual(engine.handle(.keyDown(space)), [])
+        XCTAssertEqual(engine.activeRecordingAction, .toggleToTalk)
+
+        XCTAssertEqual(engine.handle(.keyUp(space)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.stopRecording])
+        XCTAssertNil(engine.activeRecordingAction)
+    }
+
+    func testPushToTalkStartsImmediatelyWhenExactChordMatches() throws {
+        var engine = ChordEngine(bindings: [
+            .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption]))),
+            .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([leftCommand, space])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [.startRecording])
+        XCTAssertEqual(engine.activeRecordingAction, .pushToTalk)
+    }
+
+    func testToggleToTalkTogglesOnSecondMatch() throws {
+        var engine = ChordEngine(bindings: [
+            .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([leftCommand, space]))),
+            .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.startRecording])
+        XCTAssertEqual(engine.activeRecordingAction, .toggleToTalk)
+
+        XCTAssertEqual(engine.handle(.keyUp(space)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.stopRecording])
+        XCTAssertNil(engine.activeRecordingAction)
+    }
+
+    func testPushToTalkStopsWhenAnyRequiredKeyReleases() throws {
+        var engine = ChordEngine(bindings: [
+            .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption]))),
+            .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([leftCommand, space])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [.startRecording])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [.stopRecording])
+        XCTAssertNil(engine.activeRecordingAction)
+    }
+}

--- a/GhostPepperTests/CleanupBackendTests.swift
+++ b/GhostPepperTests/CleanupBackendTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import GhostPepper
+
+private final class SpyTextCleaningManager: TextCleaningManaging {
+    var cleanedInputs: [(text: String, prompt: String?)] = []
+    var nextResult: String?
+
+    func clean(text: String, prompt: String?) async -> String? {
+        cleanedInputs.append((text: text, prompt: prompt))
+        return nextResult
+    }
+}
+
+@MainActor
+final class CleanupBackendTests: XCTestCase {
+    func testLocalBackendUsesSelectedLocalPolicy() async throws {
+        let manager = SpyTextCleaningManager()
+        manager.nextResult = "local result"
+        let backend = LocalLLMCleanupBackend(cleanupManager: manager)
+
+        let result = try await backend.clean(text: "hello", prompt: "local prompt")
+
+        XCTAssertEqual(result, "local result")
+        XCTAssertEqual(manager.cleanedInputs.map(\.text), ["hello"])
+        XCTAssertEqual(manager.cleanedInputs.map(\.prompt), ["local prompt"])
+    }
+}

--- a/GhostPepperTests/CleanupPromptBuilderTests.swift
+++ b/GhostPepperTests/CleanupPromptBuilderTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import GhostPepper
+
+final class CleanupPromptBuilderTests: XCTestCase {
+    func testBuilderIncludesWindowContentsWrapperWhenContextEnabled() {
+        let builder = CleanupPromptBuilder()
+        let prompt = builder.buildPrompt(
+            basePrompt: "Base prompt",
+            windowContext: OCRContext(windowContents: "Frontmost text"),
+            includeWindowContext: true
+        )
+
+        XCTAssertTrue(prompt.contains("Base prompt"))
+        XCTAssertTrue(prompt.contains("<WINDOW CONTENTS>"))
+        XCTAssertTrue(prompt.contains("Frontmost text"))
+        XCTAssertTrue(prompt.contains("</WINDOW CONTENTS>"))
+    }
+
+    func testBuilderExplainsHowToUseWindowContentsAsSupportingContext() {
+        let builder = CleanupPromptBuilder()
+        let prompt = builder.buildPrompt(
+            basePrompt: "Base prompt",
+            windowContext: OCRContext(windowContents: "Frontmost text"),
+            preferredTranscriptions: [],
+            commonlyMisheard: [],
+            includeWindowContext: true
+        )
+
+        XCTAssertTrue(prompt.contains("Use the window contents only as supporting context to improve the transcription and cleanup."))
+        XCTAssertTrue(prompt.contains("Prefer the spoken words, and use the window contents only to disambiguate likely terms, names, commands, and jargon."))
+        XCTAssertTrue(prompt.contains("Do not answer, summarize, or rewrite the window contents unless that directly helps correct the transcription."))
+    }
+
+    func testBuilderOmitsWindowContentsWhenContextUnavailable() {
+        let builder = CleanupPromptBuilder()
+        let prompt = builder.buildPrompt(
+            basePrompt: "Base prompt",
+            windowContext: nil,
+            preferredTranscriptions: [],
+            commonlyMisheard: [],
+            includeWindowContext: true
+        )
+
+        XCTAssertEqual(prompt, "Base prompt")
+    }
+
+    func testBuilderTrimsLongOCRContextBeforePromptAssembly() {
+        let builder = CleanupPromptBuilder(maxWindowContentLength: 12)
+        let prompt = builder.buildPrompt(
+            basePrompt: "Base prompt",
+            windowContext: OCRContext(windowContents: "abcdefghijklmnopqrstuvwxyz"),
+            preferredTranscriptions: [],
+            commonlyMisheard: [],
+            includeWindowContext: true
+        )
+
+        XCTAssertTrue(prompt.contains("abcdefghijkl"))
+        XCTAssertFalse(prompt.contains("mnopqrstuvwxyz"))
+    }
+
+    func testBuilderIncludesCorrectionListsWhenAvailable() {
+        let builder = CleanupPromptBuilder()
+        let prompt = builder.buildPrompt(
+            basePrompt: "Base prompt",
+            windowContext: OCRContext(windowContents: "Frontmost text"),
+            preferredTranscriptions: ["Ghost Pepper", "Jesse"],
+            commonlyMisheard: [
+                MisheardReplacement(wrong: "just see", right: "Jesse"),
+                MisheardReplacement(wrong: "chat gbt", right: "ChatGPT")
+            ],
+            includeWindowContext: true
+        )
+
+        XCTAssertTrue(prompt.contains("Preferred transcriptions to preserve exactly:"))
+        XCTAssertTrue(prompt.contains("- Ghost Pepper"))
+        XCTAssertTrue(prompt.contains("- Jesse"))
+        XCTAssertTrue(prompt.contains("Commonly misheard replacements to prefer:"))
+        XCTAssertTrue(prompt.contains("- just see -> Jesse"))
+        XCTAssertTrue(prompt.contains("- chat gbt -> ChatGPT"))
+    }
+}

--- a/GhostPepperTests/CorrectionStoreTests.swift
+++ b/GhostPepperTests/CorrectionStoreTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class CorrectionStoreTests: XCTestCase {
+    func testPreferredTranscriptionsRoundTripThroughStorePersistence() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+
+        let store = CorrectionStore(defaults: defaults)
+        store.preferredTranscriptionsText = "Ghost Pepper\nOpenAI"
+
+        let reloadedStore = CorrectionStore(defaults: defaults)
+
+        XCTAssertEqual(reloadedStore.preferredTranscriptions, ["Ghost Pepper", "OpenAI"])
+    }
+
+    func testCommonlyMisheardRoundTripThroughStorePersistence() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+
+        let store = CorrectionStore(defaults: defaults)
+        store.commonlyMisheardText = "chat gbt -> ChatGPT\njust see -> Jesse"
+
+        let reloadedStore = CorrectionStore(defaults: defaults)
+
+        XCTAssertEqual(
+            reloadedStore.commonlyMisheard,
+            [
+                MisheardReplacement(wrong: "chat gbt", right: "ChatGPT"),
+                MisheardReplacement(wrong: "just see", right: "Jesse")
+            ]
+        )
+    }
+
+    func testPreferredTranscriptionsWinOverBroadReplacement() {
+        let engine = DeterministicCorrectionEngine(
+            preferredTranscriptions: ["Ghost Pepper"],
+            commonlyMisheard: [MisheardReplacement(wrong: "ghost", right: "goes")]
+        )
+
+        let corrected = engine.applyPreCleanupCorrections(to: "ghost pepper is ready")
+
+        XCTAssertEqual(corrected, "Ghost Pepper is ready")
+    }
+
+    func testCommonlyMisheardReplacementAppliesDeterministically() {
+        let engine = DeterministicCorrectionEngine(
+            preferredTranscriptions: [],
+            commonlyMisheard: [MisheardReplacement(wrong: "chat gbt", right: "ChatGPT")]
+        )
+
+        let corrected = engine.applyPreCleanupCorrections(to: "open chat gbt and summarize this")
+
+        XCTAssertEqual(corrected, "open ChatGPT and summarize this")
+    }
+
+    func testPreferredOCRCustomWordsMatchPreferredTranscriptions() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+
+        let store = CorrectionStore(defaults: defaults)
+        store.preferredTranscriptionsText = "Ghost Pepper\nJesse"
+
+        XCTAssertEqual(store.preferredOCRCustomWords, ["Ghost Pepper", "Jesse"])
+    }
+
+    func testCommonlyMisheardDraftPreservesIncompleteLine() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+
+        let store = CorrectionStore(defaults: defaults)
+        store.commonlyMisheardText = "chat gbt -> ChatGPT\nstill typing"
+
+        XCTAssertEqual(store.commonlyMisheardText, "chat gbt -> ChatGPT\nstill typing")
+        XCTAssertEqual(store.commonlyMisheard, [MisheardReplacement(wrong: "chat gbt", right: "ChatGPT")])
+
+        let reloadedStore = CorrectionStore(defaults: defaults)
+        XCTAssertEqual(reloadedStore.commonlyMisheardText, "chat gbt -> ChatGPT\nstill typing")
+        XCTAssertEqual(reloadedStore.commonlyMisheard, [MisheardReplacement(wrong: "chat gbt", right: "ChatGPT")])
+    }
+
+    func testAppendCommonlyMisheardPreservesDraftAndDeduplicates() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+
+        let store = CorrectionStore(defaults: defaults)
+        store.commonlyMisheardText = "chat gbt -> ChatGPT\nstill typing"
+
+        store.appendCommonlyMisheard(MisheardReplacement(wrong: "just see", right: "Jesse"))
+        store.appendCommonlyMisheard(MisheardReplacement(wrong: "just see", right: "Jesse"))
+
+        XCTAssertEqual(
+            store.commonlyMisheardText,
+            "chat gbt -> ChatGPT\nstill typing\njust see -> Jesse"
+        )
+        XCTAssertEqual(
+            store.commonlyMisheard,
+            [
+                MisheardReplacement(wrong: "chat gbt", right: "ChatGPT"),
+                MisheardReplacement(wrong: "just see", right: "Jesse")
+            ]
+        )
+    }
+}

--- a/GhostPepperTests/DebugLogStoreTests.swift
+++ b/GhostPepperTests/DebugLogStoreTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class DebugLogStoreTests: XCTestCase {
+    func testStoreDropsOldestEntriesWhenCapacityIsExceeded() {
+        let store = DebugLogStore(maxEntries: 2)
+
+        store.record(category: .hotkey, message: "first")
+        store.record(category: .ocr, message: "second")
+        store.record(category: .cleanup, message: "third")
+
+        XCTAssertEqual(store.entries.count, 2)
+        XCTAssertEqual(store.entries.map(\.message), ["second", "third"])
+    }
+
+    func testClearRemovesFormattedLogOutput() {
+        let store = DebugLogStore(maxEntries: 2)
+
+        store.record(category: .model, message: "loaded")
+        store.clear()
+
+        XCTAssertTrue(store.entries.isEmpty)
+        XCTAssertEqual(store.formattedText, "")
+    }
+
+    func testSensitiveEntriesAreIgnoredWhenNoDebugViewerIsOpen() {
+        let store = DebugLogStore()
+
+        store.recordSensitive(category: .cleanup, message: "full prompt")
+
+        XCTAssertTrue(store.entries.isEmpty)
+    }
+
+    func testSensitiveEntriesAreRecordedOnlyWhileDebugViewerIsOpen() {
+        let store = DebugLogStore()
+
+        store.beginLiveViewing()
+        store.recordSensitive(category: .cleanup, message: "full prompt")
+        store.endLiveViewing()
+        store.recordSensitive(category: .cleanup, message: "full output")
+
+        XCTAssertEqual(store.entries.map(\.message), ["full prompt"])
+    }
+}

--- a/GhostPepperTests/FocusedElementLocatorTests.swift
+++ b/GhostPepperTests/FocusedElementLocatorTests.swift
@@ -1,0 +1,39 @@
+import CoreGraphics
+import XCTest
+@testable import GhostPepper
+
+final class FocusedElementLocatorTests: XCTestCase {
+    func testWindowReferenceReadsSwiftDictionaryBounds() {
+        let locator = FocusedElementLocator()
+        let windowList: [[String: Any]] = [[
+            kCGWindowOwnerPID as String: NSNumber(value: 42),
+            kCGWindowLayer as String: 0,
+            kCGWindowAlpha as String: 1.0,
+            kCGWindowNumber as String: NSNumber(value: 99),
+            kCGWindowBounds as String: [
+                "X": 10,
+                "Y": 20,
+                "Width": 300,
+                "Height": 200
+            ]
+        ]]
+
+        let reference = locator.windowReference(in: windowList, for: 42)
+
+        XCTAssertEqual(reference?.windowID, 99)
+        XCTAssertEqual(reference?.frame, CGRect(x: 10, y: 20, width: 300, height: 200))
+    }
+
+    func testWindowReferenceIgnoresUnsupportedBoundsValue() {
+        let locator = FocusedElementLocator()
+        let windowList: [[String: Any]] = [[
+            kCGWindowOwnerPID as String: NSNumber(value: 42),
+            kCGWindowLayer as String: 0,
+            kCGWindowAlpha as String: 1.0,
+            kCGWindowNumber as String: NSNumber(value: 99),
+            kCGWindowBounds as String: "not a bounds dictionary"
+        ]]
+
+        XCTAssertNil(locator.windowReference(in: windowList, for: 42))
+    }
+}

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -2,6 +2,47 @@ import XCTest
 import SwiftUI
 @testable import GhostPepper
 
+private final class FakeHotkeyMonitor: HotkeyMonitoring {
+    var onRecordingStart: (() -> Void)?
+    var onRecordingStop: (() -> Void)?
+    var onPushToTalkStart: (() -> Void)?
+    var onPushToTalkStop: (() -> Void)?
+    var onToggleToTalkStart: (() -> Void)?
+    var onToggleToTalkStop: (() -> Void)?
+
+    var updatedBindings: [ChordAction: KeyChord] = [:]
+    var startResult = true
+    var startCallCount = 0
+    var suspendedStates: [Bool] = []
+
+    func start() -> Bool {
+        startCallCount += 1
+        return startResult
+    }
+
+    func stop() {}
+
+    func updateBindings(_ bindings: [ChordAction: KeyChord]) {
+        updatedBindings = bindings
+    }
+
+    func setSuspended(_ suspended: Bool) {
+        suspendedStates.append(suspended)
+    }
+}
+
+private final class FakeAppRelauncher: AppRelaunching {
+    var relaunchCallCount = 0
+    var error: Error?
+
+    func relaunch() throws {
+        relaunchCallCount += 1
+        if let error {
+            throw error
+        }
+    }
+}
+
 @MainActor
 final class GhostPepperTests: XCTestCase {
     func testAppStateInitialStatus() {
@@ -41,5 +82,640 @@ final class GhostPepperTests: XCTestCase {
         }
 
         return optionalMirror.children.first?.value as? T
+    }
+
+    func testAppStateLoadsDefaultShortcutBindingsIntoHotkeyMonitor() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let appState = AppState(hotkeyMonitor: monitor, chordBindingStore: ChordBindingStore(defaults: defaults))
+
+        await appState.startHotkeyMonitor()
+
+        XCTAssertEqual(monitor.updatedBindings[.pushToTalk], AppState.defaultPushToTalkChord)
+        XCTAssertEqual(monitor.updatedBindings[.toggleToTalk], AppState.defaultToggleToTalkChord)
+    }
+
+    func testAppStateWiresPushAndToggleCallbacksIntoHotkeyMonitor() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let appState = AppState(hotkeyMonitor: monitor, chordBindingStore: ChordBindingStore(defaults: defaults))
+
+        await appState.startHotkeyMonitor()
+
+        XCTAssertNotNil(monitor.onPushToTalkStart)
+        XCTAssertNotNil(monitor.onPushToTalkStop)
+        XCTAssertNotNil(monitor.onToggleToTalkStart)
+        XCTAssertNotNil(monitor.onToggleToTalkStop)
+    }
+
+    func testAppStateStartHotkeyMonitorSkipsRepeatedStartAfterSuccess() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let appState = AppState(
+            hotkeyMonitor: monitor,
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            inputMonitoringChecker: { true }
+        )
+
+        await appState.startHotkeyMonitor()
+        await appState.startHotkeyMonitor()
+
+        XCTAssertEqual(monitor.startCallCount, 1)
+    }
+
+    func testAppStateStartHotkeyMonitorRequiresInputMonitoringBeforeStartingTap() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        var requestCount = 0
+        let appState = AppState(
+            hotkeyMonitor: monitor,
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            inputMonitoringChecker: { false },
+            inputMonitoringPrompter: { requestCount += 1 }
+        )
+
+        await appState.startHotkeyMonitor()
+
+        XCTAssertEqual(monitor.startCallCount, 0)
+        XCTAssertEqual(requestCount, 1)
+        XCTAssertEqual(appState.status, .error)
+        XCTAssertEqual(appState.errorMessage, "Input Monitoring access required — grant permission then click Retry")
+    }
+
+    func testAppStateUpdateShortcutRefreshesHotkeyMonitorBindings() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let appState = AppState(hotkeyMonitor: monitor, chordBindingStore: ChordBindingStore(defaults: defaults))
+        let newChord = try XCTUnwrap(KeyChord(keys: Set([
+            PhysicalKey(keyCode: 54),
+            PhysicalKey(keyCode: 61),
+            PhysicalKey(keyCode: 53)
+        ])))
+
+        appState.updateShortcut(newChord, for: .pushToTalk)
+
+        XCTAssertEqual(appState.pushToTalkChord, newChord)
+        XCTAssertEqual(monitor.updatedBindings[.pushToTalk], newChord)
+    }
+
+    func testAppStateUpdateShortcutRejectsDuplicateBindings() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let appState = AppState(hotkeyMonitor: monitor, chordBindingStore: ChordBindingStore(defaults: defaults))
+        let originalToggleChord = appState.toggleToTalkChord
+
+        appState.updateShortcut(AppState.defaultPushToTalkChord, for: .toggleToTalk)
+
+        XCTAssertEqual(appState.toggleToTalkChord, originalToggleChord)
+        XCTAssertEqual(monitor.updatedBindings[.toggleToTalk], originalToggleChord)
+        XCTAssertEqual(appState.shortcutErrorMessage, "That shortcut is already in use.")
+    }
+
+    func testAppStateLoadsPersistedCleanupBackendSelection() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set("foundationModels", forKey: "cleanupBackend")
+
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        XCTAssertEqual(appState.cleanupBackend, .localModels)
+    }
+
+    func testAppStateUpdateCleanupBackendPersistsAndUpdatesTextCleaner() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.updateCleanupBackend(.localModels)
+
+        XCTAssertEqual(appState.cleanupBackend, .localModels)
+        XCTAssertEqual(
+            defaults.string(forKey: "cleanupBackend"),
+            CleanupBackendOption.localModels.rawValue
+        )
+    }
+
+    func testAppStateDefaultsPostPasteLearningToEnabled() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        XCTAssertTrue(appState.postPasteLearningEnabled)
+        XCTAssertTrue(appState.postPasteLearningCoordinator.learningEnabled)
+    }
+
+    func testAppStateUpdatePostPasteLearningPersistsAndUpdatesCoordinator() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.postPasteLearningEnabled = false
+
+        XCTAssertFalse(appState.postPasteLearningEnabled)
+        XCTAssertFalse(appState.postPasteLearningCoordinator.learningEnabled)
+        XCTAssertEqual(defaults.object(forKey: "postPasteLearningEnabled") as? Bool, false)
+    }
+
+    func testAppStateRelaunchAppUsesConfiguredRelauncher() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let relauncher = FakeAppRelauncher()
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults,
+            appRelauncher: relauncher
+        )
+
+        appState.relaunchApp()
+
+        XCTAssertEqual(relauncher.relaunchCallCount, 1)
+        XCTAssertNil(appState.errorMessage)
+    }
+
+    func testAppStateRelaunchAppSurfacesRelaunchFailures() throws {
+        struct RelaunchError: LocalizedError {
+            var errorDescription: String? { "open failed" }
+        }
+
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let relauncher = FakeAppRelauncher()
+        relauncher.error = RelaunchError()
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults,
+            appRelauncher: relauncher
+        )
+
+        appState.relaunchApp()
+
+        XCTAssertEqual(relauncher.relaunchCallCount, 1)
+        XCTAssertEqual(appState.errorMessage, "Failed to relaunch Ghost Pepper: open failed")
+    }
+
+    func testSettingsWindowHostsSwiftUIViaContentViewController() throws {
+        closeWindows(titled: "Ghost Pepper Settings")
+        defer { closeWindows(titled: "Ghost Pepper Settings") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let controller = SettingsWindowController()
+
+        controller.show(appState: appState)
+
+        let window = try XCTUnwrap(NSApp.windows.first(where: { $0.title == "Ghost Pepper Settings" }))
+        defer { window.close() }
+
+        XCTAssertNotNil(window.contentViewController)
+    }
+
+    func testSettingsWindowControllerCloseButtonOrdersWindowOutWithoutClosing() throws {
+        closeWindows(titled: "Ghost Pepper Settings")
+        defer { closeWindows(titled: "Ghost Pepper Settings") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let controller = SettingsWindowController()
+
+        controller.show(appState: appState)
+        let window = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Ghost Pepper Settings" && $0.isVisible })
+        )
+
+        let shouldClose = window.delegate?.windowShouldClose?(window)
+
+        XCTAssertEqual(shouldClose, false)
+        XCTAssertFalse(window.isVisible)
+
+        controller.show(appState: appState)
+        let reopenedWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Ghost Pepper Settings" && $0.isVisible })
+        )
+
+        XCTAssertTrue(window === reopenedWindow)
+    }
+
+    func testPromptEditorHostsSwiftUIViaContentViewController() throws {
+        closeWindows(titled: "Edit Cleanup Prompt")
+        defer { closeWindows(titled: "Edit Cleanup Prompt") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let controller = PromptEditorController()
+
+        controller.show(appState: appState)
+
+        let window = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Edit Cleanup Prompt" && $0.isVisible })
+        )
+        defer { window.close() }
+
+        XCTAssertNotNil(window.contentViewController)
+    }
+
+    func testPromptEditorControllerReusesExistingWindow() throws {
+        closeWindows(titled: "Edit Cleanup Prompt")
+        defer { closeWindows(titled: "Edit Cleanup Prompt") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let controller = PromptEditorController()
+
+        controller.show(appState: appState)
+        let firstWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Edit Cleanup Prompt" && $0.isVisible })
+        )
+
+        controller.show(appState: appState)
+        let secondWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Edit Cleanup Prompt" && $0.isVisible })
+        )
+        defer { secondWindow.close() }
+
+        XCTAssertTrue(firstWindow === secondWindow)
+    }
+
+    func testPromptEditorControllerDismissKeepsWindowReusable() throws {
+        closeWindows(titled: "Edit Cleanup Prompt")
+        defer { closeWindows(titled: "Edit Cleanup Prompt") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let controller = PromptEditorController()
+
+        controller.show(appState: appState)
+        let firstWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Edit Cleanup Prompt" && $0.isVisible })
+        )
+
+        controller.dismiss()
+        XCTAssertFalse(firstWindow.isVisible)
+
+        controller.show(appState: appState)
+        let secondWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Edit Cleanup Prompt" && $0.isVisible })
+        )
+        defer { secondWindow.close() }
+
+        XCTAssertTrue(firstWindow === secondWindow)
+    }
+
+    func testPromptEditorControllerCloseButtonOrdersWindowOutWithoutClosing() throws {
+        closeWindows(titled: "Edit Cleanup Prompt")
+        defer { closeWindows(titled: "Edit Cleanup Prompt") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let controller = PromptEditorController()
+
+        controller.show(appState: appState)
+        let window = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Edit Cleanup Prompt" && $0.isVisible })
+        )
+
+        let shouldClose = controller.windowShouldClose(window)
+
+        XCTAssertFalse(shouldClose)
+        XCTAssertFalse(window.isVisible)
+    }
+
+    func testPromptEditorControllerDismissResignsFirstResponder() throws {
+        closeWindows(titled: "Edit Cleanup Prompt")
+        defer { closeWindows(titled: "Edit Cleanup Prompt") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let controller = PromptEditorController()
+
+        controller.show(appState: appState)
+        let window = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Edit Cleanup Prompt" && $0.isVisible })
+        )
+        let textView = NSTextView(frame: .zero)
+        window.contentView?.addSubview(textView)
+        XCTAssertTrue(window.makeFirstResponder(textView))
+
+        controller.dismiss()
+
+        XCTAssertFalse(window.firstResponder === textView)
+    }
+
+    func testAppStateShowPromptEditorReusesSingleWindow() throws {
+        closeWindows(titled: "Edit Cleanup Prompt")
+        defer { closeWindows(titled: "Edit Cleanup Prompt") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.showPromptEditor()
+        appState.showPromptEditor()
+
+        let windows = NSApp.windows.filter { $0.title == "Edit Cleanup Prompt" && $0.isVisible }
+        defer { windows.forEach { $0.close() } }
+
+        XCTAssertEqual(windows.count, 1)
+    }
+
+    func testAppStateShowSettingsReusesSingleWindow() throws {
+        closeWindows(titled: "Ghost Pepper Settings")
+        defer { closeWindows(titled: "Ghost Pepper Settings") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.showSettings()
+        appState.showSettings()
+
+        let windows = NSApp.windows.filter { $0.title == "Ghost Pepper Settings" }
+        defer { windows.forEach { $0.close() } }
+
+        XCTAssertEqual(windows.count, 1)
+    }
+
+    func testAppStateShowDebugLogHostsSwiftUIViaContentViewController() throws {
+        closeWindows(titled: "Ghost Pepper Debug Log")
+        defer { closeWindows(titled: "Ghost Pepper Debug Log") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.showDebugLog()
+
+        let window = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Ghost Pepper Debug Log" && $0.isVisible })
+        )
+        defer { window.close() }
+
+        XCTAssertNotNil(window.contentViewController)
+    }
+
+    func testDebugLogWindowControllerCloseButtonOrdersWindowOutWithoutClosing() throws {
+        closeWindows(titled: "Ghost Pepper Debug Log")
+        defer { closeWindows(titled: "Ghost Pepper Debug Log") }
+        let controller = DebugLogWindowController()
+        let debugLogStore = DebugLogStore()
+
+        controller.show(debugLogStore: debugLogStore)
+        let window = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Ghost Pepper Debug Log" && $0.isVisible })
+        )
+
+        let shouldClose = window.delegate?.windowShouldClose?(window)
+
+        XCTAssertEqual(shouldClose, false)
+        XCTAssertFalse(window.isVisible)
+
+        controller.show(debugLogStore: debugLogStore)
+        let reopenedWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Ghost Pepper Debug Log" && $0.isVisible })
+        )
+
+        XCTAssertTrue(window === reopenedWindow)
+    }
+
+    func testAppStateShowDebugLogReusesSingleWindow() throws {
+        closeWindows(titled: "Ghost Pepper Debug Log")
+        defer { closeWindows(titled: "Ghost Pepper Debug Log") }
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.showDebugLog()
+        let firstWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Ghost Pepper Debug Log" && $0.isVisible })
+        )
+        appState.showDebugLog()
+
+        let secondWindow = try XCTUnwrap(
+            NSApp.windows.first(where: { $0.title == "Ghost Pepper Debug Log" && $0.isVisible })
+        )
+        defer { secondWindow.close() }
+
+        XCTAssertTrue(firstWindow === secondWindow)
+    }
+
+    func testAppStateShortcutCaptureSuspendsHotkeyMonitor() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let appState = AppState(
+            hotkeyMonitor: monitor,
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.setShortcutCaptureActive(true)
+        appState.setShortcutCaptureActive(false)
+
+        XCTAssertEqual(monitor.suspendedStates, [true, false])
+    }
+
+    func testRecordingOverlayHostsSwiftUIViaContentViewController() throws {
+        let overlay = RecordingOverlayController()
+        let existingWindowNumbers = Set(NSApp.windows.map(\.windowNumber))
+
+        overlay.show()
+
+        let panel = try XCTUnwrap(
+            NSApp.windows
+                .filter { !existingWindowNumbers.contains($0.windowNumber) }
+                .compactMap { $0 as? NSPanel }
+                .first
+        )
+        defer {
+            overlay.dismiss()
+            panel.close()
+        }
+
+        XCTAssertNotNil(panel.contentViewController)
+    }
+
+    func testAppStateLoadsPersistedCorrectionSettingsIntoStore() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let seededStore = CorrectionStore(defaults: defaults)
+        seededStore.preferredTranscriptionsText = "Ghost Pepper\nJesse"
+        seededStore.commonlyMisheardText = "just see -> Jesse"
+
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        XCTAssertEqual(appState.correctionStore.preferredTranscriptions, ["Ghost Pepper", "Jesse"])
+        XCTAssertEqual(
+            appState.correctionStore.commonlyMisheard,
+            [MisheardReplacement(wrong: "just see", right: "Jesse")]
+        )
+    }
+
+    func testAppStateUsesPreferredTranscriptionsAsOCRCustomWords() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        appState.correctionStore.preferredTranscriptionsText = "Ghost Pepper\nJesse"
+
+        XCTAssertEqual(appState.ocrCustomWords, ["Ghost Pepper", "Jesse"])
+    }
+
+    func testAppStateLoadsLocalCleanupModelsWhenCleanupIsEnabled() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        appState.cleanupEnabled = true
+
+        XCTAssertTrue(appState.shouldLoadLocalCleanupModels)
+    }
+
+    func testAppStateRecordsCleanupDebugSnapshotOnlyWhileDebugViewerIsOpen() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let debugLogStore = DebugLogStore()
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults,
+            debugLogStore: debugLogStore
+        )
+
+        appState.recordCleanupDebugSnapshot(
+            rawTranscription: "raw text",
+            basePrompt: "base prompt",
+            windowContext: OCRContext(windowContents: "window text"),
+            resolvedPrompt: "resolved prompt",
+            cleanedOutput: "cleaned text",
+            attemptedCleanup: true
+        )
+        XCTAssertTrue(debugLogStore.formattedText.isEmpty)
+
+        debugLogStore.beginLiveViewing()
+        appState.recordCleanupDebugSnapshot(
+            rawTranscription: "raw text",
+            basePrompt: "base prompt",
+            windowContext: OCRContext(windowContents: "window text"),
+            resolvedPrompt: "resolved prompt",
+            cleanedOutput: "cleaned text",
+            attemptedCleanup: true
+        )
+        debugLogStore.endLiveViewing()
+
+        let formattedText = debugLogStore.formattedText
+        XCTAssertTrue(formattedText.contains("raw text"))
+        XCTAssertTrue(formattedText.contains("window text"))
+        XCTAssertTrue(formattedText.contains("base prompt"))
+        XCTAssertTrue(formattedText.contains("resolved prompt"))
+        XCTAssertTrue(formattedText.contains("cleaned text"))
+    }
+
+    func testAppStateAppliesDeterministicCorrectionsWhenCleanupModelIsUnavailable() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        correctionStore.commonlyMisheardText = "just see -> Jesse"
+        let cleanupManager = TextCleanupManager(
+            defaults: defaults,
+            fastModelAvailabilityOverride: false,
+            fullModelAvailabilityOverride: false
+        )
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults,
+            textCleanupManager: cleanupManager,
+            correctionStore: correctionStore
+        )
+        appState.cleanupEnabled = true
+
+        let result = await appState.cleanedTranscription("just see approved it")
+
+        XCTAssertEqual(result, "Jesse approved it")
+    }
+
+    private func closeWindows(titled title: String) {
+        NSApp.windows
+            .filter { $0.title == title }
+            .forEach { window in
+                window.delegate = nil
+                window.orderOut(nil)
+                window.close()
+            }
     }
 }

--- a/GhostPepperTests/HotkeyMonitorTests.swift
+++ b/GhostPepperTests/HotkeyMonitorTests.swift
@@ -1,25 +1,567 @@
 import XCTest
+import CoreGraphics
+import IOKit.hidsystem
 @testable import GhostPepper
 
 final class HotkeyMonitorTests: XCTestCase {
-    func testControlOnlyDetection() {
-        let controlOnly: CGEventFlags = .maskControl
-        XCTAssertTrue(HotkeyMonitor.isControlOnly(flags: controlOnly))
+    private let a = PhysicalKey(keyCode: 0)
+    private let rightCommand = PhysicalKey(keyCode: 54)
+    private let rightOption = PhysicalKey(keyCode: 61)
+    private let space = PhysicalKey(keyCode: 49)
+
+    func testPushChordTriggersStartAndStopCallbacks() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+        monitor.onRecordingStop = {
+            events.append("stop")
+        }
+
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[rightOption] = false
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        XCTAssertEqual(events, ["start", "stop"])
     }
 
-    func testControlWithOtherModifierRejected() {
-        let controlCmd: CGEventFlags = [.maskControl, .maskCommand]
-        XCTAssertFalse(HotkeyMonitor.isControlOnly(flags: controlCmd))
+    func testToggleChordTriggersStopOnSecondMatch() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+        monitor.onRecordingStop = {
+            events.append("stop")
+        }
+
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[space] = true
+        monitor.handleInput(.keyDown(space))
+        keyStates[space] = false
+        monitor.handleInput(.keyUp(space))
+        keyStates[rightOption] = false
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[rightCommand] = false
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[space] = true
+        monitor.handleInput(.keyDown(space))
+
+        XCTAssertEqual(events, ["start", "stop"])
     }
 
-    func testNoControlRejected() {
-        let noFlags: CGEventFlags = []
-        XCTAssertFalse(HotkeyMonitor.isControlOnly(flags: noFlags))
+    func testPushChordStartsWhenCurrentKeyStateLagsBehindModifierEvents() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[rightOption] = true
+
+        XCTAssertEqual(events, ["start"])
     }
 
-    func testMinimumHoldDuration() {
-        let monitor = HotkeyMonitor()
-        XCTAssertFalse(monitor.isHoldLongEnough(duration: 0.2))
-        XCTAssertTrue(monitor.isHoldLongEnough(duration: 0.4))
+    func testToggleChordStartsWhenCurrentKeyStateLagsBehindKeyDownEvent() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[rightOption] = true
+        monitor.handleInput(.keyDown(space))
+        keyStates[space] = true
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testMonitorResyncsMissingModifierEdgeFromCurrentKeyState() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false },
+            modifierFlagsProvider: { self.modifierFlags(for: keyStates) }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        keyStates[rightCommand] = true
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testMonitorResyncsToggleChordFromCurrentKeyStateOnKeyDown() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false },
+            modifierFlagsProvider: { self.modifierFlags(for: keyStates) }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        keyStates[rightCommand] = true
+        keyStates[rightOption] = true
+        keyStates[space] = true
+        monitor.handleInput(.keyDown(space))
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testToggleChordStillStartsWhenPolledStateOmitsEarlierModifier() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+
+        keyStates = [rightOption: true]
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        keyStates = [
+            rightOption: true,
+            space: true
+        ]
+        monitor.handleInput(.keyDown(space))
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testToggleChordStillStopsWhenPolledStateOmitsEarlierModifier() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+        monitor.onRecordingStop = {
+            events.append("stop")
+        }
+
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[space] = true
+        monitor.handleInput(.keyDown(space))
+        keyStates[space] = false
+        monitor.handleInput(.keyUp(space))
+        keyStates[rightOption] = false
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[rightCommand] = false
+        monitor.handleInput(.flagsChanged(rightCommand))
+
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+
+        keyStates = [rightOption: true]
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        keyStates = [
+            rightOption: true,
+            space: true
+        ]
+        monitor.handleInput(.keyDown(space))
+
+        XCTAssertEqual(events, ["start", "stop"])
+    }
+
+    func testSuspendedMonitorWaitsForKeysToReleaseBeforeMatchingAgain() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        monitor.setSuspended(true)
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        monitor.setSuspended(false)
+        keyStates[rightOption] = false
+        monitor.handleInput(.flagsChanged(rightOption))
+        keyStates[rightCommand] = false
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testMonitorRecoversAfterShortcutCaptureWhenReleaseEventsWereConsumedElsewhere() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        monitor.setSuspended(true)
+        keyStates[rightCommand] = true
+        keyStates[rightOption] = true
+
+        monitor.setSuspended(false)
+
+        // Shortcut capture consumed the release events, so the hotkey monitor only sees
+        // the next real hotkey attempt after the physical keys are already back up.
+        keyStates[rightCommand] = false
+        keyStates[rightOption] = false
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testMonitorClearsStalePressedKeysWhenStopEventSeesNoPhysicalKeys() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+        monitor.onRecordingStop = {
+            events.append("stop")
+        }
+
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        keyStates[rightOption] = false
+        keyStates[rightCommand] = false
+        monitor.handleInput(.flagsChanged(rightCommand))
+
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[rightOption] = true
+        monitor.handleInput(.flagsChanged(rightOption))
+
+        XCTAssertEqual(events, ["start", "stop", "start"])
+    }
+
+    func testMonitorIgnoresUnboundKeysWithoutLoggingOrTriggeringCallbacks() throws {
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { _ in false },
+            eventProcessor: { work in work() }
+        )
+        var events: [String] = []
+        var logs: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+        monitor.onRecordingStop = {
+            events.append("stop")
+        }
+        monitor.debugLogger = { _, message in
+            logs.append(message)
+        }
+
+        monitor.handleInput(.keyDown(a))
+        monitor.handleInput(.keyUp(a))
+
+        XCTAssertEqual(events, [])
+        XCTAssertEqual(logs, [])
+    }
+
+    func testFlagsChangedSnapshotsDoNotRestartChordFromStaleModifierState() throws {
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { _ in false },
+            eventProcessor: { work in work() }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+        monitor.onRecordingStop = {
+            events.append("stop")
+        }
+
+        monitor.handleEvent(
+            .flagsChanged,
+            event: modifierEvent(
+                key: rightCommand,
+                flagsRawValue: UInt64(NX_COMMANDMASK | NX_DEVICERCMDKEYMASK)
+            )
+        )
+        monitor.handleEvent(
+            .flagsChanged,
+            event: modifierEvent(
+                key: rightOption,
+                flagsRawValue: UInt64(NX_COMMANDMASK | NX_ALTERNATEMASK | NX_DEVICERCMDKEYMASK | NX_DEVICERALTKEYMASK)
+            )
+        )
+
+        // The Right Command release was missed. The next Right Option release arrives after both keys are already up,
+        // so its flags snapshot must clear the stale command state instead of leaving it latched.
+        monitor.handleEvent(
+            .flagsChanged,
+            event: modifierEvent(
+                key: rightOption,
+                flagsRawValue: 0
+            )
+        )
+        monitor.handleEvent(
+            .flagsChanged,
+            event: modifierEvent(
+                key: rightOption,
+                flagsRawValue: UInt64(NX_ALTERNATEMASK | NX_DEVICERALTKEYMASK)
+            )
+        )
+
+        XCTAssertEqual(events, ["start", "stop"])
+    }
+
+    func testFlagsChangedSnapshotStartsChordWhenEarlierModifierEdgeWasMissed() throws {
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { _ in false },
+            eventProcessor: { work in work() }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        // The Right Command press edge was missed, but the next modifier event already reports the
+        // full side-specific modifier snapshot. Matching should still start from that snapshot.
+        monitor.handleEvent(
+            .flagsChanged,
+            event: modifierEvent(
+                key: rightOption,
+                flagsRawValue: UInt64(NX_COMMANDMASK | NX_ALTERNATEMASK | NX_DEVICERCMDKEYMASK | NX_DEVICERALTKEYMASK)
+            )
+        )
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testKeyDownIgnoresNonModifierWithoutActiveModifierPrefix() throws {
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+            ],
+            keyStateProvider: { _ in
+                XCTFail("Non-modifier key handling should not poll global key state when modifiers are inactive.")
+                return false
+            },
+            modifierFlagsProvider: {
+                XCTFail("Non-modifier key handling should not poll modifier state when modifiers are inactive.")
+                return []
+            },
+            eventProcessor: { work in work() }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        monitor.handleEvent(
+            .keyDown,
+            event: modifierEvent(
+                key: space,
+                flagsRawValue: 0
+            )
+        )
+
+        XCTAssertEqual(events, [])
+    }
+
+    func testKeyDownSnapshotStartsChordWhenModifierPrefixIsAlreadyHeld() throws {
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .toggleToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+            ],
+            keyStateProvider: { _ in
+                XCTFail("Real-key matching should rely on the event snapshot instead of polling global key state.")
+                return false
+            },
+            modifierFlagsProvider: {
+                XCTFail("Real-key matching should rely on the event snapshot instead of polling modifier state.")
+                return []
+            },
+            eventProcessor: { work in work() }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        monitor.handleEvent(
+            .keyDown,
+            event: modifierEvent(
+                key: space,
+                flagsRawValue: UInt64(NX_COMMANDMASK | NX_ALTERNATEMASK | NX_DEVICERCMDKEYMASK | NX_DEVICERALTKEYMASK)
+            )
+        )
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testHandleEventDispatchesCallbacksAsynchronously() throws {
+        let queue = DispatchQueue(label: "HotkeyMonitorTests.eventProcessor")
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption])))
+            ],
+            keyStateProvider: { _ in false },
+            eventProcessor: { work in
+                queue.async(execute: work)
+            }
+        )
+        let started = expectation(description: "start callback")
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+            started.fulfill()
+        }
+
+        monitor.handleEvent(
+            .flagsChanged,
+            event: modifierEvent(
+                key: rightOption,
+                flagsRawValue: UInt64(NX_COMMANDMASK | NX_ALTERNATEMASK | NX_DEVICERCMDKEYMASK | NX_DEVICERALTKEYMASK)
+            )
+        )
+
+        XCTAssertEqual(events, [])
+        wait(for: [started], timeout: 1.0)
+        XCTAssertEqual(events, ["start"])
+    }
+
+    private func modifierEvent(key: PhysicalKey, flagsRawValue: UInt64) -> CGEvent {
+        let event = CGEvent(
+            keyboardEventSource: nil,
+            virtualKey: CGKeyCode(key.keyCode),
+            keyDown: true
+        )!
+        event.flags = CGEventFlags(rawValue: flagsRawValue)
+        return event
+    }
+
+    private func modifierFlags(for keyStates: [PhysicalKey: Bool]) -> CGEventFlags {
+        var rawValue: UInt64 = 0
+
+        if keyStates[rightCommand] == true {
+            rawValue |= UInt64(NX_COMMANDMASK | NX_DEVICERCMDKEYMASK)
+        }
+        if keyStates[rightOption] == true {
+            rawValue |= UInt64(NX_ALTERNATEMASK | NX_DEVICERALTKEYMASK)
+        }
+
+        return CGEventFlags(rawValue: rawValue)
     }
 }

--- a/GhostPepperTests/KeyChordTests.swift
+++ b/GhostPepperTests/KeyChordTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import GhostPepper
+
+final class KeyChordTests: XCTestCase {
+    func testPhysicalKeyUsesRawKeyCodesForSideSpecificKeys() {
+        let rightCommand = PhysicalKey(keyCode: 54)
+        let leftCommand = PhysicalKey(keyCode: 55)
+
+        XCTAssertNotEqual(rightCommand, leftCommand)
+        XCTAssertEqual(rightCommand.keyCode, 54)
+        XCTAssertEqual(leftCommand.keyCode, 55)
+    }
+
+    func testKeyChordPreservesSideSpecificModifiers() {
+        let chord = KeyChord(keys: Set([
+            PhysicalKey(keyCode: 54),
+            PhysicalKey(keyCode: 61),
+            PhysicalKey(keyCode: 49)
+        ]))
+
+        XCTAssertEqual(chord?.keys, Set([
+            PhysicalKey(keyCode: 54),
+            PhysicalKey(keyCode: 61),
+            PhysicalKey(keyCode: 49)
+        ]))
+    }
+
+    func testKeyChordRejectsEmptyChord() {
+        XCTAssertNil(KeyChord(keys: []))
+    }
+
+    func testKeyChordDecodingRejectsEmptyChord() {
+        let data = #"{"keys":[]}"#.data(using: .utf8)!
+
+        XCTAssertThrowsError(try JSONDecoder().decode(KeyChord.self, from: data))
+    }
+
+    func testKeyChordDisplayStringUsesReadableKeyNames() throws {
+        let chord = try XCTUnwrap(KeyChord(keys: Set([
+            PhysicalKey(keyCode: 54),
+            PhysicalKey(keyCode: 61),
+            PhysicalKey(keyCode: 49)
+        ])))
+
+        XCTAssertEqual(chord.displayString, "Right Command + Right Option + Space")
+    }
+
+    func testKeyChordShortcutRecorderDisplayStringUsesSymbolsWithSideSuffixes() throws {
+        let chord = try XCTUnwrap(KeyChord(keys: Set([
+            PhysicalKey(keyCode: 54),
+            PhysicalKey(keyCode: 61),
+            PhysicalKey(keyCode: 49)
+        ])))
+
+        XCTAssertEqual(chord.shortcutRecorderDisplayString, "⌘ʳ + ⌥ʳ + Space")
+    }
+}

--- a/GhostPepperTests/MicPreviewControllerTests.swift
+++ b/GhostPepperTests/MicPreviewControllerTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import GhostPepper
+
+private final class SpyMicLevelMonitor: MicLevelMonitoring {
+    var startCallCount = 0
+    var stopCallCount = 0
+    var restartCallCount = 0
+
+    func start() {
+        startCallCount += 1
+    }
+
+    func stop() {
+        stopCallCount += 1
+    }
+
+    func restart() {
+        restartCallCount += 1
+    }
+}
+
+@MainActor
+final class MicPreviewControllerTests: XCTestCase {
+    func testPreviewStartsDisabled() {
+        let controller = MicPreviewController(monitor: SpyMicLevelMonitor())
+
+        XCTAssertFalse(controller.isPreviewing)
+    }
+
+    func testEnablingPreviewStartsMonitorOnce() {
+        let monitor = SpyMicLevelMonitor()
+        let controller = MicPreviewController(monitor: monitor)
+
+        controller.setPreviewing(true)
+        controller.setPreviewing(true)
+
+        XCTAssertTrue(controller.isPreviewing)
+        XCTAssertEqual(monitor.startCallCount, 1)
+        XCTAssertEqual(monitor.stopCallCount, 0)
+    }
+
+    func testDisablingPreviewStopsMonitor() {
+        let monitor = SpyMicLevelMonitor()
+        let controller = MicPreviewController(monitor: monitor)
+
+        controller.setPreviewing(true)
+        controller.setPreviewing(false)
+
+        XCTAssertFalse(controller.isPreviewing)
+        XCTAssertEqual(monitor.startCallCount, 1)
+        XCTAssertEqual(monitor.stopCallCount, 1)
+    }
+
+    func testRestartIfNeededOnlyRestartsWhenPreviewing() {
+        let monitor = SpyMicLevelMonitor()
+        let controller = MicPreviewController(monitor: monitor)
+
+        controller.restartIfNeeded()
+        controller.setPreviewing(true)
+        controller.restartIfNeeded()
+
+        XCTAssertEqual(monitor.restartCallCount, 1)
+    }
+}

--- a/GhostPepperTests/OCRContextTests.swift
+++ b/GhostPepperTests/OCRContextTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+import Vision
+@testable import GhostPepper
+
+private enum TestImageFactory {
+    static func makeCGImage() -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bytesPerPixel = 4
+        let bytesPerRow = bytesPerPixel
+        let bitsPerComponent = 8
+        var pixel: [UInt8] = [255, 255, 255, 255]
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+
+        guard let provider = CGDataProvider(data: NSData(bytes: &pixel, length: pixel.count)) else {
+            fatalError("Failed to create test image provider")
+        }
+
+        guard let image = CGImage(
+            width: 1,
+            height: 1,
+            bitsPerComponent: bitsPerComponent,
+            bitsPerPixel: bytesPerPixel * bitsPerComponent,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        ) else {
+            fatalError("Failed to create test CGImage")
+        }
+
+        return image
+    }
+}
+
+private final class SpyWindowCaptureService: WindowCaptureServing {
+    var captureCallCount = 0
+    var nextImage: CGImage?
+
+    func captureFrontmostWindowImage() async throws -> CGImage? {
+        captureCallCount += 1
+        return nextImage
+    }
+}
+
+final class OCRContextTests: XCTestCase {
+    func testOCRRequestFactoryUsesAccurateRecognitionLevel() {
+        let request = OCRRequestFactory().makeRequest(customWords: [])
+
+        XCTAssertEqual(request.recognitionLevel, .accurate)
+        XCTAssertEqual(request.revision, VNRecognizeTextRequestRevision3)
+    }
+
+    func testOCRRequestFactoryEnablesLanguageCorrection() {
+        let request = OCRRequestFactory().makeRequest(customWords: [])
+
+        XCTAssertTrue(request.usesLanguageCorrection)
+    }
+
+    func testOCRRequestFactoryAcceptsCustomWords() {
+        let request = OCRRequestFactory().makeRequest(customWords: ["Ghost Pepper", "Jesse"])
+
+        XCTAssertEqual(request.customWords, ["Ghost Pepper", "Jesse"])
+    }
+
+    func testCaptureStillAttemptsWindowImageWhenPreflightPermissionIsFalse() async {
+        let captureService = SpyWindowCaptureService()
+        captureService.nextImage = TestImageFactory.makeCGImage()
+        let service = FrontmostWindowOCRService(
+            permissionProvider: { false },
+            windowCaptureService: captureService,
+            recognizeText: { _, _ in
+                "hello from ocr"
+            }
+        )
+
+        let context = await service.captureContext(customWords: [])
+
+        XCTAssertEqual(context?.windowContents, "hello from ocr")
+        XCTAssertEqual(captureService.captureCallCount, 1)
+    }
+
+    func testCaptureLogsFullOCRTextOnlyToSensitiveLogger() async {
+        let captureService = SpyWindowCaptureService()
+        captureService.nextImage = TestImageFactory.makeCGImage()
+        var regularMessages: [String] = []
+        var sensitiveMessages: [String] = []
+        let service = FrontmostWindowOCRService(
+            permissionProvider: { true },
+            windowCaptureService: captureService,
+            recognizeText: { _, _ in
+                "hello from ocr"
+            }
+        )
+        service.debugLogger = { _, message in
+            regularMessages.append(message)
+        }
+        service.sensitiveDebugLogger = { _, message in
+            sensitiveMessages.append(message)
+        }
+
+        _ = await service.captureContext(customWords: [])
+
+        XCTAssertFalse(regularMessages.contains(where: { $0.contains("hello from ocr") }))
+        XCTAssertTrue(sensitiveMessages.contains(where: { $0.contains("hello from ocr") }))
+    }
+}

--- a/GhostPepperTests/PostPasteLearningCoordinatorTests.swift
+++ b/GhostPepperTests/PostPasteLearningCoordinatorTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class PostPasteLearningCoordinatorTests: XCTestCase {
+    func testCoordinatorStartsLearningPassAfterPasteDelay() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        var scheduledDelay: TimeInterval?
+        var scheduledWork: (() -> Void)?
+        var revisitCallCount = 0
+        let coordinator = PostPasteLearningCoordinator(
+            correctionStore: correctionStore,
+            scheduler: { delay, work in
+                scheduledDelay = delay
+                scheduledWork = work
+            },
+            revisit: { _ in
+                revisitCallCount += 1
+                return nil
+            }
+        )
+
+        coordinator.handlePaste(samplePasteSession())
+
+        XCTAssertEqual(scheduledDelay, PostPasteLearningCoordinator.learningDelay)
+        XCTAssertEqual(revisitCallCount, 0)
+
+        scheduledWork?()
+        await waitUntil { revisitCallCount == 1 }
+
+        XCTAssertEqual(revisitCallCount, 1)
+    }
+
+    func testCoordinatorRejectsLargeRewriteDiffs() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        var scheduledWork: (() -> Void)?
+        let coordinator = PostPasteLearningCoordinator(
+            correctionStore: correctionStore,
+            scheduler: { _, work in scheduledWork = work },
+            revisit: { _ in
+                PostPasteLearningObservation(
+                    recognizedText: "This sentence was rewritten into something unrelated",
+                    confidence: 0.99
+                )
+            }
+        )
+
+        coordinator.handlePaste(samplePasteSession())
+        scheduledWork?()
+        await Task.yield()
+
+        XCTAssertTrue(correctionStore.commonlyMisheard.isEmpty)
+    }
+
+    func testCoordinatorStoresHighConfidenceNarrowReplacement() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        var scheduledWork: (() -> Void)?
+        let coordinator = PostPasteLearningCoordinator(
+            correctionStore: correctionStore,
+            scheduler: { _, work in scheduledWork = work },
+            revisit: { _ in
+                PostPasteLearningObservation(
+                    recognizedText: "Jesse approved it",
+                    confidence: 0.99
+                )
+            }
+        )
+
+        coordinator.handlePaste(samplePasteSession())
+        scheduledWork?()
+        await waitUntil {
+            correctionStore.commonlyMisheard == [MisheardReplacement(wrong: "just see", right: "Jesse")]
+        }
+
+        XCTAssertEqual(
+            correctionStore.commonlyMisheard,
+            [MisheardReplacement(wrong: "just see", right: "Jesse")]
+        )
+    }
+
+    func testCoordinatorUsesInjectedSchedulerInsteadOfRealSleep() {
+        let correctionStore = CorrectionStore(defaults: UserDefaults(suiteName: #function)!)
+        var scheduledDelay: TimeInterval?
+        var scheduledWork: (() -> Void)?
+        let coordinator = PostPasteLearningCoordinator(
+            correctionStore: correctionStore,
+            scheduler: { delay, work in
+                scheduledDelay = delay
+                scheduledWork = work
+            },
+            revisit: { _ in
+                XCTFail("Revisit should not run until the test triggers the scheduled work")
+                return nil
+            }
+        )
+
+        coordinator.handlePaste(samplePasteSession())
+
+        XCTAssertEqual(scheduledDelay, PostPasteLearningCoordinator.learningDelay)
+        XCTAssertNotNil(scheduledWork)
+    }
+
+    func testCoordinatorDoesNotScheduleWhenLearningIsDisabled() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        var scheduledWork: (() -> Void)?
+        let coordinator = PostPasteLearningCoordinator(
+            correctionStore: correctionStore,
+            learningEnabled: false,
+            scheduler: { _, work in
+                scheduledWork = work
+            },
+            revisit: { _ in
+                XCTFail("Disabled learning should not trigger OCR revisit")
+                return nil
+            }
+        )
+
+        coordinator.handlePaste(samplePasteSession())
+
+        XCTAssertNil(scheduledWork)
+        XCTAssertTrue(correctionStore.commonlyMisheard.isEmpty)
+    }
+
+    func testCoordinatorRejectsLowConfidenceObservation() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        var scheduledWork: (() -> Void)?
+        let coordinator = PostPasteLearningCoordinator(
+            correctionStore: correctionStore,
+            scheduler: { _, work in scheduledWork = work },
+            revisit: { _ in
+                PostPasteLearningObservation(
+                    recognizedText: "Jesse approved it",
+                    confidence: 0.6
+                )
+            }
+        )
+
+        coordinator.handlePaste(samplePasteSession())
+        scheduledWork?()
+        await Task.yield()
+
+        XCTAssertTrue(correctionStore.commonlyMisheard.isEmpty)
+    }
+
+    func testCoordinatorLogsScheduledAndLearnedCorrection() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        var scheduledWork: (() -> Void)?
+        var debugMessages: [String] = []
+        let coordinator = PostPasteLearningCoordinator(
+            correctionStore: correctionStore,
+            scheduler: { _, work in scheduledWork = work },
+            revisit: { _ in
+                PostPasteLearningObservation(
+                    recognizedText: "Jesse approved it",
+                    confidence: 0.99
+                )
+            }
+        )
+        coordinator.debugLogger = { _, message in
+            debugMessages.append(message)
+        }
+
+        coordinator.handlePaste(samplePasteSession())
+        scheduledWork?()
+        await waitUntil {
+            correctionStore.commonlyMisheard == [MisheardReplacement(wrong: "just see", right: "Jesse")]
+        }
+
+        XCTAssertTrue(debugMessages.contains(where: { $0.contains("Scheduled post-paste learning revisit") }))
+        XCTAssertTrue(debugMessages.contains(where: { $0.contains("Post-paste learning learned replacement: just see -> Jesse") }))
+    }
+
+    func testCoordinatorLogsWhyLearningSkipped() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        var scheduledWork: (() -> Void)?
+        var debugMessages: [String] = []
+        let coordinator = PostPasteLearningCoordinator(
+            correctionStore: correctionStore,
+            scheduler: { _, work in scheduledWork = work },
+            revisit: { _ in
+                PostPasteLearningObservation(
+                    recognizedText: "Jesse approved it",
+                    confidence: 0.6
+                )
+            }
+        )
+        coordinator.debugLogger = { _, message in
+            debugMessages.append(message)
+        }
+
+        coordinator.handlePaste(samplePasteSession())
+        scheduledWork?()
+        await Task.yield()
+
+        XCTAssertTrue(debugMessages.contains(where: { $0.contains("Post-paste learning skipped because OCR confidence") }))
+    }
+
+    private func samplePasteSession() -> PasteSession {
+        PasteSession(
+            pastedText: "just see approved it",
+            pastedAt: Date(timeIntervalSince1970: 1_742_751_200),
+            frontmostAppBundleIdentifier: "com.example.app",
+            frontmostWindowID: 42,
+            frontmostWindowFrame: CGRect(x: 10, y: 20, width: 800, height: 600),
+            focusedElementFrame: CGRect(x: 20, y: 40, width: 300, height: 120)
+        )
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 0.5,
+        condition: @escaping @Sendable () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+}

--- a/GhostPepperTests/ScreenRecordingPermissionControllerTests.swift
+++ b/GhostPepperTests/ScreenRecordingPermissionControllerTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class ScreenRecordingPermissionControllerTests: XCTestCase {
+    func testControllerStartsGrantedWhenPermissionAlreadyAvailable() {
+        let controller = ScreenRecordingPermissionController(
+            hasPermission: { true }
+        )
+
+        XCTAssertTrue(controller.isGranted)
+    }
+
+    func testControllerStartsDeniedWhenPermissionMissing() {
+        let controller = ScreenRecordingPermissionController(
+            hasPermission: { false }
+        )
+
+        XCTAssertFalse(controller.isGranted)
+    }
+
+    func testRefreshUpdatesWhenPermissionIsGrantedInSystemSettings() {
+        var hasPermission = false
+        let controller = ScreenRecordingPermissionController(
+            hasPermission: { hasPermission }
+        )
+
+        XCTAssertFalse(controller.isGranted)
+
+        hasPermission = true
+        controller.refresh()
+
+        XCTAssertTrue(controller.isGranted)
+    }
+
+    func testRefreshKeepsControllerDeniedWhenPermissionRemainsMissing() {
+        let controller = ScreenRecordingPermissionController(
+            hasPermission: { false }
+        )
+
+        controller.refresh()
+
+        XCTAssertFalse(controller.isGranted)
+    }
+
+    func testRequestAccessRequestsPermissionAndRefreshesGrantedState() {
+        var hasPermission = false
+        var requestCount = 0
+        let controller = ScreenRecordingPermissionController(
+            hasPermission: { hasPermission },
+            requestPermission: {
+                requestCount += 1
+                hasPermission = true
+            }
+        )
+
+        XCTAssertFalse(controller.isGranted)
+
+        controller.requestAccess()
+
+        XCTAssertEqual(requestCount, 1)
+        XCTAssertTrue(controller.isGranted)
+    }
+
+    func testRequestAccessLeavesControllerDeniedWhenPermissionRemainsMissing() {
+        var requestCount = 0
+        let controller = ScreenRecordingPermissionController(
+            hasPermission: { false },
+            requestPermission: {
+                requestCount += 1
+            }
+        )
+
+        controller.requestAccess()
+
+        XCTAssertEqual(requestCount, 1)
+        XCTAssertFalse(controller.isGranted)
+    }
+}

--- a/GhostPepperTests/ShortcutCaptureStateTests.swift
+++ b/GhostPepperTests/ShortcutCaptureStateTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import GhostPepper
+
+final class ShortcutCaptureStateTests: XCTestCase {
+    private let rightCommand = PhysicalKey(keyCode: 54)
+    private let rightOption = PhysicalKey(keyCode: 61)
+    private let space = PhysicalKey(keyCode: 49)
+
+    func testCaptureStateCommitsChordAfterReleasingPrefixModifiers() throws {
+        var state = ShortcutCaptureState()
+
+        XCTAssertNil(state.handle(.flagsChanged(rightCommand)))
+        XCTAssertNil(state.handle(.flagsChanged(rightOption)))
+        XCTAssertNil(state.handle(.keyDown(space)))
+        XCTAssertNil(state.handle(.keyUp(space)))
+        XCTAssertNil(state.handle(.flagsChanged(rightOption)))
+        let chord = try XCTUnwrap(state.handle(.flagsChanged(rightCommand)))
+
+        XCTAssertEqual(
+            chord,
+            try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption, space])))
+        )
+        XCTAssertTrue(state.pressedKeys.isEmpty)
+        XCTAssertTrue(state.capturedKeys.isEmpty)
+    }
+}

--- a/GhostPepperTests/TextCleanerTests.swift
+++ b/GhostPepperTests/TextCleanerTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import GhostPepper
+
+private final class SpyCleanupBackend: CleanupBackend {
+    var cleanedInputs: [(text: String, prompt: String)] = []
+    var nextResult: Result<String, Error>
+
+    init(nextResult: Result<String, Error>) {
+        self.nextResult = nextResult
+    }
+
+    func clean(text: String, prompt: String) async throws -> String {
+        cleanedInputs.append((text: text, prompt: prompt))
+        return try nextResult.get()
+    }
+}
+
+@MainActor
+final class TextCleanerTests: XCTestCase {
+    func testPreferredTranscriptionsPreserveConfiguredPhrase() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        correctionStore.preferredTranscriptionsText = "Ghost Pepper"
+        let localBackend = SpyCleanupBackend(nextResult: .success("ghost pepper is ready"))
+        let cleaner = TextCleaner(
+            localBackend: localBackend,
+            correctionStore: correctionStore
+        )
+
+        let result = await cleaner.clean(text: "Ghost Pepper is ready", prompt: "unused prompt")
+
+        XCTAssertEqual(result, "Ghost Pepper is ready")
+        XCTAssertEqual(localBackend.cleanedInputs.map(\.text), ["Ghost Pepper is ready"])
+    }
+
+    func testCommonlyMisheardReplacementAppliesBeforeCleanup() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        correctionStore.commonlyMisheardText = "chat gbt -> ChatGPT"
+        let localBackend = SpyCleanupBackend(nextResult: .success("ChatGPT fixes text"))
+        let cleaner = TextCleaner(
+            localBackend: localBackend,
+            correctionStore: correctionStore
+        )
+
+        let result = await cleaner.clean(text: "chat gbt fixes text", prompt: "unused prompt")
+
+        XCTAssertEqual(result, "ChatGPT fixes text")
+        XCTAssertEqual(localBackend.cleanedInputs.map(\.text), ["ChatGPT fixes text"])
+    }
+
+    func testCleanerFallsBackToCorrectedRawTextWhenBackendFails() async {
+        let localBackend = SpyCleanupBackend(nextResult: .failure(CleanupBackendError.unavailable))
+        let cleaner = TextCleaner(
+            localBackend: localBackend
+        )
+        let text = "Keep this exactly as spoken."
+
+        let result = await cleaner.clean(text: text, prompt: "unused prompt")
+
+        XCTAssertEqual(result, text)
+        XCTAssertEqual(localBackend.cleanedInputs.map(\.text), [text])
+    }
+
+    func testDeterministicCorrectionsStillApplyWhenNoCleanupBackendIsAvailable() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        correctionStore.commonlyMisheardText = "just see -> Jesse"
+        let localBackend = SpyCleanupBackend(nextResult: .failure(CleanupBackendError.unavailable))
+        let cleaner = TextCleaner(
+            localBackend: localBackend,
+            correctionStore: correctionStore
+        )
+
+        let result = await cleaner.clean(text: "just see approved it", prompt: "unused prompt")
+
+        XCTAssertEqual(result, "Jesse approved it")
+    }
+
+    func testPreferredTranscriptionsRestoreSpacingAfterCleanupMutatesPhrase() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        correctionStore.preferredTranscriptionsText = "Ghost Pepper"
+        let localBackend = SpyCleanupBackend(nextResult: .success("ghost-pepper is ready"))
+        let cleaner = TextCleaner(
+            localBackend: localBackend,
+            correctionStore: correctionStore
+        )
+
+        let result = await cleaner.clean(text: "Ghost Pepper is ready", prompt: "unused prompt")
+
+        XCTAssertEqual(result, "Ghost Pepper is ready")
+    }
+
+    func testCommonlyMisheardReplacementTreatsSpecialCharactersLiterally() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        correctionStore.commonlyMisheardText = "environment -> $HOME C:\\\\temp"
+        let localBackend = SpyCleanupBackend(nextResult: .failure(CleanupBackendError.unavailable))
+        let cleaner = TextCleaner(
+            localBackend: localBackend,
+            correctionStore: correctionStore
+        )
+
+        let result = await cleaner.clean(text: "environment", prompt: "unused prompt")
+
+        XCTAssertEqual(result, #"$HOME C:\\temp"#)
+    }
+
+    func testCleanerStripsThinkBlocksFromCleanupOutput() async {
+        let localBackend = SpyCleanupBackend(
+            nextResult: .success(
+                """
+                <think>
+                internal reasoning
+                </think>
+
+                Final cleaned text
+                """
+            )
+        )
+        let cleaner = TextCleaner(
+            localBackend: localBackend
+        )
+
+        let result = await cleaner.clean(text: "raw text", prompt: "unused prompt")
+
+        XCTAssertEqual(result, "Final cleaned text")
+    }
+
+    func testCleanerLogsPromptInputAndCorrectionStagesToSensitiveLogger() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let correctionStore = CorrectionStore(defaults: defaults)
+        correctionStore.commonlyMisheardText = "chat gbt -> ChatGPT"
+        correctionStore.preferredTranscriptionsText = "Ghost Pepper"
+        let localBackend = SpyCleanupBackend(nextResult: .success("ghost-pepper is ready"))
+        let cleaner = TextCleaner(
+            localBackend: localBackend,
+            correctionStore: correctionStore
+        )
+        var sensitiveMessages: [String] = []
+        cleaner.sensitiveDebugLogger = { _, message in
+            sensitiveMessages.append(message)
+        }
+
+        let result = await cleaner.clean(
+            text: "chat gbt is ready",
+            prompt: "Use OCR context if present."
+        )
+
+        XCTAssertEqual(result, "Ghost Pepper is ready")
+        XCTAssertTrue(sensitiveMessages.contains(where: { $0.contains("Pre-cleanup corrections") }))
+        XCTAssertTrue(sensitiveMessages.contains(where: { $0.contains("Cleanup prompt") }))
+        XCTAssertTrue(sensitiveMessages.contains(where: { $0.contains("Cleanup LLM input") }))
+        XCTAssertTrue(sensitiveMessages.contains(where: { $0.contains("Cleanup LLM raw output") }))
+        XCTAssertTrue(sensitiveMessages.contains(where: { $0.contains("Post-cleanup corrections") }))
+    }
+}

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class TextCleanupManagerTests: XCTestCase {
+    func testAutomaticPolicyPrefersFastForShortInput() {
+        let manager = TextCleanupManager(
+            localModelPolicy: .automatic,
+            fastModelAvailabilityOverride: true,
+            fullModelAvailabilityOverride: true
+        )
+
+        XCTAssertEqual(
+            manager.selectedModelKind(wordCount: 4, isQuestion: false),
+            .fast
+        )
+    }
+
+    func testFastOnlyPolicyAlwaysReturnsFastWhenReady() {
+        let manager = TextCleanupManager(
+            localModelPolicy: .fastOnly,
+            fastModelAvailabilityOverride: true,
+            fullModelAvailabilityOverride: true
+        )
+
+        XCTAssertEqual(
+            manager.selectedModelKind(wordCount: 40, isQuestion: true),
+            .fast
+        )
+    }
+
+    func testFullOnlyPolicyAlwaysReturnsFullWhenReady() {
+        let manager = TextCleanupManager(
+            localModelPolicy: .fullOnly,
+            fastModelAvailabilityOverride: true,
+            fullModelAvailabilityOverride: true
+        )
+
+        XCTAssertEqual(
+            manager.selectedModelKind(wordCount: 4, isQuestion: false),
+            .full
+        )
+    }
+
+    func testQuestionSelectionStillFlowsThroughManagerPolicy() {
+        let manager = TextCleanupManager(
+            localModelPolicy: .fastOnly,
+            fastModelAvailabilityOverride: true,
+            fullModelAvailabilityOverride: true
+        )
+
+        XCTAssertEqual(
+            manager.selectedModelKind(wordCount: 3, isQuestion: true),
+            .fast
+        )
+    }
+
+    func testAutomaticPolicyTreatsFastModelAsUsableWhenFullModelIsUnavailable() {
+        let manager = TextCleanupManager(
+            localModelPolicy: .automatic,
+            fastModelAvailabilityOverride: true,
+            fullModelAvailabilityOverride: false
+        )
+
+        XCTAssertTrue(manager.hasUsableModelForCurrentPolicy)
+    }
+
+    func testFullOnlyPolicyRequiresFullModelToBeUsable() {
+        let manager = TextCleanupManager(
+            localModelPolicy: .fullOnly,
+            fastModelAvailabilityOverride: true,
+            fullModelAvailabilityOverride: false
+        )
+
+        XCTAssertFalse(manager.hasUsableModelForCurrentPolicy)
+    }
+}

--- a/docs/superpowers/plans/2026-03-23-transcription-stack.md
+++ b/docs/superpowers/plans/2026-03-23-transcription-stack.md
@@ -1,0 +1,661 @@
+# Transcription Stack Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build configurable recording chords, cleanup backend/model selection, OCR-informed cleanup, and conservative correction learning as a stacked series of feature branches.
+
+**Architecture:** Keep the current app structure, but add four durable seams: chord bindings, cleanup backend selection, OCR context collection, and deterministic corrections/learning. Each branch should ship working software on its own and become the base for the next branch.
+
+**Tech Stack:** Swift, SwiftUI, AppKit, CoreGraphics event taps, Accessibility APIs, Vision OCR, WhisperKit, LLM.swift, optional FoundationModels, XCTest
+
+---
+
+## File Map
+
+### Project Generation Rule
+
+- This repo uses `project.yml` with XcodeGen.
+- After any task that creates, deletes, or renames Swift files, run `xcodegen generate` before the next `xcodebuild` command so the new files are included in the project.
+
+### Existing Files To Modify
+
+- `GhostPepper/AppState.swift`
+  Wire new chord actions, cleanup pipeline, OCR context, and post-paste learning into the existing app flow.
+- `GhostPepper/Input/HotkeyMonitor.swift`
+  Convert from Control-only logic into a wrapper around the new chord engine, or replace its internals while preserving the app-facing callback shape.
+- `GhostPepper/UI/SettingsWindow.swift`
+  Add `Shortcuts`, `Cleanup`, `Context`, and `Corrections` sections.
+- `GhostPepper/UI/OnboardingWindow.swift`
+  Keep onboarding minimal while pointing advanced users to settings.
+- `GhostPepper/Cleanup/TextCleanupManager.swift`
+  Move from implicit local-model behavior toward explicit backend/model policy state.
+- `GhostPepper/Cleanup/TextCleaner.swift`
+  Stop owning all cleanup decisions directly; call the deterministic correction layer, optional OCR context provider, and selected cleanup backend.
+- `GhostPepper/PermissionChecker.swift`
+  Add Screen Recording status/open-settings helpers.
+- `GhostPepper/Input/TextPaster.swift`
+  Expose enough paste metadata for the delayed learning branch.
+- `.gitignore`
+  Keep `docs/superpowers/specs` and `docs/superpowers/plans` tracked.
+
+### New Input Files
+
+- `GhostPepper/Input/PhysicalKey.swift`
+- `GhostPepper/Input/KeyChord.swift`
+- `GhostPepper/Input/ChordAction.swift`
+- `GhostPepper/Input/ChordBindingStore.swift`
+- `GhostPepper/Input/ChordEngine.swift`
+- `GhostPepper/Input/PasteSession.swift`
+- `GhostPepper/UI/ShortcutRecorderView.swift`
+
+### New Cleanup Files
+
+- `GhostPepper/Cleanup/CleanupBackend.swift`
+- `GhostPepper/Cleanup/LocalLLMCleanupBackend.swift`
+- `GhostPepper/Cleanup/FoundationModelsCleanupBackend.swift`
+- `GhostPepper/Cleanup/FoundationModelAvailabilityProvider.swift`
+- `GhostPepper/Cleanup/CleanupSettings.swift`
+- `GhostPepper/Cleanup/CleanupPromptBuilder.swift`
+- `GhostPepper/Cleanup/CorrectionStore.swift`
+- `GhostPepper/Cleanup/DeterministicCorrectionEngine.swift`
+- `GhostPepper/Cleanup/PostPasteLearningCoordinator.swift`
+
+### New OCR/Context Files
+
+- `GhostPepper/Context/OCRContext.swift`
+- `GhostPepper/Context/OCRRequestFactory.swift`
+- `GhostPepper/Context/WindowCaptureService.swift`
+- `GhostPepper/Context/FrontmostWindowOCRService.swift`
+- `GhostPepper/Context/FocusedElementLocator.swift`
+
+### New Test Files
+
+- `GhostPepperTests/KeyChordTests.swift`
+- `GhostPepperTests/ChordEngineTests.swift`
+- `GhostPepperTests/ChordBindingStoreTests.swift`
+- `GhostPepperTests/TextCleanupManagerTests.swift`
+- `GhostPepperTests/TextCleanerTests.swift`
+- `GhostPepperTests/CleanupPromptBuilderTests.swift`
+- `GhostPepperTests/CleanupBackendTests.swift`
+- `GhostPepperTests/OCRContextTests.swift`
+- `GhostPepperTests/CorrectionStoreTests.swift`
+- `GhostPepperTests/PostPasteLearningCoordinatorTests.swift`
+
+## Chunk 1: `codex/chord-actions`
+
+### Task 1: Add the chord domain model and persistence
+
+**Files:**
+- Create: `GhostPepper/Input/PhysicalKey.swift`
+- Create: `GhostPepper/Input/KeyChord.swift`
+- Create: `GhostPepper/Input/ChordAction.swift`
+- Create: `GhostPepper/Input/ChordBindingStore.swift`
+- Test: `GhostPepperTests/KeyChordTests.swift`
+- Test: `GhostPepperTests/ChordBindingStoreTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testPhysicalKeyUsesRawKeyCodesForSideSpecificKeys()
+func testKeyChordPreservesSideSpecificModifiers()
+func testKeyChordRejectsEmptyChord()
+func testBindingStorePersistsPushAndToggleChords()
+func testBindingStoreRejectsDuplicateBindings()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/KeyChordTests -only-testing:GhostPepperTests/ChordBindingStoreTests`
+Expected: FAIL because the new types do not exist yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```swift
+enum ChordAction: String, Codable {
+    case pushToTalk
+    case toggleToTalk
+}
+
+struct PhysicalKey: Codable, Hashable {
+    let keyCode: UInt16
+}
+
+struct KeyChord: Codable, Equatable {
+    let keys: Set<PhysicalKey>
+}
+```
+
+Implement `PhysicalKey` as a raw key-code wrapper so side-specific modifiers are encoded by their distinct hardware key codes, non-modifier keys like Space use the same type, and Globe can be recorded if it surfaces as a key code on the running hardware. Implement `ChordBindingStore` with exactly one binding per action, conflict validation, and `AppStorage`/`UserDefaults` persistence.
+
+- [ ] **Step 4: Run the targeted tests to verify they pass**
+
+Run the same command from Step 2.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Input/PhysicalKey.swift GhostPepper/Input/KeyChord.swift GhostPepper/Input/ChordAction.swift GhostPepper/Input/ChordBindingStore.swift GhostPepperTests/KeyChordTests.swift GhostPepperTests/ChordBindingStoreTests.swift
+git commit -m "feat: add chord bindings"
+```
+
+### Task 2: Replace Control-only matching with a chord engine
+
+**Files:**
+- Create: `GhostPepper/Input/ChordEngine.swift`
+- Modify: `GhostPepper/Input/HotkeyMonitor.swift`
+- Modify: `GhostPepperTests/HotkeyMonitorTests.swift`
+- Test: `GhostPepperTests/ChordEngineTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testPrefixChordDoesNotFireEarly()
+func testPushToTalkStartsImmediatelyWhenExactChordMatches()
+func testToggleToTalkTogglesOnSecondMatch()
+func testPushToTalkStopsWhenAnyRequiredKeyReleases()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/ChordEngineTests -only-testing:GhostPepperTests/HotkeyMonitorTests`
+Expected: FAIL because prefix-aware chord matching does not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```swift
+enum ChordMatchResult {
+    case none
+    case prefix
+    case exact(ChordAction)
+}
+```
+
+Update `HotkeyMonitor` to observe `.flagsChanged`, `.keyDown`, and `.keyUp`, convert them into a small synthetic input event type, and delegate matching to `ChordEngine` instead of using `isControlOnly`. Keep `ChordEngine` testable as a pure reducer over synthetic key events so `HotkeyMonitorTests` do not depend on real Accessibility-backed taps. As part of this task, remove the existing 0.3-second hold timer path (`minimumHoldDuration`, `holdTimer`, `startHoldTimer`, `cancelHoldTimer`) and replace it with immediate exact-match start plus key-release stop semantics for both modifier and non-modifier keys.
+
+- [ ] **Step 4: Run the targeted and full test suites**
+
+Run targeted command from Step 2, then:
+`xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Input/ChordEngine.swift GhostPepper/Input/HotkeyMonitor.swift GhostPepperTests/ChordEngineTests.swift GhostPepperTests/HotkeyMonitorTests.swift
+git commit -m "feat: add chord engine"
+```
+
+### Task 3: Add settings/onboarding support for push and toggle chords
+
+**Files:**
+- Create: `GhostPepper/UI/ShortcutRecorderView.swift`
+- Modify: `GhostPepper/UI/SettingsWindow.swift`
+- Modify: `GhostPepper/UI/OnboardingWindow.swift`
+- Modify: `GhostPepper/AppState.swift`
+- Test: `GhostPepperTests/GhostPepperTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add app-state-level tests that assert default bindings are loaded and both actions are wired into recording behavior.
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/GhostPepperTests`
+Expected: FAIL on missing shortcut defaults or missing recorder wiring.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add a `Shortcuts` settings section, keep onboarding focused on the default behavior, and wire `AppState` to separate push/toggle callbacks without changing the rest of the transcription flow yet.
+
+- [ ] **Step 4: Run the full test suite and build**
+
+Run:
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Debug -derivedDataPath build/derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
+Expected: PASS / BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/UI/ShortcutRecorderView.swift GhostPepper/UI/SettingsWindow.swift GhostPepper/UI/OnboardingWindow.swift GhostPepper/AppState.swift GhostPepperTests/GhostPepperTests.swift
+git commit -m "feat: add shortcut settings"
+```
+
+## Chunk 2: `codex/cleanup-model-picker`
+
+### Task 4: Add explicit cleanup settings and local model policy
+
+**Files:**
+- Create: `GhostPepper/Cleanup/CleanupSettings.swift`
+- Modify: `GhostPepper/Cleanup/TextCleanupManager.swift`
+- Test: `GhostPepperTests/TextCleanerTests.swift`
+- Test: `GhostPepperTests/TextCleanupManagerTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testAutomaticPolicyPrefersFastForShortInput()
+func testFastOnlyPolicyAlwaysReturnsFastWhenReady()
+func testFullOnlyPolicyAlwaysReturnsFullWhenReady()
+func testQuestionSelectionStillFlowsThroughManagerPolicy()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/TextCleanupManagerTests`
+Expected: FAIL because explicit policy types do not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add a persisted local policy enum and replace `model(for:)` with a manager-owned selection API that takes both `wordCount` and `isQuestion`, so `TextCleaner` no longer needs to bypass manager policy when it sees a question or long input. Make the manager testable with injected fake model handles or a tiny model-provider seam so the tests do not require real GGUF downloads.
+
+- [ ] **Step 4: Run targeted and full tests**
+
+Run targeted command from Step 2, then:
+`xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Cleanup/CleanupSettings.swift GhostPepper/Cleanup/TextCleanupManager.swift GhostPepperTests/TextCleanupManagerTests.swift GhostPepperTests/TextCleanerTests.swift
+git commit -m "feat: add cleanup model policy"
+```
+
+### Task 5: Expose cleanup model policy in settings
+
+**Files:**
+- Modify: `GhostPepper/UI/SettingsWindow.swift`
+- Modify: `GhostPepper/AppState.swift`
+- Modify: `GhostPepper/Cleanup/TextCleaner.swift`
+- Test: `GhostPepperTests/TextCleanerTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Add `TextCleaner`-level tests that verify the selected manager policy is consulted when cleanup runs, including question input and longer text.
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/TextCleanerTests`
+Expected: FAIL because `TextCleaner.clean` still bypasses the selected policy.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add a model picker under the `Cleanup` section and update `TextCleaner.clean` to delegate all local-model selection back to `TextCleanupManager`, including question input.
+
+- [ ] **Step 4: Run the full test suite and build**
+
+Run:
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Debug -derivedDataPath build/derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
+Expected: PASS / BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/UI/SettingsWindow.swift GhostPepper/AppState.swift GhostPepper/Cleanup/TextCleaner.swift
+git commit -m "feat: add cleanup model picker"
+```
+
+## Chunk 3: `codex/foundation-model-cleanup`
+
+### Task 6: Introduce a pluggable cleanup backend layer
+
+**Files:**
+- Create: `GhostPepper/Cleanup/CleanupBackend.swift`
+- Create: `GhostPepper/Cleanup/LocalLLMCleanupBackend.swift`
+- Modify: `GhostPepper/Cleanup/TextCleaner.swift`
+- Modify: `GhostPepper/Cleanup/TextCleanupManager.swift`
+- Test: `GhostPepperTests/CleanupBackendTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testLocalBackendUsesSelectedLocalPolicy()
+func testCleanerFallsBackToCorrectedRawTextWhenBackendFails()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/CleanupBackendTests`
+Expected: FAIL because the backend abstraction does not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```swift
+protocol CleanupBackend {
+    func clean(text: String, prompt: String) async throws -> String
+}
+```
+
+Move the current `LLM.swift` cleanup behavior behind `LocalLLMCleanupBackend`, make failure explicit with `throws`, and have `TextCleaner` catch backend failure so it can fall back to the deterministic corrected text. Add an injected backend/model-provider seam so these tests can run against fakes instead of real model downloads.
+
+- [ ] **Step 4: Run targeted and full tests**
+
+Run targeted command from Step 2, then:
+`xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Cleanup/CleanupBackend.swift GhostPepper/Cleanup/LocalLLMCleanupBackend.swift GhostPepper/Cleanup/TextCleaner.swift GhostPepper/Cleanup/TextCleanupManager.swift GhostPepperTests/CleanupBackendTests.swift
+git commit -m "refactor: add cleanup backend abstraction"
+```
+
+### Task 7: Add the optional Foundation Models backend
+
+**Files:**
+- Create: `GhostPepper/Cleanup/FoundationModelsCleanupBackend.swift`
+- Create: `GhostPepper/Cleanup/FoundationModelAvailabilityProvider.swift`
+- Modify: `GhostPepper/Cleanup/CleanupSettings.swift`
+- Modify: `GhostPepper/UI/SettingsWindow.swift`
+- Modify: `GhostPepper/AppState.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testFoundationBackendUnavailableFallsBackToLocal()
+func testFoundationBackendAvailabilityReasonIsExposed()
+func testFoundationAvailabilityCanBeStubbedInTests()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/CleanupBackendTests`
+Expected: FAIL because there is no Foundation Models backend or fallback behavior.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Guard Foundation Models code with `if #available(macOS 26.0, *)` and `SystemLanguageModel` availability checks so the app still compiles and runs on macOS 14.0+. Put all direct Foundation Models availability reads behind a small injectable provider protocol so the macOS 14-targeted tests can stub available/unavailable states and reasons deterministically, and use a backend factory/provider seam so fallback behavior can be tested without invoking the real system model.
+
+- [ ] **Step 4: Run the full test suite and build**
+
+Run:
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Debug -derivedDataPath build/derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
+Expected: PASS / BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Cleanup/FoundationModelsCleanupBackend.swift GhostPepper/Cleanup/FoundationModelAvailabilityProvider.swift GhostPepper/Cleanup/CleanupSettings.swift GhostPepper/UI/SettingsWindow.swift GhostPepper/AppState.swift GhostPepperTests/CleanupBackendTests.swift
+git commit -m "feat: add foundation models cleanup backend"
+```
+
+## Chunk 4: `codex/ocr-context`
+
+Reference implementation notes:
+
+- Use the local ignored reference checkout at `inspo/winby` during implementation.
+- Start with:
+  - `inspo/winby/Sources/Winby/AppConfig.swift`
+  - `inspo/winby/Sources/Winby/WindowManager+Screenshots.swift`
+  - `inspo/winby/Sources/Winby/WindowManager+ContentSearch.swift`
+  - `inspo/winby/docs/screenshot-capture.md`
+- Relevant APIs already exercised there:
+  - `CGPreflightScreenCaptureAccess()`
+  - Screen Recording settings URL
+  - `SCShareableContent`, `SCContentFilter`, `SCScreenshotManager.captureImage`
+  - `VNRecognizeTextRequest` in accurate mode
+
+### Task 8: Add permission-aware window capture and OCR services
+
+**Files:**
+- Create: `GhostPepper/Context/OCRContext.swift`
+- Create: `GhostPepper/Context/OCRRequestFactory.swift`
+- Create: `GhostPepper/Context/WindowCaptureService.swift`
+- Create: `GhostPepper/Context/FrontmostWindowOCRService.swift`
+- Modify: `GhostPepper/PermissionChecker.swift`
+- Test: `GhostPepperTests/OCRContextTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testOCRRequestFactoryUsesAccurateRecognitionLevel()
+func testOCRRequestFactoryEnablesLanguageCorrection()
+func testOCRRequestFactoryAcceptsCustomWords()
+func testMissingScreenRecordingPermissionDisablesCapture()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/OCRContextTests`
+Expected: FAIL because capture/OCR services do not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add an `OCRRequestFactory` that builds the configured `VNRecognizeTextRequest` so tests can assert request settings directly. The factory should accept `customWords` as input even if the initial caller passes an empty list, so branch 5 can plug preferred words in without refactoring the OCR service. Add Screen Recording helpers to `PermissionChecker`, and keep the OCR service injectable with a permission provider and window-capture source so tests do not require real capture permissions.
+
+- [ ] **Step 4: Run targeted and full tests**
+
+Run targeted command from Step 2, then:
+`xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Context/OCRContext.swift GhostPepper/Context/OCRRequestFactory.swift GhostPepper/Context/WindowCaptureService.swift GhostPepper/Context/FrontmostWindowOCRService.swift GhostPepper/PermissionChecker.swift GhostPepperTests/OCRContextTests.swift
+git commit -m "feat: add OCR context services"
+```
+
+### Task 9: Inject OCR context into the cleanup prompt
+
+**Files:**
+- Create: `GhostPepper/Cleanup/CleanupPromptBuilder.swift`
+- Modify: `GhostPepper/AppState.swift`
+- Modify: `GhostPepper/Cleanup/TextCleaner.swift`
+- Modify: `GhostPepper/UI/SettingsWindow.swift`
+- Test: `GhostPepperTests/CleanupPromptBuilderTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testBuilderIncludesWindowContentsWrapperWhenContextEnabled()
+func testBuilderOmitsWindowContentsWhenContextUnavailable()
+func testBuilderTrimsLongOCRContextBeforePromptAssembly()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/CleanupPromptBuilderTests`
+Expected: FAIL because prompt assembly still lives inline in the cleanup path.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Move prompt assembly into `CleanupPromptBuilder`, add a `Context` settings section, collect OCR text only when enabled and permitted, and inject it using the exact `<WINDOW CONTENTS>` wrapper from the spec.
+
+- [ ] **Step 4: Run the full test suite and build**
+
+Run:
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Debug -derivedDataPath build/derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
+Expected: PASS / BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Cleanup/CleanupPromptBuilder.swift GhostPepper/AppState.swift GhostPepper/Cleanup/TextCleaner.swift GhostPepper/UI/SettingsWindow.swift GhostPepperTests/CleanupPromptBuilderTests.swift
+git commit -m "feat: inject OCR context into cleanup"
+```
+
+## Chunk 5: `codex/preferred-transcriptions`
+
+### Task 10: Add the correction store and deterministic correction engine
+
+**Files:**
+- Create: `GhostPepper/Cleanup/CorrectionStore.swift`
+- Create: `GhostPepper/Cleanup/DeterministicCorrectionEngine.swift`
+- Modify: `GhostPepper/Cleanup/TextCleaner.swift`
+- Test: `GhostPepperTests/TextCleanerTests.swift`
+- Test: `GhostPepperTests/CorrectionStoreTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testPreferredTranscriptionsPreserveConfiguredPhrase()
+func testCommonlyMisheardReplacementAppliesBeforeCleanup()
+func testPreferredTranscriptionsWinOverBroadReplacement()
+func testDeterministicCorrectionsStillApplyWhenNoCleanupBackendIsAvailable()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/CorrectionStoreTests`
+Expected: FAIL because the store and deterministic correction engine do not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Persist both lists locally, apply them deterministically before any backend call, re-apply protected preferred phrases after cleanup when necessary, and keep the deterministic correction layer active even when no cleanup backend/model is available.
+
+- [ ] **Step 4: Run targeted and full tests**
+
+Run targeted command from Step 2, then:
+`xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Cleanup/CorrectionStore.swift GhostPepper/Cleanup/DeterministicCorrectionEngine.swift GhostPepper/Cleanup/TextCleaner.swift GhostPepperTests/CorrectionStoreTests.swift GhostPepperTests/TextCleanerTests.swift
+git commit -m "feat: add deterministic transcription corrections"
+```
+
+### Task 11: Add corrections UI and feed preferred words into OCR
+
+**Files:**
+- Modify: `GhostPepper/UI/SettingsWindow.swift`
+- Modify: `GhostPepper/Context/FrontmostWindowOCRService.swift`
+- Modify: `GhostPepper/AppState.swift`
+- Modify: `GhostPepper/Cleanup/CorrectionStore.swift`
+- Modify: `GhostPepperTests/GhostPepperTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `CorrectionStoreTests` and `GhostPepperTests` coverage that preferred words are forwarded into the OCR configuration and that correction settings round-trip through app state/store persistence.
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/CorrectionStoreTests -only-testing:GhostPepperTests/GhostPepperTests`
+Expected: FAIL because the UI wiring and OCR custom words integration do not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add a `Corrections` settings section with editor affordances for both lists and route preferred words into OCR `customWords`.
+
+- [ ] **Step 4: Run the full test suite and build**
+
+Run:
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Debug -derivedDataPath build/derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
+Expected: PASS / BUILD SUCCEEDED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/UI/SettingsWindow.swift GhostPepper/Context/FrontmostWindowOCRService.swift GhostPepper/AppState.swift GhostPepper/Cleanup/CorrectionStore.swift GhostPepperTests/CorrectionStoreTests.swift GhostPepperTests/GhostPepperTests.swift
+git commit -m "feat: add corrections settings"
+```
+
+## Chunk 6: `codex/learn-misheard`
+
+### Task 12: Add paste metadata capture and the delayed learning coordinator
+
+**Files:**
+- Create: `GhostPepper/Input/PasteSession.swift`
+- Create: `GhostPepper/Context/FocusedElementLocator.swift`
+- Create: `GhostPepper/Cleanup/PostPasteLearningCoordinator.swift`
+- Modify: `GhostPepper/Input/TextPaster.swift`
+- Modify: `GhostPepper/AppState.swift`
+- Test: `GhostPepperTests/PostPasteLearningCoordinatorTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+func testCoordinatorStartsLearningPassAfterPasteDelay()
+func testCoordinatorRejectsLargeRewriteDiffs()
+func testCoordinatorStoresHighConfidenceNarrowReplacement()
+func testCoordinatorUsesInjectedSchedulerInsteadOfRealSleep()
+```
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/PostPasteLearningCoordinatorTests`
+Expected: FAIL because the learning coordinator does not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Introduce a `PasteSession` contract that captures pasted text, timestamp, frontmost app bundle identifier, frontmost window identifier if available, window frame, and focused-element frame snapshot at paste time. Have `TextPaster` expose a completion hook that hands off a `PasteSession`, and give `PostPasteLearningCoordinator` an injected scheduler/clock so the 15-second delay is testable without real sleeps. Use that session to revisit the destination, prefer OCR on the saved focused-element region when it still makes sense, fall back to the saved window region when focus has moved, and only persist narrow, high-confidence replacements.
+
+- [ ] **Step 4: Run targeted and full tests**
+
+Run targeted command from Step 2, then:
+`xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/Input/PasteSession.swift GhostPepper/Context/FocusedElementLocator.swift GhostPepper/Cleanup/PostPasteLearningCoordinator.swift GhostPepper/Input/TextPaster.swift GhostPepper/AppState.swift GhostPepperTests/PostPasteLearningCoordinatorTests.swift
+git commit -m "feat: add post-paste learning"
+```
+
+### Task 13: Add user-facing learning controls and final verification
+
+**Files:**
+- Modify: `GhostPepper/UI/SettingsWindow.swift`
+- Modify: `GhostPepper/Cleanup/CorrectionStore.swift`
+- Modify: `GhostPepper/Cleanup/PostPasteLearningCoordinator.swift`
+- Modify: `GhostPepper/AppState.swift`
+- Modify: `GhostPepperTests/GhostPepperTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add `GhostPepperTests` and `PostPasteLearningCoordinatorTests` coverage for learning enablement/disablement and rejection of ambiguous OCR corrections even when learning is on.
+
+- [ ] **Step 2: Run the targeted tests to verify they fail**
+
+Run: `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/PostPasteLearningCoordinatorTests -only-testing:GhostPepperTests/GhostPepperTests`
+Expected: FAIL because learning controls are not wired into the coordinator.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add settings for learning behavior, keep automatic learning conservative, and default to discarding ambiguous candidates.
+
+- [ ] **Step 4: Run the complete verification suite**
+
+Run:
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
+- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Debug -derivedDataPath build/derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
+
+Smoke-check:
+- launch the built app
+- verify push-to-talk and toggle-to-talk both trigger
+- verify Screen Recording status messaging
+- verify cleanup backend/model switching
+- verify OCR context injection and delayed learning flow on a manual correction
+
+Expected: PASS / BUILD SUCCEEDED / manual smoke path works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhostPepper/UI/SettingsWindow.swift GhostPepper/Cleanup/CorrectionStore.swift GhostPepper/Cleanup/PostPasteLearningCoordinator.swift GhostPepper/AppState.swift GhostPepperTests/GhostPepperTests.swift
+git commit -m "feat: finalize transcription learning controls"
+```
+
+## Execution Notes
+
+- Run `xcodegen generate` after every task that creates, deletes, or renames Swift files.
+- Create a fresh implementation worktree before branch 1 execution.
+- Stack branches in order:
+  - `codex/chord-actions`
+  - `codex/cleanup-model-picker`
+  - `codex/foundation-model-cleanup`
+  - `codex/ocr-context`
+  - `codex/preferred-transcriptions`
+  - `codex/learn-misheard`
+- After each chunk, request review before moving to the next chunk.
+- Keep commits narrow. Do not mix branch-N work into branch-(N+1).

--- a/docs/superpowers/specs/2026-03-23-transcription-stack-design.md
+++ b/docs/superpowers/specs/2026-03-23-transcription-stack-design.md
@@ -1,0 +1,286 @@
+# Transcription Stack Design
+
+## Goal
+
+Add first-class configurable recording chords, cleanup backend/model selection, OCR-informed cleanup, and a persistent correction system without turning the current app into a single `AppState` blob.
+
+## Current Constraints
+
+- The app currently hardcodes a Control-only hold-to-talk path in `GhostPepper/Input/HotkeyMonitor.swift`.
+- The settings UI in `GhostPepper/UI/SettingsWindow.swift` exposes microphone, cleanup enablement, and prompt editing, but not shortcut or backend selection.
+- Cleanup currently uses local GGUF models through `LLM.swift` in `GhostPepper/Cleanup/TextCleanupManager.swift` and `GhostPepper/Cleanup/TextCleaner.swift`.
+- The project currently targets macOS 14.0 in `project.yml`.
+- Apple Foundation Models are available on macOS 26.0+ and require runtime availability checks.
+- OCR will require Screen Recording permission.
+
+## Non-Goals
+
+- Sequential shortcut support
+- Promise of universal Globe-key support before hardware validation
+- Large refactors unrelated to the requested stack
+- Silent unconditional learning from post-paste OCR diffs
+
+## Recommended Approach
+
+Add a few narrow seams where the new behavior needs them:
+
+- A reusable chord system for recording actions
+- A pluggable cleanup backend layer
+- A pluggable OCR context layer
+- A persistent correction store with deterministic rules
+
+This keeps the repo's current shape intact while making later branches additive instead of tangled.
+
+## Branch Stack
+
+### 1. `codex/chord-actions`
+
+Replace the single-purpose hotkey monitor with a chord system that supports:
+
+- side-specific modifiers
+- simultaneous push-to-talk and toggle-to-talk actions
+- prefix-aware matching for overlapping chords
+- a custom SwiftUI-backed recorder UI that captures low-level key events
+
+Core types:
+
+- `KeyChord`
+  A persisted simultaneous chord made of physical keys, not generic modifier flags
+- `ChordAction`
+  Initial cases: `pushToTalk`, `toggleToTalk`
+- `ChordBindingStore`
+  Persistence, validation, defaults, and conflict reporting
+- `ChordRecorder`
+  Settings-side capture and display
+- `ChordEngine`
+  Runtime event matching and state transitions
+
+Runtime rules:
+
+- If the pressed key set exactly matches `pushToTalk`, start recording immediately unless the set is still a strict prefix of a longer configured chord.
+- If the pressed key set exactly matches `toggleToTalk`, toggle immediately.
+- Releasing any required push-to-talk key stops hold recording immediately.
+- Re-entering the toggle chord stops toggle recording.
+- If the pressed set can no longer become any configured chord, reset.
+
+Globe support is best effort only. If the low-level event path exposes Globe distinctly, record and match it. If not, the recorder must refuse it instead of pretending support exists.
+
+### 2. `codex/cleanup-model-picker`
+
+Add first-class cleanup model selection in settings.
+
+The current cleanup system loads a fast model and a full model and chooses between them internally. This branch should separate:
+
+- cleanup enabled/disabled
+- local cleanup model policy
+
+Recommended local policy choices:
+
+- `Automatic`
+  Preserve current short-vs-long text behavior
+- `Fast model only`
+- `Full model only`
+
+This keeps the current local backend behavior available while making the chosen model explicit in the UI.
+
+### 3. `codex/foundation-model-cleanup`
+
+Make cleanup backend-pluggable while keeping the project target at macOS 14.0.
+
+Add a cleanup backend abstraction with two initial implementations:
+
+- `LocalLLMCleanupBackend`
+  Existing GGUF-based cleanup through `LLM.swift`
+- `FoundationModelsCleanupBackend`
+  Available only behind compile-time and runtime availability checks on macOS 26.0+
+
+The Foundation Models backend must:
+
+- use `SystemLanguageModel` availability checks
+- expose unavailable reasons in settings
+- fall back cleanly to the local backend
+- keep prompts short because the system model context window is limited
+
+Recommended settings model:
+
+- backend: `Local Models` or `Apple Foundation Models`
+- local model policy: `Automatic`, `Fast`, `Full`
+- when Foundation Models is selected but unavailable, show status and do not break recording
+
+### 4. `codex/ocr-context`
+
+Add frontmost-window OCR context for cleanup prompts.
+
+Pipeline:
+
+1. Determine the frontmost app/window.
+2. Capture the window image.
+3. Run high-quality OCR with Vision.
+4. Inject the resulting text into the cleanup prompt as:
+
+```text
+The full current content of the frontmost window is:
+<WINDOW CONTENTS>
+...
+</WINDOW CONTENTS>
+```
+
+OCR requirements:
+
+- Use Vision `VNRecognizeTextRequest` in highest-quality mode, not fast mode.
+- Enable language correction.
+- Prefer automatic language detection where it helps recognition quality.
+- Trim OCR text before prompt injection so cleanup backends do not receive unbounded context.
+
+Permission model:
+
+- Screen Recording permission is required for capture.
+- Accessibility remains useful for locating the frontmost focused element and bounds, especially for the later post-paste learning branch.
+
+### 5. `codex/preferred-transcriptions`
+
+Add a persistent local correction store with two user-owned lists:
+
+- preferred transcriptions
+  domain-specific words or phrases that should be preserved
+- commonly misheard
+  deterministic replacement pairs of "probably wrong" -> "probably right"
+
+This layer should not rely only on prompt text. It needs a deterministic preprocessing/postprocessing path so user corrections are predictable even when the cleanup model is unavailable.
+
+Recommended behavior:
+
+- Apply deterministic corrections before cleanup so the cleanup backend sees better text.
+- Re-apply preferred transcriptions after cleanup where necessary to protect user-owned vocabulary.
+- Feed preferred words into OCR `customWords` where helpful so the OCR branches benefit from the same vocabulary.
+
+### 6. `codex/learn-misheard`
+
+Add a delayed post-paste learning pass.
+
+Pipeline:
+
+1. After paste, wait 15 seconds.
+2. Re-locate the destination text input if possible.
+3. Capture a targeted image of the pasted region or its containing window.
+4. Run high-quality OCR.
+5. Compare the pasted text with the observed text.
+6. If the user appears to have made a narrow correction, extract a candidate misheard mapping.
+
+This branch must be conservative. Blind auto-learning will poison the correction store.
+
+Learning rules:
+
+- Learn only from narrow substitutions, not large rewrites.
+- Reject low-confidence OCR or ambiguous diffs.
+- Reject edits that look like formatting or unrelated typing.
+- Persist only plausible "spoken wrong" -> "corrected right" replacements.
+
+Recommended product behavior:
+
+- Run the learning pass automatically.
+- Store only high-confidence mappings automatically.
+- Discard ambiguous cases instead of forcing a guess.
+
+## Cross-Cutting Architecture
+
+### Cleanup Pipeline
+
+The cleanup pipeline should become:
+
+1. raw transcription
+2. deterministic correction pass
+3. optional OCR context collection
+4. optional cleanup backend
+5. final paste
+6. delayed post-paste learning
+
+This ordering keeps user-owned deterministic corrections from being overwritten by model output.
+
+### Settings and Onboarding
+
+Settings should gain four clear sections:
+
+- `Shortcuts`
+- `Cleanup`
+- `Context`
+- `Corrections`
+
+Onboarding should stay minimal:
+
+- permissions
+- microphone choice
+- default shortcut behavior
+- link into advanced settings
+
+The new controls belong in settings, not in a longer first-run wizard.
+
+### Error Handling
+
+- Invalid or conflicting chords should fail at save time, not at runtime.
+- If Screen Recording permission is missing, disable OCR features and show clear status.
+- If Foundation Models is unavailable, keep recording functional and fall back cleanly.
+- If OCR fails, discard OCR context or learning for that pass rather than blocking transcription.
+- If the cleanup backend fails, paste the corrected deterministic text instead of nothing.
+
+## Testing Strategy
+
+Each branch gets TDD and its own regression coverage.
+
+### Branch 1
+
+- side-specific chord serialization
+- exact matching
+- prefix disambiguation
+- push-to-talk semantics
+- toggle semantics
+- recorder persistence and conflict validation
+
+### Branch 2
+
+- cleanup model selection persistence
+- local model policy behavior
+- settings state wiring
+
+### Branch 3
+
+- backend selection
+- availability-gated Foundation Models behavior
+- fallback when Foundation Models is unavailable
+
+### Branch 4
+
+- OCR request configuration
+- prompt injection format
+- context trimming
+- permission gating
+
+### Branch 5
+
+- deterministic correction precedence
+- preferred transcription persistence
+- commonly misheard replacement behavior
+
+### Branch 6
+
+- learning heuristics for narrow substitutions
+- rejection of ambiguous diffs
+- OCR-like noisy-input regression tests
+
+## Risks and Guardrails
+
+- Globe support may not be uniformly observable through the event path on all hardware layouts.
+- OCR context can become too large for the cleanup backend if left unbounded.
+- Silent learning without confidence thresholds will degrade quality over time.
+- Foundation Models integration must remain strictly optional while the app still targets macOS 14.0.
+
+## Outcome
+
+This stack keeps the existing app intact while creating four durable seams:
+
+- input bindings
+- cleanup backend selection
+- OCR context collection
+- deterministic corrections and learning
+
+That is the smallest design that supports the requested features without burying everything inside `AppState`.

--- a/project.yml
+++ b/project.yml
@@ -41,6 +41,8 @@ targets:
       - package: Sparkle
     entitlements:
       path: GhostPepper/GhostPepper.entitlements
+      properties:
+        com.apple.security.device.audio-input: true
 
   GhostPepperTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary

This PR introduces the transcription-stack core work that was developed and manually tested on a single integrated branch, then re-sliced into a clean upstream stack.

It includes:
- side-specific global shortcut capture, storage, display, and matching
- lower-latency hotkey monitoring with the event tap moved off the main run loop and matching queued off the tap
- OCR capture of the frontmost window and injection of that screen text into the cleanup prompt as supporting context
- cleanup prompt construction, deterministic correction support, and correction-store plumbing
- richer in-memory debug logging and a bottom-anchored live debug log window
- Screen Recording and Input Monitoring permission plumbing in onboarding and settings
- the initial Accessibility-based post-paste learning path and learned-correction notifications

## Notes On History

Jesse manually tested this functionality extensively on the integrated working branch before I rebuilt the history into a reviewable stack. This PR is the first slice of that rebased/reorganized result rather than a literal replay of the original mixed commits.

## Testing

Manual testing:
- Jesse manually tested the integrated branch extensively before this stack was prepared.

Automated testing:
- `xcodebuild test -project GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS' -derivedDataPath /tmp/derived-stack-core -skipMacroValidation CODE_SIGNING_ALLOWED=NO -only-testing:GhostPepperTests/ChordBindingStoreTests -only-testing:GhostPepperTests/ChordEngineTests -only-testing:GhostPepperTests/HotkeyMonitorTests -only-testing:GhostPepperTests/KeyChordTests -only-testing:GhostPepperTests/CleanupPromptBuilderTests -only-testing:GhostPepperTests/TextCleanerTests -only-testing:GhostPepperTests/GhostPepperTests`
