### PR TITLE
Add search to transcription history

### DIFF
--- a/GhostPepper/Lab/TranscriptionLabController.swift
+++ b/GhostPepper/Lab/TranscriptionLabController.swift
@@ -41,6 +41,7 @@ final class TranscriptionLabController: ObservableObject {
     }
 
     @Published private(set) var entries: [TranscriptionLabEntry] = []
+    @Published var searchText: String = ""
     @Published var selectedEntryID: UUID?
     @Published var selectedSpeechModelID: String {
         didSet {
@@ -109,6 +110,15 @@ final class TranscriptionLabController: ObservableObject {
         }
 
         return entries.first { $0.id == selectedEntryID }
+    }
+
+    var filteredEntries: [TranscriptionLabEntry] {
+        guard !searchText.isEmpty else { return entries }
+        let query = searchText.lowercased()
+        return entries.filter { entry in
+            (entry.correctedTranscription ?? "").lowercased().contains(query) ||
+                (entry.rawTranscription ?? "").lowercased().contains(query)
+        }
     }
 
     var isRunningTranscription: Bool {

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -780,16 +780,28 @@ struct SettingsView: View {
             Text("Recent recordings")
                 .font(.title3.weight(.semibold))
 
-            if transcriptionLabController.entries.isEmpty {
-                ContentUnavailableView(
-                    "No Saved Recordings",
-                    systemImage: "waveform",
-                    description: Text("Make a few dictations in Ghost Pepper and they will appear here.")
-                )
-                .frame(maxWidth: .infinity, minHeight: 280)
+            TextField("Search transcriptions", text: $transcriptionLabController.searchText)
+                .textFieldStyle(.roundedBorder)
+
+            if transcriptionLabController.filteredEntries.isEmpty {
+                if transcriptionLabController.searchText.isEmpty {
+                    ContentUnavailableView(
+                        "No Saved Recordings",
+                        systemImage: "waveform",
+                        description: Text("Make a few dictations in Ghost Pepper and they will appear here.")
+                    )
+                    .frame(maxWidth: .infinity, minHeight: 280)
+                } else {
+                    ContentUnavailableView(
+                        "No Results",
+                        systemImage: "magnifyingglass",
+                        description: Text("No transcriptions match \"\(transcriptionLabController.searchText)\".")
+                    )
+                    .frame(maxWidth: .infinity, minHeight: 280)
+                }
             } else {
                 VStack(alignment: .leading, spacing: 4) {
-                    ForEach(transcriptionLabController.entries) { entry in
+                    ForEach(transcriptionLabController.filteredEntries) { entry in
                         HStack(alignment: .top, spacing: 8) {
                             Button {
                                 transcriptionLabController.selectEntry(entry.id)


### PR DESCRIPTION
## Summary

Adds a search field to the History tab that filters transcription entries by matching against raw and corrected transcription text.

## Why this matters

In [PR #14](https://github.com/matthartman/ghost-pepper/pull/14#issuecomment-4157482087), @matthartman asked about "search/filter across transcriptions" as a feature worth exploring. The TranscriptionLab already stores up to 50 entries, but there's no way to find a specific transcription without scrolling through the list.

## Changes

- **TranscriptionLabController**: Added `searchText` published property and `filteredEntries` computed property that filters entries by case-insensitive match against `rawTranscription` and `correctedTranscription`.

- **SettingsWindow** (History section): Added a `TextField` with rounded border style above the entry list. Switched from `entries` to `filteredEntries` for both the list and empty-state check. Shows "No Results" with a magnifying glass icon when search has no matches, vs the existing "No Saved Recordings" when no recordings exist at all.

2 files changed, 30 insertions, 8 deletions.

This contribution was developed with AI assistance (Codex).