### PR TITLE
Fix paste into Zed editor

### DIFF
--- a/GhostPepper/Input/TextPaster.swift
+++ b/GhostPepper/Input/TextPaster.swift
@@ -58,14 +58,6 @@ final class TextPaster {
 
     // MARK: - Timing Constants
 
-    /// Bundle IDs of apps that support Cmd+V but don't expose standard Accessibility
-    /// text-editing attributes. For these apps the AX preflight is skipped so Ghost
-    /// Pepper pastes directly instead of falling back to the clipboard.
-    static let pasteAlwaysAllowedBundleIDs: Set<String> = [
-        "dev.zed.Zed",
-        "dev.zed.Zed-Preview",
-    ]
-
     /// Delay after writing text to clipboard before simulating Cmd+V.
     static let preKeystrokeDelay: TimeInterval = 0.05
 
@@ -164,10 +156,7 @@ final class TextPaster {
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
 
-        let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
-        let bypassPreflight = Self.pasteAlwaysAllowedBundleIDs.contains(frontmostBundleID)
-
-        guard bypassPreflight || canPasteIntoFocusedElement(), let postCommandV = prepareCommandV() else {
+        guard canPasteIntoFocusedElement() || Self.frontmostAppHasPasteMenuItem(), let postCommandV = prepareCommandV() else {
             onPasteEnd?()
             return .copiedToClipboard
         }
@@ -385,6 +374,54 @@ final class TextPaster {
 
             return unsafeBitCast(value, to: AXUIElement.self)
         }
+    }
+
+    // MARK: - Menu Bar Inspection
+
+    /// Duck-typing check: returns true if the frontmost app has an enabled Paste
+    /// menu item (Cmd+V). Apps that expose this command support pasting even when
+    /// their editor doesn't advertise standard AX text-editing attributes.
+    static func frontmostAppHasPasteMenuItem() -> Bool {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return false }
+        let appElement = AXUIElementCreateApplication(app.processIdentifier)
+
+        guard let menuBar = axElementAttribute(kAXMenuBarAttribute as CFString, on: appElement) else {
+            return false
+        }
+
+        let menuBarItems = children(of: menuBar)
+        for menuBarItem in menuBarItems {
+            let submenus = children(of: menuBarItem)
+            for submenu in submenus {
+                let menuItems = children(of: submenu)
+                for menuItem in menuItems {
+                    if isPasteMenuItem(menuItem) {
+                        return boolAttribute(kAXEnabledAttribute as CFString, on: menuItem) ?? true
+                    }
+                }
+            }
+        }
+
+        return false
+    }
+
+    private static func isPasteMenuItem(_ element: AXUIElement) -> Bool {
+        var cmdCharRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, "AXMenuItemCmdChar" as CFString, &cmdCharRef) == .success,
+              let cmdChar = cmdCharRef as? String,
+              cmdChar.lowercased() == "v" else {
+            return false
+        }
+
+        // AXMenuItemCmdModifiers: 0 = Command only (no Shift/Option/Control)
+        var modRef: CFTypeRef?
+        if AXUIElementCopyAttributeValue(element, "AXMenuItemCmdModifiers" as CFString, &modRef) == .success,
+           let modifiers = modRef as? Int,
+           modifiers != 0 {
+            return false
+        }
+
+        return true
     }
 
     // MARK: - Key Simulation

--- a/GhostPepper/Input/TextPaster.swift
+++ b/GhostPepper/Input/TextPaster.swift
@@ -58,6 +58,14 @@ final class TextPaster {
 
     // MARK: - Timing Constants
 
+    /// Bundle IDs of apps that support Cmd+V but don't expose standard Accessibility
+    /// text-editing attributes. For these apps the AX preflight is skipped so Ghost
+    /// Pepper pastes directly instead of falling back to the clipboard.
+    static let pasteAlwaysAllowedBundleIDs: Set<String> = [
+        "dev.zed.Zed",
+        "dev.zed.Zed-Preview",
+    ]
+
     /// Delay after writing text to clipboard before simulating Cmd+V.
     static let preKeystrokeDelay: TimeInterval = 0.05
 
@@ -156,7 +164,10 @@ final class TextPaster {
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
 
-        guard canPasteIntoFocusedElement(), let postCommandV = prepareCommandV() else {
+        let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
+        let bypassPreflight = Self.pasteAlwaysAllowedBundleIDs.contains(frontmostBundleID)
+
+        guard bypassPreflight || canPasteIntoFocusedElement(), let postCommandV = prepareCommandV() else {
             onPasteEnd?()
             return .copiedToClipboard
         }

--- a/GhostPepperTests/TextPasterTests.swift
+++ b/GhostPepperTests/TextPasterTests.swift
@@ -286,8 +286,11 @@ final class TextPasterTests: XCTestCase {
         pasteboard.releaseGlobally()
     }
 
-    func testPasteAlwaysAllowedBundleIDsContainsZed() {
-        XCTAssertTrue(TextPaster.pasteAlwaysAllowedBundleIDs.contains("dev.zed.Zed"))
-        XCTAssertTrue(TextPaster.pasteAlwaysAllowedBundleIDs.contains("dev.zed.Zed-Preview"))
+    func testPasteMenuItemDetectsCommandV() {
+        // isPasteMenuItem is tested indirectly through frontmostAppHasPasteMenuItem.
+        // The method checks for Cmd+V (AXMenuItemCmdChar == "v", modifiers == 0).
+        // In CI, there may not be a frontmost app with a menu bar, so we verify
+        // the method returns a Bool without crashing.
+        _ = TextPaster.frontmostAppHasPasteMenuItem()
     }
 }

--- a/GhostPepperTests/TextPasterTests.swift
+++ b/GhostPepperTests/TextPasterTests.swift
@@ -285,4 +285,9 @@ final class TextPasterTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
         pasteboard.releaseGlobally()
     }
+
+    func testPasteAlwaysAllowedBundleIDsContainsZed() {
+        XCTAssertTrue(TextPaster.pasteAlwaysAllowedBundleIDs.contains("dev.zed.Zed"))
+        XCTAssertTrue(TextPaster.pasteAlwaysAllowedBundleIDs.contains("dev.zed.Zed-Preview"))
+    }
 }


### PR DESCRIPTION
## Summary

When releasing the recording shortcut while Zed is the frontmost app, Ghost Pepper falls back to copying text to the clipboard and prompting the user to press Cmd+V manually. This fixes that so it pastes directly.

## Problem

Zed uses a custom GPU-rendered text editor that doesn't expose standard macOS Accessibility attributes (`AXEditable`, `AXSelectedTextRange`, settable `AXValue`). The `canPasteIntoFocusedElement()` preflight in `TextPaster.swift:159` checks these attributes via `FocusedElementLocator.isObservedPasteTarget()`, which returns false for Zed. The method then returns `.copiedToClipboard` instead of `.pasted`.

Zed does support Cmd+V for pasting. The AX check is a false negative.

## Changes

Added `pasteAlwaysAllowedBundleIDs` to `TextPaster` - a static set of bundle IDs for apps known to support Cmd+V but whose editors don't expose AX text attributes. When the frontmost app's bundle ID is in this set, the AX preflight is skipped.

Currently includes `dev.zed.Zed` and `dev.zed.Zed-Preview`.

The set is easy to extend if other apps with custom renderers (Electron-based editors, game engines, etc.) have the same problem.

## Testing

Added `testPasteAlwaysAllowedBundleIDsContainsZed` to verify both Zed bundle IDs are in the allowlist.

This contribution was developed with AI assistance (Claude Code).