### PR TITLE
Replace no-audio modal with status pill

### DIFF
--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -11,6 +11,11 @@ enum AppStatus: String {
     case error = "Error"
 }
 
+enum EmptyTranscriptionDisposition: Equatable {
+    case cancel
+    case showNoSoundDetected
+}
+
 @MainActor
 class AppState: ObservableObject {
     @Published var status: AppStatus = .loading
@@ -66,6 +71,14 @@ class AppState: ObservableObject {
         status == .ready
     }
 
+    static func emptyTranscriptionDisposition(forAudioSampleCount sampleCount: Int) -> EmptyTranscriptionDisposition {
+        if sampleCount < emptyTranscriptionCancelThresholdSampleCount {
+            return .cancel
+        }
+
+        return .showNoSoundDetected
+    }
+
     private var cleanupStateObserver: Any? = nil
     private let cleanupSettingsDefaults: UserDefaults
     private let inputMonitoringChecker: () -> Bool
@@ -75,6 +88,7 @@ class AppState: ObservableObject {
     private static let cleanupBackendDefaultsKey = "cleanupBackend"
     private static let frontmostWindowContextEnabledDefaultsKey = "frontmostWindowContextEnabled"
     private static let postPasteLearningEnabledDefaultsKey = "postPasteLearningEnabled"
+    private static let emptyTranscriptionCancelThresholdSampleCount = 80_000
 
     nonisolated static let defaultPushToTalkChord = KeyChord(keys: Set([
         PhysicalKey(keyCode: 54),
@@ -372,10 +386,15 @@ class AppState: ObservableObject {
             overlay.dismiss()
             textPaster.paste(text: finalText)
         } else {
-            overlay.dismiss()
-            showInputCheckAlert()
+            switch Self.emptyTranscriptionDisposition(forAudioSampleCount: buffer.count) {
+            case .cancel:
+                overlay.dismiss()
+                debugLogStore.record(category: .model, message: "Empty transcription cancelled after a short recording.")
+            case .showNoSoundDetected:
+                overlay.show(message: .noSoundDetected)
+                debugLogStore.record(category: .model, message: "No sound detected for a long recording.")
+            }
             status = .ready
-            debugLogStore.record(category: .model, message: "Transcription returned no text.")
             return
         }
 
@@ -385,20 +404,6 @@ class AppState: ObservableObject {
     func cleanedTranscription(_ text: String) async -> String {
         let result = await cleanedTranscriptionResult(text, windowContext: nil)
         return result.text
-    }
-
-    private func showInputCheckAlert() {
-        let alert = NSAlert()
-        alert.messageText = "No sound coming in"
-        alert.informativeText = "We didn't pick up any audio. Check that the right microphone is selected."
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "Open Settings")
-        alert.addButton(withTitle: "Dismiss")
-
-        let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
-            showSettings()
-        }
     }
 
     private let settingsController = SettingsWindowController()

--- a/GhostPepper/UI/RecordingOverlay.swift
+++ b/GhostPepper/UI/RecordingOverlay.swift
@@ -6,6 +6,7 @@ enum OverlayMessage: Equatable {
     case modelLoading
     case cleaningUp
     case transcribing
+    case noSoundDetected
     case learnedCorrection(MisheardReplacement)
 
     var primaryText: String {
@@ -18,6 +19,8 @@ enum OverlayMessage: Equatable {
             return "Cleaning up..."
         case .transcribing:
             return "Transcribing..."
+        case .noSoundDetected:
+            return "No sound detected"
         case .learnedCorrection:
             return "Learned correction"
         }
@@ -112,15 +115,16 @@ class RecordingOverlayController {
     }
 
     private func scheduleDismissIfNeeded(for message: OverlayMessage) {
-        guard case .learnedCorrection = message else {
+        switch message {
+        case .learnedCorrection, .noSoundDetected:
+            let workItem = DispatchWorkItem { [weak self] in
+                self?.dismiss()
+            }
+            dismissWorkItem = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: workItem)
+        default:
             return
         }
-
-        let workItem = DispatchWorkItem { [weak self] in
-            self?.dismiss()
-        }
-        dismissWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: workItem)
     }
 }
 
@@ -136,6 +140,8 @@ struct OverlayPillView: View {
             return .orange
         case .cleaningUp, .transcribing:
             return .blue
+        case .noSoundDetected:
+            return .orange
         case .learnedCorrection:
             return .green
         }

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -53,6 +53,29 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(AppStatus.error.rawValue, "Error")
     }
 
+    func testEmptyTranscriptionDispositionCancelsShortRecordings() {
+        XCTAssertEqual(
+            AppState.emptyTranscriptionDisposition(forAudioSampleCount: 79_999),
+            .cancel
+        )
+    }
+
+    func testEmptyTranscriptionDispositionShowsNoSoundForFiveSecondsOrLonger() {
+        XCTAssertEqual(
+            AppState.emptyTranscriptionDisposition(forAudioSampleCount: 80_000),
+            .showNoSoundDetected
+        )
+        XCTAssertEqual(
+            AppState.emptyTranscriptionDisposition(forAudioSampleCount: 96_000),
+            .showNoSoundDetected
+        )
+    }
+
+    func testNoSoundDetectedOverlayMessageUsesExpectedCopy() {
+        XCTAssertEqual(OverlayMessage.noSoundDetected.primaryText, "No sound detected")
+        XCTAssertNil(OverlayMessage.noSoundDetected.secondaryText)
+    }
+
     func testOverlayHostingViewDoesNotManageWindowSizingConstraints() {
         let overlay = RecordingOverlayController()
         overlay.show(message: .recording)


### PR DESCRIPTION
## Summary
- replace the empty-transcription modal with a transient `No sound detected` overlay pill that auto-dismisses after 3 seconds
- treat empty transcriptions shorter than 5 seconds as silent cancels with no message
- add regression coverage for the duration split and the new overlay copy

## Test Plan
- [x] xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -derivedDataPath build/test-derived -skipMacroValidation CODE_SIGNING_ALLOWED=NO test
