### PR TITLE
Make Pepper Chat opt-in

### DIFF
--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -68,6 +68,11 @@ class AppState: ObservableObject {
     @AppStorage("preferredLanguage") var preferredLanguage: String = "auto"
     @AppStorage("pepperChatHost") var pepperChatHost: String = "https://api.zo.computer"
     @AppStorage("pepperChatApiKey") var pepperChatApiKey: String = ""
+    @AppStorage("pepperChatEnabled") var pepperChatEnabled: Bool = false {
+        didSet {
+            hotkeyMonitor.updateBindings(shortcutBindings)
+        }
+    }
     @AppStorage("pepperChatIncludeScreenContext") var pepperChatIncludeScreenContext: Bool = true
     @AppStorage("meetingTranscriptEnabled") var meetingTranscriptEnabled: Bool = false
     @AppStorage("meetingAutoDetectEnabled") var meetingAutoDetectEnabled: Bool = true
@@ -149,6 +154,7 @@ class AppState: ObservableObject {
     private static let postPasteLearningEnabledDefaultsKey = "postPasteLearningEnabled"
     private static let ignoreOtherSpeakersDefaultsKey = "ignoreOtherSpeakers"
     private static let playSoundsDefaultsKey = "playSounds"
+    private static let pepperChatEnabledDefaultsKey = "pepperChatEnabled"
     private static let emptyTranscriptionCancelThresholdSampleCount = 8_000 // ~0.5 seconds — show "no sound" hint for almost all failed recordings
     private static let speechModelErrorPrefix = "Failed to load speech model: "
 
@@ -240,6 +246,9 @@ class AppState: ObservableObject {
             self.playSounds = true
         } else {
             self.playSounds = cleanupSettingsDefaults.bool(forKey: Self.playSoundsDefaultsKey)
+        }
+        if UserDefaults.standard.object(forKey: Self.pepperChatEnabledDefaultsKey) == nil {
+            pepperChatEnabled = !(UserDefaults.standard.string(forKey: "pepperChatApiKey") ?? "").isEmpty
         }
         self.transcriber = SpeechTranscriber(modelManager: modelManager)
         self.textCleaner = TextCleaner(
@@ -834,13 +843,14 @@ class AppState: ObservableObject {
     }
 
     func showPepperChat() {
+        guard pepperChatEnabled else { return }
         pepperChatWindowController.show(session: pepperChatSession)
     }
 
     private var pepperChatRecorder: AudioRecorder?
 
     func beginPepperChatRecording() {
-        guard !pepperChatApiKey.isEmpty else { return }
+        guard pepperChatEnabled, !pepperChatApiKey.isEmpty else { return }
         // Clear previous state so new recording takes over
         pepperChatSession.isReviewingContext = false
         pepperChatSession.capturedCommand = nil
@@ -860,6 +870,7 @@ class AppState: ObservableObject {
         guard let recorder = pepperChatRecorder else { return }
         pepperChatSession.isRecording = false
         pepperChatRecorder = nil
+        hotkeyMonitor.updateBindings(shortcutBindings)
         soundEffects.playStop()
         debugLogStore.record(category: .hotkey, message: "Pepper Chat recording stopped.")
 
@@ -969,11 +980,16 @@ class AppState: ObservableObject {
     }
 
     private var shortcutBindings: [ChordAction: KeyChord] {
-        [
+        var bindings: [ChordAction: KeyChord] = [
             .pushToTalk: pushToTalkChord,
-            .toggleToTalk: toggleToTalkChord,
-            .pepperChat: pepperChatChord
+            .toggleToTalk: toggleToTalkChord
         ]
+
+        if pepperChatEnabled || pepperChatRecorder != nil {
+            bindings[.pepperChat] = pepperChatChord
+        }
+
+        return bindings
     }
 
     private func persistShortcutBindingsIfNeeded() {

--- a/GhostPepper/UI/MenuBarView.swift
+++ b/GhostPepper/UI/MenuBarView.swift
@@ -12,8 +12,10 @@ struct MenuBarView: View {
                 appState.showSettings()
             }
 
-            Button("Pepper Chat...") {
-                appState.showPepperChat()
+            if appState.pepperChatEnabled {
+                Button("Pepper Chat...") {
+                    appState.showPepperChat()
+                }
             }
 
             Button("Debug Log...") {

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -1306,6 +1306,14 @@ struct SettingsView: View {
 
     private var pepperChatSection: some View {
         VStack(alignment: .leading, spacing: 24) {
+            SettingsCard("Availability") {
+                Toggle("Enable Pepper Chat", isOn: $appState.pepperChatEnabled)
+
+                Text("When disabled, Pepper Chat stays out of the menu bar and its shortcut will not start new chats.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             SettingsCard("Shortcut") {
                 ShortcutRecorderView(
                     title: "Pepper Chat (hold to speak)",

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -49,11 +49,66 @@ private final class FakeAppRelauncher: AppRelaunching {
 
 @MainActor
 final class GhostPepperTests: XCTestCase {
+    private let pepperChatAppStorageKeys = [
+        "pepperChatEnabled",
+        "pepperChatApiKey"
+    ]
+
     private func makeDebugLogStore() -> DebugLogStore {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
             .appendingPathComponent("debug-log.json")
         return DebugLogStore(storageURL: fileURL)
+    }
+
+    private func withClearedPepperChatAppStorage<T>(
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let defaults = UserDefaults.standard
+        let originalValues = pepperChatAppStorageKeys.map { key in
+            (key, defaults.object(forKey: key))
+        }
+
+        for key in pepperChatAppStorageKeys {
+            defaults.removeObject(forKey: key)
+        }
+
+        defer {
+            for (key, value) in originalValues {
+                if let value {
+                    defaults.set(value, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+        }
+
+        return try body()
+    }
+
+    private func withClearedPepperChatAppStorage<T>(
+        _ body: () async throws -> T
+    ) async rethrows -> T {
+        let defaults = UserDefaults.standard
+        let originalValues = pepperChatAppStorageKeys.map { key in
+            (key, defaults.object(forKey: key))
+        }
+
+        for key in pepperChatAppStorageKeys {
+            defaults.removeObject(forKey: key)
+        }
+
+        defer {
+            for (key, value) in originalValues {
+                if let value {
+                    defaults.set(value, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+        }
+
+        return try await body()
     }
 
     override func tearDown() {
@@ -233,6 +288,90 @@ final class GhostPepperTests: XCTestCase {
         )
 
         XCTAssertEqual(appState.cleanupBackend, .localModels)
+    }
+
+    func testAppStateDefaultsPepperChatToEnabledWhenZoTokenAlreadyStored() throws {
+        try withClearedPepperChatAppStorage {
+            UserDefaults.standard.set("zo_sk_existing", forKey: "pepperChatApiKey")
+
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+            defaults.removePersistentDomain(forName: #function)
+            let appState = AppState(
+                hotkeyMonitor: FakeHotkeyMonitor(),
+                chordBindingStore: ChordBindingStore(defaults: defaults),
+                cleanupSettingsDefaults: defaults
+            )
+
+            XCTAssertTrue(appState.pepperChatEnabled)
+        }
+    }
+
+    func testAppStateDefaultsPepperChatToDisabledWithoutZoToken() throws {
+        try withClearedPepperChatAppStorage {
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+            defaults.removePersistentDomain(forName: #function)
+            let appState = AppState(
+                hotkeyMonitor: FakeHotkeyMonitor(),
+                chordBindingStore: ChordBindingStore(defaults: defaults),
+                cleanupSettingsDefaults: defaults
+            )
+
+            XCTAssertFalse(appState.pepperChatEnabled)
+        }
+    }
+
+    func testAppStateUsesStoredPepperChatToggleOverZoTokenBackCompatDefault() throws {
+        try withClearedPepperChatAppStorage {
+            UserDefaults.standard.set("zo_sk_existing", forKey: "pepperChatApiKey")
+            UserDefaults.standard.set(false, forKey: "pepperChatEnabled")
+
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+            defaults.removePersistentDomain(forName: #function)
+            let appState = AppState(
+                hotkeyMonitor: FakeHotkeyMonitor(),
+                chordBindingStore: ChordBindingStore(defaults: defaults),
+                cleanupSettingsDefaults: defaults
+            )
+
+            XCTAssertFalse(appState.pepperChatEnabled)
+        }
+    }
+
+    func testAppStateStartHotkeyMonitorOmitsPepperChatBindingWhenDisabled() async throws {
+        try await withClearedPepperChatAppStorage {
+            UserDefaults.standard.set(false, forKey: "pepperChatEnabled")
+
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+            defaults.removePersistentDomain(forName: #function)
+            let monitor = FakeHotkeyMonitor()
+            let appState = AppState(
+                hotkeyMonitor: monitor,
+                chordBindingStore: ChordBindingStore(defaults: defaults)
+            )
+
+            await appState.startHotkeyMonitor()
+
+            XCTAssertNil(monitor.updatedBindings[.pepperChat])
+        }
+    }
+
+    func testAppStateDoesNotStartPepperChatRecordingWhenDisabled() throws {
+        try withClearedPepperChatAppStorage {
+            UserDefaults.standard.set(false, forKey: "pepperChatEnabled")
+            UserDefaults.standard.set("zo_sk_existing", forKey: "pepperChatApiKey")
+
+            let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+            defaults.removePersistentDomain(forName: #function)
+            let appState = AppState(
+                hotkeyMonitor: FakeHotkeyMonitor(),
+                chordBindingStore: ChordBindingStore(defaults: defaults),
+                cleanupSettingsDefaults: defaults
+            )
+
+            appState.beginPepperChatRecording()
+
+            XCTAssertFalse(appState.pepperChatSession.isRecording)
+        }
     }
 
     func testSpeechModelPresentationDoesNotExposeManagerLoadFailureInMenuErrorMessage() {

--- a/docs/superpowers/plans/2026-04-09-pepper-chat-opt-in.md
+++ b/docs/superpowers/plans/2026-04-09-pepper-chat-opt-in.md
@@ -1,0 +1,50 @@
+# Pepper Chat Opt-In Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Pepper Chat opt-in so new users do not see or trigger it until they enable it, while preserving the existing enabled behavior for users who already stored a Zo token.
+
+**Architecture:** Add one persisted `pepperChatEnabled` flag in `AppState` and derive its initial value from `pepperChatApiKey` only when the new setting has not been stored yet. Use that single source of truth to gate the menu bar entry, Pepper Chat hotkey bindings, and new launch/record entry points, while leaving already-open windows alone.
+
+**Tech Stack:** SwiftUI, AppStorage/UserDefaults, XCTest
+
+---
+
+## Chunk 1: Persistence and gating
+
+### Task 1: Add failing tests for Pepper Chat enablement defaults and hotkey gating
+
+**Files:**
+- Modify: `GhostPepperTests/GhostPepperTests.swift`
+- Test: `GhostPepperTests/GhostPepperTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 2: Run the focused tests and verify they fail for the missing behavior**
+- [ ] **Step 3: Add the minimal `AppState` implementation for the new persisted flag and shortcut gating**
+- [ ] **Step 4: Run the focused tests again and verify they pass**
+- [ ] **Step 5: Commit**
+
+### Task 2: Gate new Pepper Chat launches in the app state
+
+**Files:**
+- Modify: `GhostPepper/AppState.swift`
+
+- [ ] **Step 1: Add a failing test or extend an existing one if needed**
+- [ ] **Step 2: Guard new Pepper Chat launches/recordings behind `pepperChatEnabled`**
+- [ ] **Step 3: Re-run the focused test target**
+- [ ] **Step 4: Commit**
+
+## Chunk 2: Surface the setting in the UI
+
+### Task 3: Update settings and menu bar UI
+
+**Files:**
+- Modify: `GhostPepper/UI/SettingsWindow.swift`
+- Modify: `GhostPepper/UI/MenuBarView.swift`
+- Test: `GhostPepperTests/GhostPepperTests.swift`
+
+- [ ] **Step 1: Add or extend tests for the visible behavior where practical**
+- [ ] **Step 2: Add the Pepper Chat enable toggle in Settings**
+- [ ] **Step 3: Hide the menu bar Pepper Chat item when disabled**
+- [ ] **Step 4: Run the focused test target, then the broader relevant test target**
+- [ ] **Step 5: Commit**


### PR DESCRIPTION
## Summary
- add a persisted Pepper Chat enable toggle with a back-compat default seeded from an existing Zo API key
- hide Pepper Chat from the menu bar and omit its hotkey binding when disabled
- add regression coverage for the new defaulting and disabled launch/record behavior

## Testing
- `xcodebuild test -project GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS' -derivedDataPath build/test-derived CODE_SIGNING_ALLOWED=NO -skipMacroValidation -only-testing:GhostPepperTests/GhostPepperTests/testAppStateLoadsDefaultShortcutBindingsIntoHotkeyMonitor -only-testing:GhostPepperTests/GhostPepperTests/testAppStateDefaultsPepperChatToEnabledWhenZoTokenAlreadyStored -only-testing:GhostPepperTests/GhostPepperTests/testAppStateDefaultsPepperChatToDisabledWithoutZoToken -only-testing:GhostPepperTests/GhostPepperTests/testAppStateUsesStoredPepperChatToggleOverZoTokenBackCompatDefault -only-testing:GhostPepperTests/GhostPepperTests/testAppStateStartHotkeyMonitorOmitsPepperChatBindingWhenDisabled -only-testing:GhostPepperTests/GhostPepperTests/testAppStateDoesNotStartPepperChatRecordingWhenDisabled`

## Notes
- A broader `GhostPepperTests` run on this branch still hit `testAppStateArchivesCompletedRecordingWithOCRAndOutputs`; I did not investigate that failure as part of this change.