### PR TITLE
Add per-app cleanup profiles

### DIFF
--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import Combine
 import ServiceManagement
@@ -101,6 +102,7 @@ class AppState: ObservableObject {
     let frontmostWindowOCRService: FrontmostWindowOCRService
     let cleanupPromptBuilder: CleanupPromptBuilder
     let correctionStore: CorrectionStore
+    let appProfileStore: AppProfileStore
     let textCleaner: TextCleaner
     let chordBindingStore: ChordBindingStore
     let postPasteLearningCoordinator: PostPasteLearningCoordinator
@@ -172,6 +174,7 @@ class AppState: ObservableObject {
         frontmostWindowOCRService: FrontmostWindowOCRService = FrontmostWindowOCRService(),
         cleanupPromptBuilder: CleanupPromptBuilder = CleanupPromptBuilder(),
         correctionStore: CorrectionStore? = nil,
+        appProfileStore: AppProfileStore = AppProfileStore(),
         audioRecorder: AudioRecorder = AudioRecorder(),
         textPaster: TextPaster = TextPaster(),
         debugLogStore: DebugLogStore = DebugLogStore(),
@@ -200,6 +203,7 @@ class AppState: ObservableObject {
         }
         self.cleanupPromptBuilder = cleanupPromptBuilder
         self.correctionStore = correctionStore ?? CorrectionStore(defaults: cleanupSettingsDefaults)
+        self.appProfileStore = appProfileStore
         let storedCleanupBackend = CleanupBackendOption(
             rawValue: cleanupSettingsDefaults.string(forKey: Self.cleanupBackendDefaultsKey) ?? ""
         ) ?? .localModels
@@ -835,15 +839,19 @@ class AppState: ObservableObject {
             return await cleanedTranscriptionResultOverride(text, windowContext)
         }
 
+        let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
+        let activeProfile = appProfileStore.profileFor(bundleID: frontmostBundleID)
+        let effectivePrompt = activeProfile.name == "Default" ? cleanupPrompt : activeProfile.prompt
+
         guard cleanupEnabled else {
-            return (text: text, prompt: cleanupPrompt, attemptedCleanup: false, cleanupUsedFallback: false)
+            return (text: text, prompt: effectivePrompt, attemptedCleanup: false, cleanupUsedFallback: false)
         }
 
         let activeCleanupPrompt: String
         if canAttemptCleanup {
             let promptBuildStart = Date()
             activeCleanupPrompt = cleanupPromptBuilder.buildPrompt(
-                basePrompt: cleanupPrompt,
+                basePrompt: effectivePrompt,
                 windowContext: windowContext,
                 preferredTranscriptions: correctionStore.preferredTranscriptions,
                 commonlyMisheard: correctionStore.commonlyMisheard,
@@ -851,7 +859,7 @@ class AppState: ObservableObject {
             )
             activePerformanceTrace?.promptBuildDuration = Date().timeIntervalSince(promptBuildStart)
         } else {
-            activeCleanupPrompt = cleanupPrompt
+            activeCleanupPrompt = effectivePrompt
         }
 
         let cleanedResult = await textCleaner.cleanWithPerformance(

--- a/GhostPepper/Cleanup/AppProfile.swift
+++ b/GhostPepper/Cleanup/AppProfile.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct AppProfile: Codable, Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var prompt: String
+    var bundleIDs: [String]
+    var isBuiltIn: Bool
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        prompt: String,
+        bundleIDs: [String] = [],
+        isBuiltIn: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.prompt = prompt
+        self.bundleIDs = bundleIDs
+        self.isBuiltIn = isBuiltIn
+    }
+}

--- a/GhostPepper/Cleanup/AppProfileStore.swift
+++ b/GhostPepper/Cleanup/AppProfileStore.swift
@@ -1,0 +1,115 @@
+import Combine
+import Foundation
+
+final class AppProfileStore: ObservableObject {
+    @Published var profiles: [AppProfile]
+
+    private static let defaultsKey = "appProfiles"
+    private static let builtInProfiles: [AppProfile] = [
+        AppProfile(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            name: "Default",
+            prompt: TextCleaner.defaultPrompt,
+            bundleIDs: [],
+            isBuiltIn: true
+        ),
+        AppProfile(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            name: "Code",
+            prompt: """
+            Clean up this transcription with minimal changes. Preserve technical terms, code identifiers, filenames, commands, APIs, and version numbers exactly as spoken unless there is an obvious recognition error. Remove filler words, keep the original structure and meaning, and only fix punctuation and clear transcription mistakes.
+            """,
+            bundleIDs: [
+                "com.microsoft.VSCode",
+                "com.apple.dt.Xcode",
+                "com.github.atom",
+                "com.jetbrains.intellij"
+            ],
+            isBuiltIn: true
+        ),
+        AppProfile(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+            name: "Messaging",
+            prompt: """
+            Clean up this transcription for chat apps. Keep the meaning the same, use a casual tone, shorten long run-on phrasing into shorter sentences, and keep punctuation light and natural. Remove filler words and obvious recognition mistakes.
+            """,
+            bundleIDs: [
+                "com.tinyspeck.slackmacgap",
+                "com.apple.MobileSMS",
+                "com.hnc.Discord"
+            ],
+            isBuiltIn: true
+        )
+    ]
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        let customProfiles = Self.loadCustomProfiles(from: defaults)
+        self.profiles = Self.builtInProfiles + customProfiles
+    }
+
+    func profileFor(bundleID: String) -> AppProfile {
+        if let customProfile = profiles.first(where: { !$0.isBuiltIn && $0.bundleIDs.contains(bundleID) }) {
+            return customProfile
+        }
+
+        if let builtInProfile = profiles.first(where: { $0.isBuiltIn && $0.bundleIDs.contains(bundleID) }) {
+            return builtInProfile
+        }
+
+        return profiles.first(where: { $0.isBuiltIn && $0.name == "Default" }) ?? Self.builtInProfiles[0]
+    }
+
+    func addProfile(_ profile: AppProfile) {
+        var profile = profile
+        profile.isBuiltIn = false
+        profiles.append(profile)
+        persistCustomProfiles()
+    }
+
+    func updateProfile(_ profile: AppProfile) {
+        guard let index = profiles.firstIndex(where: { $0.id == profile.id }),
+              !profiles[index].isBuiltIn else {
+            return
+        }
+
+        var profile = profile
+        profile.isBuiltIn = false
+        profiles[index] = profile
+        persistCustomProfiles()
+    }
+
+    @discardableResult
+    func deleteProfile(_ id: UUID) -> Bool {
+        guard let index = profiles.firstIndex(where: { $0.id == id }),
+              !profiles[index].isBuiltIn else {
+            return false
+        }
+
+        profiles.remove(at: index)
+        persistCustomProfiles()
+        return true
+    }
+
+    private func persistCustomProfiles() {
+        let customProfiles = profiles.filter { !$0.isBuiltIn }
+        guard let data = try? encoder.encode(customProfiles) else {
+            return
+        }
+
+        defaults.set(data, forKey: Self.defaultsKey)
+    }
+
+    private static func loadCustomProfiles(from defaults: UserDefaults) -> [AppProfile] {
+        let decoder = JSONDecoder()
+        guard let data = defaults.data(forKey: defaultsKey),
+              let decodedProfiles = try? decoder.decode([AppProfile].self, from: data) else {
+            return []
+        }
+
+        return decodedProfiles.filter { !$0.isBuiltIn }
+    }
+}

--- a/GhostPepperTests/AppProfileStoreTests.swift
+++ b/GhostPepperTests/AppProfileStoreTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class AppProfileStoreTests: XCTestCase {
+    private let suiteName = "test-profiles"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testBuiltInProfilesExist() throws {
+        let store = AppProfileStore(defaults: try defaults())
+
+        XCTAssertEqual(store.profiles.count, 3)
+        XCTAssertEqual(Set(store.profiles.map(\.name)), Set(["Default", "Code", "Messaging"]))
+    }
+
+    func testProfileForBundleID() throws {
+        let store = AppProfileStore(defaults: try defaults())
+
+        XCTAssertEqual(store.profileFor(bundleID: "com.microsoft.VSCode").name, "Code")
+    }
+
+    func testProfileForUnknownBundleID() throws {
+        let store = AppProfileStore(defaults: try defaults())
+
+        XCTAssertEqual(store.profileFor(bundleID: "com.example.unknown").name, "Default")
+    }
+
+    func testAddCustomProfile() throws {
+        let store = AppProfileStore(defaults: try defaults())
+        let custom = AppProfile(
+            name: "Docs",
+            prompt: "Clean up for docs.",
+            bundleIDs: ["com.example.docs"]
+        )
+
+        store.addProfile(custom)
+
+        XCTAssertTrue(store.profiles.contains(custom))
+    }
+
+    func testCustomProfileTakesPriority() throws {
+        let store = AppProfileStore(defaults: try defaults())
+        let custom = AppProfile(
+            name: "My Code",
+            prompt: "Use my coding prompt.",
+            bundleIDs: ["com.microsoft.VSCode"]
+        )
+        store.addProfile(custom)
+
+        XCTAssertEqual(store.profileFor(bundleID: "com.microsoft.VSCode").name, "My Code")
+    }
+
+    func testDeleteProfile() throws {
+        let store = AppProfileStore(defaults: try defaults())
+        let custom = AppProfile(
+            name: "Temp",
+            prompt: "Temp prompt",
+            bundleIDs: ["com.example.temp"]
+        )
+        store.addProfile(custom)
+
+        XCTAssertTrue(store.deleteProfile(custom.id))
+        XCTAssertFalse(store.profiles.contains(custom))
+    }
+
+    func testCannotDeleteBuiltIn() throws {
+        let store = AppProfileStore(defaults: try defaults())
+        let builtIn = try XCTUnwrap(store.profiles.first(where: { $0.name == "Default" }))
+
+        XCTAssertFalse(store.deleteProfile(builtIn.id))
+        XCTAssertTrue(store.profiles.contains(where: { $0.id == builtIn.id }))
+    }
+
+    private func defaults() throws -> UserDefaults {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}


### PR DESCRIPTION
## Summary

Detect the frontmost app when recording starts and apply a matching cleanup prompt. A developer dictating in VS Code gets code-oriented cleanup, while someone in Slack gets casual tone cleanup.

Ships with three built-in profiles:

- **Default** - standard filler word removal and grammar cleanup (existing behavior)
- **Code** - preserves technical terms, identifiers, minimal cleanup (VS Code, Xcode, IntelliJ, Atom)  
- **Messaging** - casual tone, shorter sentences (Slack, Messages, Discord)

Users can create custom profiles and assign apps by bundle ID. Custom profiles take priority over built-in ones. Falls back to Default when no match.

## Why this matters

Ghost Pepper uses a single global cleanup prompt, but different apps need different cleanup behavior. VoiceInk (4,458 stars) lists this as a headline feature under ["Power Mode"](https://github.com/Beingpax/VoiceInk). The [HN launch thread](https://news.ycombinator.com/item?id=47666024) (118 points) had multiple commenters discussing context-aware transcription.

The building blocks already exist in the codebase:
- `FocusedElementLocator` tracks the frontmost app's process ID
- `CleanupPromptBuilder` supports dynamic prompt construction
- `CorrectionStore` follows the same UserDefaults persistence pattern

## Changes

- **`AppProfile.swift`** - Codable model with `id`, `name`, `prompt`, `bundleIDs`, `isBuiltIn`
- **`AppProfileStore.swift`** - ObservableObject managing profile CRUD, bundle ID lookup with fallback chain (custom -> built-in -> Default), UserDefaults persistence
- **`AppState.swift`** - Added `appProfileStore` property. Cleanup pipeline now detects frontmost app via `NSWorkspace.shared.frontmostApplication?.bundleIdentifier` and resolves the effective prompt through `appProfileStore.profileFor(bundleID:)`
- **`AppProfileStoreTests.swift`** - 7 tests covering built-in existence, bundle ID lookup, unknown fallback, custom priority, CRUD, and built-in deletion protection

## Testing

7 XCTest cases using isolated UserDefaults suite:
- Built-in profiles exist on init
- VS Code resolves to Code profile
- Unknown bundle ID falls back to Default
- Custom profile takes priority over built-in for same bundle ID
- Add/delete custom profiles
- Cannot delete built-in profiles

Note: This PR adds the backend logic. A follow-up PR will add the Settings UI for creating and managing custom profiles.

This contribution was developed with AI assistance (Codex).