### PR TITLE
Add whisper.cpp large-v3-turbo model options

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		17AF31EA19761CA8B7DF5F9A /* CleanupSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065F99395EEC3EB77997C2C /* CleanupSettings.swift */; };
 		194F5FBCC55E0EA3E0351C15 /* SpeechModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD317A8D8E749E5596734DB7 /* SpeechModelCatalog.swift */; };
 		1A9C394F69A8A0E9DCA48219 /* ModelManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A098A2516C7563B1E4FDD3 /* ModelManagerTests.swift */; };
+		A1C3E7D91F4B6A8092D3E4F5 /* WhisperCppSpeechBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C3E7D91F4B6A8092D3E4F6 /* WhisperCppSpeechBackend.swift */; };
+		A1C3E7D91F4B6A8092D3E4F7 /* WhisperCppSpeechBackendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C3E7D91F4B6A8092D3E4F8 /* WhisperCppSpeechBackendTests.swift */; };
 		1AB34878C4E7E375F34A1339 /* CleanupModelProbeRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7201BD31C20BC2B1D0E51DB6 /* CleanupModelProbeRunner.swift */; };
 		1AECB19E0AD630641AE8649B /* TranscriptionLabRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F0BBC9BB83FDC0739EF319 /* TranscriptionLabRunner.swift */; };
 		1BA7D7D7A6F2FBFE95CC7206 /* LLM in Frameworks */ = {isa = PBXBuildFile; productRef = 28AB9D6DD22DB83ADFC3F6F3 /* LLM */; };
@@ -241,6 +243,8 @@
 		A1B93B4F9F40EE6BD8525677 /* CleanupModelProbeRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupModelProbeRunnerTests.swift; sourceTree = "<group>"; };
 		A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRContextTests.swift; sourceTree = "<group>"; };
 		A5F781190896573C3BA687CB /* FluidAudioSpeechSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluidAudioSpeechSessionTests.swift; sourceTree = "<group>"; };
+		A1C3E7D91F4B6A8092D3E4F6 /* WhisperCppSpeechBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperCppSpeechBackend.swift; sourceTree = "<group>"; };
+		A1C3E7D91F4B6A8092D3E4F8 /* WhisperCppSpeechBackendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhisperCppSpeechBackendTests.swift; sourceTree = "<group>"; };
 		A91C299194463F439E81D6BC /* ShortcutRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRecorderView.swift; sourceTree = "<group>"; };
 		AA783B889855B0811E210751 /* CleanupPromptEvalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupPromptEvalTests.swift; sourceTree = "<group>"; };
 		AACCB8CD3CFA3BA1C91B5B87 /* MenuBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuBarView.swift; sourceTree = "<group>"; };
@@ -524,6 +528,7 @@
 				F5DEE2CB8B9ED5B0CAE8C152 /* RecordingSessionCoordinator.swift */,
 				BD317A8D8E749E5596734DB7 /* SpeechModelCatalog.swift */,
 				D2CC027B53AAE03079D78761 /* SpeechTranscriber.swift */,
+				A1C3E7D91F4B6A8092D3E4F6 /* WhisperCppSpeechBackend.swift */,
 			);
 			path = Transcription;
 			sourceTree = "<group>";
@@ -606,6 +611,7 @@
 				335E3F3AA3803E2274CF6197 /* TranscriptionLabControllerTests.swift */,
 				48FD8FBD546233B0547BB89D /* TranscriptionLabRunnerTests.swift */,
 				D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */,
+				A1C3E7D91F4B6A8092D3E4F8 /* WhisperCppSpeechBackendTests.swift */,
 			);
 			path = GhostPepperTests;
 			sourceTree = "<group>";
@@ -814,6 +820,7 @@
 				DFAB770908C43B46C21F6986 /* TranscriptionLabStore.swift in Sources */,
 				829C83DF25112D375A8DB767 /* UpdaterController.swift in Sources */,
 				750B0226D3A035D24259B606 /* WindowCaptureService.swift in Sources */,
+				A1C3E7D91F4B6A8092D3E4F5 /* WhisperCppSpeechBackend.swift in Sources */,
 				3B8354B1BAACB0F28DF98815 /* ZoBackend.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -872,6 +879,7 @@
 				F43D0549F804473CD7C8A6A6 /* TranscriptionLabControllerTests.swift in Sources */,
 				950E9B7AB1223E2B2D679B71 /* TranscriptionLabRunnerTests.swift in Sources */,
 				09DA02222FFAFD8F32DB0212 /* TranscriptionLabStoreTests.swift in Sources */,
+				A1C3E7D91F4B6A8092D3E4F7 /* WhisperCppSpeechBackendTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -7,10 +7,13 @@ import WhisperKit
 final class ModelManager: ObservableObject {
     typealias ModelLoadOverride = @MainActor (SpeechModelDescriptor) async throws -> Void
     typealias RetryDelayOverride = @MainActor () async -> Void
+    typealias WhisperCppTranscriptionOverride = WhisperCppSpeechBackend.TranscriptionOverride
+    typealias WhisperCppExecutableURLOverride = WhisperCppSpeechBackend.ExecutableURLOverride
 
     private(set) var whisperKit: WhisperKit?
     private var fluidAudioManager: AsrManager?
     private var sortformerModels: SortformerModels?
+    private var loadedWhisperCppModelURL: URL?
     /// Stored as `Any?` because `Qwen3AsrManager` is `@available(macOS 15, *)`
     /// and the app deploys to macOS 14. Cast at use sites under `#available`.
     private var qwen3AsrManagerStorage: Any?
@@ -39,15 +42,22 @@ final class ModelManager: ObservableObject {
 
     private let modelLoadOverride: ModelLoadOverride?
     private let loadRetryDelayOverride: RetryDelayOverride?
+    private let whisperCppBackend: WhisperCppSpeechBackend
 
     init(
         modelName: String = SpeechModelCatalog.defaultModelID,
         modelLoadOverride: ModelLoadOverride? = nil,
-        loadRetryDelayOverride: RetryDelayOverride? = nil
+        loadRetryDelayOverride: RetryDelayOverride? = nil,
+        whisperCppTranscriptionOverride: WhisperCppTranscriptionOverride? = nil,
+        whisperCppExecutableURLOverride: WhisperCppExecutableURLOverride? = nil
     ) {
         self.modelName = modelName
         self.modelLoadOverride = modelLoadOverride
         self.loadRetryDelayOverride = loadRetryDelayOverride
+        self.whisperCppBackend = WhisperCppSpeechBackend(
+            transcriptionOverride: whisperCppTranscriptionOverride,
+            executableURLOverride: whisperCppExecutableURLOverride
+        )
     }
 
     func loadModel(name: String? = nil) async {
@@ -107,6 +117,8 @@ final class ModelManager: ObservableObject {
         switch requestedModel.backend {
         case .whisperKit:
             try await loadWhisperModel(named: requestedModel.name)
+        case .whisperCpp:
+            try await loadWhisperCppModel(requestedModel)
         case .fluidAudio:
             switch requestedModel.fluidAudioVariant {
             case .qwen3AsrInt8:
@@ -144,6 +156,19 @@ final class ModelManager: ObservableObject {
                     .joined(separator: " ")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 let cleaned = SpeechTranscriber.removeArtifacts(from: text)
+                return cleaned.isEmpty ? nil : cleaned
+            case .whisperCpp:
+                let modelURL = loadedWhisperCppModelURL ?? WhisperCppSpeechBackend.modelURL(for: model)
+                let text = try await whisperCppBackend.transcribe(
+                    model: model,
+                    modelURL: modelURL,
+                    audioBuffer: audioBuffer,
+                    language: language,
+                    debugLogger: debugLogger
+                )
+                let cleaned = SpeechTranscriber.removeArtifacts(
+                    from: text?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) ?? ""
+                )
                 return cleaned.isEmpty ? nil : cleaned
             case .fluidAudio:
                 switch model.fluidAudioVariant {
@@ -243,6 +268,16 @@ final class ModelManager: ObservableObject {
         whisperKit = try await WhisperKit(config)
     }
 
+    private func loadWhisperCppModel(_ model: SpeechModelDescriptor) async throws {
+        let modelURL = try await whisperCppBackend.loadModel(model) { [weak self] progress in
+            Task { @MainActor in
+                self?.downloadProgress = progress
+            }
+        }
+        downloadProgress = nil
+        loadedWhisperCppModelURL = modelURL
+    }
+
     private func loadFluidAudioModel(_ model: SpeechModelDescriptor) async throws {
         guard let fluidAudioVariant = model.fluidAudioVariant else {
             throw NSError(
@@ -318,6 +353,7 @@ final class ModelManager: ObservableObject {
         fluidAudioManager = nil
         sortformerModels = nil
         qwen3AsrManagerStorage = nil
+        loadedWhisperCppModelURL = nil
         downloadProgress = nil
     }
 
@@ -395,6 +431,8 @@ final class ModelManager: ObservableObject {
                 partialURL.appendingPathComponent(component, isDirectory: true)
             }
             try? FileManager.default.removeItem(at: modelPath)
+        case .whisperCpp:
+            WhisperCppSpeechBackend.deleteCachedModel(model)
         case .fluidAudio:
             guard let fluidAudioVariant = model.fluidAudioVariant else { return }
             switch fluidAudioVariant {
@@ -414,6 +452,8 @@ final class ModelManager: ObservableObject {
                 partialURL.appendingPathComponent(component, isDirectory: true)
             }
             return FileManager.default.fileExists(atPath: modelPath.path)
+        case .whisperCpp:
+            return WhisperCppSpeechBackend.modelIsCached(model)
         case .fluidAudio:
             guard let fluidAudioVariant = model.fluidAudioVariant else {
                 return false

--- a/GhostPepper/Transcription/SpeechModelCatalog.swift
+++ b/GhostPepper/Transcription/SpeechModelCatalog.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum SpeechBackendKind: Equatable {
     case whisperKit
+    case whisperCpp
     case fluidAudio
 }
 
@@ -17,6 +18,7 @@ struct SpeechModelDescriptor: Identifiable, Equatable {
     let sizeDescription: String
     let backend: SpeechBackendKind
     let cachePathComponents: [String]
+    let downloadURL: String?
     let fluidAudioVariant: FluidAudioModelVariant?
 
     var id: String { name }
@@ -29,6 +31,8 @@ struct SpeechModelDescriptor: Identifiable, Equatable {
         switch backend {
         case .whisperKit:
             "Whisper \(variantName) (\(pickerTitle.lowercased()))"
+        case .whisperCpp:
+            "\(pickerTitle) (\(variantName.lowercased()))"
         case .fluidAudio:
             "\(pickerTitle) (\(variantName.lowercased()))"
         }
@@ -49,6 +53,7 @@ enum SpeechModelCatalog {
         sizeDescription: "~75 MB",
         backend: .whisperKit,
         cachePathComponents: ["openai", "whisper-tiny.en"],
+        downloadURL: nil,
         fluidAudioVariant: nil
     )
 
@@ -59,6 +64,7 @@ enum SpeechModelCatalog {
         sizeDescription: "~466 MB",
         backend: .whisperKit,
         cachePathComponents: ["openai", "whisper-small.en"],
+        downloadURL: nil,
         fluidAudioVariant: nil
     )
 
@@ -69,6 +75,40 @@ enum SpeechModelCatalog {
         sizeDescription: "~466 MB",
         backend: .whisperKit,
         cachePathComponents: ["openai", "whisper-small"],
+        downloadURL: nil,
+        fluidAudioVariant: nil
+    )
+
+    static let whisperLargeV3Turbo = SpeechModelDescriptor(
+        name: "openai_whisper-large-v3_turbo",
+        pickerTitle: "Large v3 Turbo",
+        variantName: "multilingual",
+        sizeDescription: "~954 MB",
+        backend: .whisperKit,
+        cachePathComponents: ["openai", "whisper-large-v3_turbo"],
+        downloadURL: nil,
+        fluidAudioVariant: nil
+    )
+
+    static let whisperCppLargeV3TurboQuantized = SpeechModelDescriptor(
+        name: "ggml-large-v3-turbo-q5_0",
+        pickerTitle: "whisper.cpp Large v3 Turbo",
+        variantName: "Q5_0 quantized",
+        sizeDescription: "~574 MB",
+        backend: .whisperCpp,
+        cachePathComponents: ["ggml-large-v3-turbo-q5_0.bin"],
+        downloadURL: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
+        fluidAudioVariant: nil
+    )
+
+    static let whisperCppLargeV3Turbo = SpeechModelDescriptor(
+        name: "ggml-large-v3-turbo",
+        pickerTitle: "whisper.cpp Large v3 Turbo",
+        variantName: "F16 full precision",
+        sizeDescription: "~1.5 GB",
+        backend: .whisperCpp,
+        cachePathComponents: ["ggml-large-v3-turbo.bin"],
+        downloadURL: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin",
         fluidAudioVariant: nil
     )
 
@@ -79,6 +119,7 @@ enum SpeechModelCatalog {
         sizeDescription: "~1.4 GB",
         backend: .fluidAudio,
         cachePathComponents: ["FluidInference", "parakeet-tdt-0.6b-v3-coreml"],
+        downloadURL: nil,
         fluidAudioVariant: .parakeetV3
     )
 
@@ -89,6 +130,7 @@ enum SpeechModelCatalog {
         sizeDescription: "~900 MB",
         backend: .fluidAudio,
         cachePathComponents: [],
+        downloadURL: nil,
         fluidAudioVariant: .qwen3AsrInt8
     )
 
@@ -97,6 +139,9 @@ enum SpeechModelCatalog {
         whisperTiny,
         whisperSmallEnglish,
         whisperSmallMultilingual,
+        whisperLargeV3Turbo,
+        whisperCppLargeV3TurboQuantized,
+        whisperCppLargeV3Turbo,
         parakeetV3,
     ]
 
@@ -110,7 +155,7 @@ enum SpeechModelCatalog {
     static let defaultModelID = whisperSmallEnglish.id
 
     static var whisperModels: [SpeechModelDescriptor] {
-        availableModels.filter { $0.backend == .whisperKit }
+        availableModels.filter { $0.backend == .whisperKit || $0.backend == .whisperCpp }
     }
 
     static func model(named name: String) -> SpeechModelDescriptor? {

--- a/GhostPepper/Transcription/WhisperCppSpeechBackend.swift
+++ b/GhostPepper/Transcription/WhisperCppSpeechBackend.swift
@@ -1,0 +1,319 @@
+import Foundation
+
+@MainActor
+final class WhisperCppSpeechBackend {
+    typealias TranscriptionOverride = @MainActor (
+        SpeechModelDescriptor,
+        URL,
+        [Float],
+        String?
+    ) async throws -> String?
+    typealias ExecutableURLOverride = @MainActor () -> URL?
+
+    private let transcriptionOverride: TranscriptionOverride?
+    private let executableURLOverride: ExecutableURLOverride?
+
+    init(
+        transcriptionOverride: TranscriptionOverride? = nil,
+        executableURLOverride: ExecutableURLOverride? = nil
+    ) {
+        self.transcriptionOverride = transcriptionOverride
+        self.executableURLOverride = executableURLOverride
+    }
+
+    func loadModel(
+        _ model: SpeechModelDescriptor,
+        onProgress: @escaping @Sendable (Double) -> Void
+    ) async throws -> URL {
+        let modelURL = Self.modelURL(for: model)
+        guard let executableURL = resolveExecutableURL() else {
+            throw NSError(
+                domain: "GhostPepper.WhisperCppSpeechBackend",
+                code: 503,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "whisper.cpp runtime not found. Install it with `brew install whisper-cpp`."
+                ]
+            )
+        }
+
+        try? FileManager.default.createDirectory(at: Self.modelsDirectory, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(
+            at: modelURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        if !Self.modelIsCached(model) {
+            guard let downloadURLString = model.downloadURL,
+                  let downloadURL = URL(string: downloadURLString) else {
+                throw NSError(
+                    domain: "GhostPepper.WhisperCppSpeechBackend",
+                    code: 500,
+                    userInfo: [NSLocalizedDescriptionKey: "Missing download URL for \(model.name)"]
+                )
+            }
+
+            try await downloadModel(from: downloadURL, to: modelURL, onProgress: onProgress)
+        }
+
+        try await validateModelLoad(modelURL: modelURL, executableURL: executableURL)
+        return modelURL
+    }
+
+    func transcribe(
+        model: SpeechModelDescriptor,
+        modelURL: URL,
+        audioBuffer: [Float],
+        language: String?,
+        debugLogger: ((DebugLogCategory, String) -> Void)? = nil
+    ) async throws -> String? {
+        if let transcriptionOverride {
+            return try await transcriptionOverride(model, modelURL, audioBuffer, language)
+        }
+
+        guard FileManager.default.fileExists(atPath: modelURL.path) else {
+            return nil
+        }
+
+        guard let executableURL = resolveExecutableURL() else {
+            throw NSError(
+                domain: "GhostPepper.WhisperCppSpeechBackend",
+                code: 503,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "whisper.cpp runtime not found. Install it with `brew install whisper-cpp`."
+                ]
+            )
+        }
+
+        let scratchDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "ghost-pepper-whispercpp-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchDirectory) }
+
+        let audioURL = scratchDirectory.appendingPathComponent("input.wav")
+        let outputBaseURL = scratchDirectory.appendingPathComponent("transcript")
+        let audioData = try AudioRecorder.serializePlayableArchiveAudioBuffer(audioBuffer)
+        try audioData.write(to: audioURL)
+
+        let arguments = [
+            "--model", modelURL.path,
+            "--file", audioURL.path,
+            "--output-txt",
+            "--output-file", outputBaseURL.path,
+            "--no-prints",
+            "--no-timestamps",
+            "--language", normalizedLanguage(language),
+        ]
+
+        debugLogger?(.model, "Running whisper.cpp transcription with \(model.name).")
+        try await runProcess(executableURL: executableURL, arguments: arguments)
+
+        let transcriptURL = outputBaseURL.appendingPathExtension("txt")
+        guard FileManager.default.fileExists(atPath: transcriptURL.path) else {
+            return nil
+        }
+
+        let text = try String(contentsOf: transcriptURL, encoding: .utf8)
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func deleteCachedModel(_ model: SpeechModelDescriptor) {
+        try? FileManager.default.removeItem(at: modelURL(for: model))
+    }
+
+    static func modelIsCached(_ model: SpeechModelDescriptor) -> Bool {
+        FileManager.default.fileExists(atPath: modelURL(for: model).path)
+    }
+
+    static func modelURL(for model: SpeechModelDescriptor) -> URL {
+        model.cachePathComponents.reduce(modelsDirectory) { partialURL, component in
+            partialURL.appendingPathComponent(component, isDirectory: false)
+        }
+    }
+
+    private static var modelsDirectory: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("GhostPepper/whisper-cpp-models", isDirectory: true)
+    }
+
+    private func downloadModel(
+        from url: URL,
+        to destination: URL,
+        onProgress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        let delegate = WhisperCppDownloadProgressDelegate(onProgress: onProgress)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let (tempURL, response) = try await session.download(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+
+        try? FileManager.default.removeItem(at: destination)
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+    }
+
+    private func resolveExecutableURL() -> URL? {
+        if let executableURLOverride {
+            return executableURLOverride()
+        }
+
+        let environment = ProcessInfo.processInfo.environment
+        if let explicitPath = environment["GHOSTPEPPER_WHISPER_CPP_CLI"],
+           !explicitPath.isEmpty,
+           FileManager.default.isExecutableFile(atPath: explicitPath) {
+            return URL(fileURLWithPath: explicitPath)
+        }
+
+        for directory in (environment["PATH"] ?? "").split(separator: ":") {
+            let candidate = URL(fileURLWithPath: String(directory)).appendingPathComponent("whisper-cli")
+            if FileManager.default.isExecutableFile(atPath: candidate.path) {
+                return candidate
+            }
+        }
+
+        let fallbackPaths = [
+            "/opt/homebrew/bin/whisper-cli",
+            "/usr/local/bin/whisper-cli",
+        ]
+
+        for path in fallbackPaths where FileManager.default.isExecutableFile(atPath: path) {
+            return URL(fileURLWithPath: path)
+        }
+
+        return nil
+    }
+
+    private func normalizedLanguage(_ language: String?) -> String {
+        guard let language else {
+            return "auto"
+        }
+
+        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "auto" : trimmed
+    }
+
+    private func validateModelLoad(modelURL: URL, executableURL: URL) async throws {
+        let scratchDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "ghost-pepper-whispercpp-validate-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: scratchDirectory) }
+
+        let audioURL = scratchDirectory.appendingPathComponent("validation.wav")
+        let outputBaseURL = scratchDirectory.appendingPathComponent("validation")
+        let silence = [Float](repeating: 0, count: 1_600)
+        let audioData = try AudioRecorder.serializePlayableArchiveAudioBuffer(silence)
+        try audioData.write(to: audioURL)
+
+        try await runProcess(
+            executableURL: executableURL,
+            arguments: [
+                "--model", modelURL.path,
+                "--file", audioURL.path,
+                "--duration", "100",
+                "--output-txt",
+                "--output-file", outputBaseURL.path,
+                "--no-prints",
+                "--no-timestamps",
+                "--language", "en",
+            ]
+        )
+    }
+
+    private func runProcess(executableURL: URL, arguments: [String]) async throws {
+        let outputPipe = Pipe()
+        let outputBuffer = ProcessOutputBuffer()
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let outputHandle = outputPipe.fileHandleForReading
+            outputHandle.readabilityHandler = { handle in
+                let data = handle.availableData
+                if data.isEmpty {
+                    handle.readabilityHandler = nil
+                    return
+                }
+                outputBuffer.append(data)
+            }
+
+            process.terminationHandler = { process in
+                outputHandle.readabilityHandler = nil
+                outputBuffer.append(outputHandle.readDataToEndOfFile())
+                let outputText = outputBuffer.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                if process.terminationStatus == 0 {
+                    continuation.resume(returning: ())
+                    return
+                }
+
+                let message = outputText.isEmpty == false
+                    ? outputText
+                    : "whisper.cpp exited with status \(process.terminationStatus)."
+                continuation.resume(
+                    throwing: NSError(
+                        domain: "GhostPepper.WhisperCppSpeechBackend",
+                        code: Int(process.terminationStatus),
+                        userInfo: [NSLocalizedDescriptionKey: message]
+                    )
+                )
+            }
+
+            do {
+                try process.run()
+            } catch {
+                outputHandle.readabilityHandler = nil
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+
+private final class WhisperCppDownloadProgressDelegate: NSObject, URLSessionDownloadDelegate {
+    let onProgress: @Sendable (Double) -> Void
+
+    init(onProgress: @escaping @Sendable (Double) -> Void) {
+        self.onProgress = onProgress
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        onProgress(Double(totalBytesWritten) / Double(totalBytesExpectedToWrite))
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        // Handled by the async download(from:) call in WhisperCppSpeechBackend.
+    }
+}
+
+private final class ProcessOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ newData: Data) {
+        guard !newData.isEmpty else { return }
+        lock.lock()
+        data.append(newData)
+        lock.unlock()
+    }
+
+    var text: String {
+        lock.lock()
+        let snapshot = data
+        lock.unlock()
+        return String(decoding: snapshot, as: UTF8.self)
+    }
+}

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -757,7 +757,7 @@ struct SettingsView: View {
                     }
                 }
 
-                Text("Ghost Pepper uses this model for speech recognition everywhere in the app.")
+                Text("Ghost Pepper uses this model for speech recognition everywhere in the app. `whisper.cpp` models require the local `whisper-cli` runtime (`brew install whisper-cpp`).")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
@@ -787,7 +787,7 @@ struct SettingsView: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
                             .font(.caption)
-                        Text("You've selected a non-English language but are using an English-only model. Switch to **Multilingual** or **Parakeet v3** above for best results.")
+                        Text("You've selected a non-English language but are using an English-only model. Switch to **Multilingual**, **Large v3 Turbo**, **whisper.cpp Large v3 Turbo**, or **Parakeet v3** above for best results.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -337,11 +337,26 @@ final class GhostPepperTests: XCTestCase {
         let whisperState = RecordingSpeakerFilteringToggleState(
             speechModel: SpeechModelCatalog.whisperSmallEnglish
         )
+        let whisperTurboState = RecordingSpeakerFilteringToggleState(
+            speechModel: SpeechModelCatalog.whisperLargeV3Turbo
+        )
+        let whisperCppQuantizedTurboState = RecordingSpeakerFilteringToggleState(
+            speechModel: SpeechModelCatalog.whisperCppLargeV3TurboQuantized
+        )
+        let whisperCppTurboState = RecordingSpeakerFilteringToggleState(
+            speechModel: SpeechModelCatalog.whisperCppLargeV3Turbo
+        )
 
         XCTAssertTrue(parakeetState.isVisible)
         XCTAssertTrue(parakeetState.isEnabled)
         XCTAssertTrue(whisperState.isVisible)
         XCTAssertFalse(whisperState.isEnabled)
+        XCTAssertTrue(whisperTurboState.isVisible)
+        XCTAssertFalse(whisperTurboState.isEnabled)
+        XCTAssertTrue(whisperCppQuantizedTurboState.isVisible)
+        XCTAssertFalse(whisperCppQuantizedTurboState.isEnabled)
+        XCTAssertTrue(whisperCppTurboState.isVisible)
+        XCTAssertFalse(whisperCppTurboState.isEnabled)
     }
 
     func testAppStateUpdatePostPasteLearningPersistsAndUpdatesCoordinator() throws {

--- a/GhostPepperTests/ModelManagerTests.swift
+++ b/GhostPepperTests/ModelManagerTests.swift
@@ -58,4 +58,107 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .idle)
         XCTAssertNil(manager.error)
     }
+
+    func testModelManagerLoadsWhisperLargeV3TurboThroughOverride() async {
+        var loadedNames: [String] = []
+        let manager = ModelManager(
+            modelName: "openai_whisper-large-v3_turbo",
+            modelLoadOverride: { descriptor in
+                loadedNames.append(descriptor.name)
+            },
+            loadRetryDelayOverride: {}
+        )
+
+        await manager.loadModel()
+
+        XCTAssertEqual(manager.state, .ready)
+        XCTAssertNil(manager.error)
+        XCTAssertEqual(loadedNames, ["openai_whisper-large-v3_turbo"])
+    }
+
+    func testDeleteCachedLargeV3TurboNotifiesObserversForInventoryRefresh() throws {
+        let manager = ModelManager(modelName: "openai_whisper-small.en")
+        let expectation = expectation(description: "large v3 turbo deletion publishes change")
+        var cancellable: AnyCancellable? = manager.objectWillChange.sink {
+            expectation.fulfill()
+        }
+
+        let model = try XCTUnwrap(SpeechModelCatalog.model(named: "openai_whisper-large-v3_turbo"))
+        manager.deleteCachedModel(model)
+
+        wait(for: [expectation], timeout: 1.0)
+        withExtendedLifetime(cancellable) {}
+        cancellable = nil
+    }
+
+    func testModelManagerLoadsWhisperCppQuantizedTurboThroughOverride() async {
+        var loadedNames: [String] = []
+        let manager = ModelManager(
+            modelName: "ggml-large-v3-turbo-q5_0",
+            modelLoadOverride: { descriptor in
+                loadedNames.append(descriptor.name)
+            },
+            loadRetryDelayOverride: {}
+        )
+
+        await manager.loadModel()
+
+        XCTAssertEqual(manager.state, .ready)
+        XCTAssertNil(manager.error)
+        XCTAssertEqual(loadedNames, ["ggml-large-v3-turbo-q5_0"])
+    }
+
+    func testDeleteCachedWhisperCppQuantizedTurboNotifiesObserversForInventoryRefresh() throws {
+        let manager = ModelManager(modelName: "openai_whisper-small.en")
+        let expectation = expectation(description: "whisper.cpp quantized turbo deletion publishes change")
+        var cancellable: AnyCancellable? = manager.objectWillChange.sink {
+            expectation.fulfill()
+        }
+
+        let model = try XCTUnwrap(SpeechModelCatalog.model(named: "ggml-large-v3-turbo-q5_0"))
+        manager.deleteCachedModel(model)
+
+        wait(for: [expectation], timeout: 1.0)
+        withExtendedLifetime(cancellable) {}
+        cancellable = nil
+    }
+
+    func testDeleteCachedWhisperCppTurboNotifiesObserversForInventoryRefresh() throws {
+        let manager = ModelManager(modelName: "openai_whisper-small.en")
+        let expectation = expectation(description: "whisper.cpp turbo deletion publishes change")
+        var cancellable: AnyCancellable? = manager.objectWillChange.sink {
+            expectation.fulfill()
+        }
+
+        let model = try XCTUnwrap(SpeechModelCatalog.model(named: "ggml-large-v3-turbo"))
+        manager.deleteCachedModel(model)
+
+        wait(for: [expectation], timeout: 1.0)
+        withExtendedLifetime(cancellable) {}
+        cancellable = nil
+    }
+
+    func testModelManagerReportsErrorWhenWhisperCppValidationFails() async throws {
+        let model = try XCTUnwrap(SpeechModelCatalog.model(named: "ggml-large-v3-turbo-q5_0"))
+        let modelURL = WhisperCppSpeechBackend.modelURL(for: model)
+        try FileManager.default.createDirectory(
+            at: modelURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("test".utf8).write(to: modelURL)
+        defer { try? FileManager.default.removeItem(at: modelURL) }
+
+        let manager = ModelManager(
+            modelName: model.name,
+            loadRetryDelayOverride: {},
+            whisperCppExecutableURLOverride: {
+                URL(fileURLWithPath: "/usr/bin/false")
+            }
+        )
+
+        await manager.loadModel()
+
+        XCTAssertEqual(manager.state, .error)
+        XCTAssertNotNil(manager.error)
+    }
 }

--- a/GhostPepperTests/PerformanceTraceTests.swift
+++ b/GhostPepperTests/PerformanceTraceTests.swift
@@ -62,4 +62,61 @@ final class PerformanceTraceTests: XCTestCase {
 
         XCTAssertTrue(summary.contains("cleanup=skipped"))
     }
+
+    func testSummaryIncludesWhisperLargeV3TurboSpeechModelID() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 300)
+        var trace = PerformanceTrace(sessionID: "session-3", startedAt: startedAt)
+        trace.hotkeyDetectedAt = startedAt
+        trace.micLiveAt = startedAt.addingTimeInterval(0.05)
+        trace.hotkeyLiftedAt = startedAt.addingTimeInterval(0.90)
+        trace.micColdAt = startedAt.addingTimeInterval(1.10)
+        trace.transcriptionStartAt = startedAt.addingTimeInterval(1.10)
+        trace.transcriptionEndAt = startedAt.addingTimeInterval(1.75)
+
+        let summary = trace.summary(
+            speechModelID: "openai_whisper-large-v3_turbo",
+            cleanupBackend: .localModels,
+            cleanupAttempted: false
+        )
+
+        XCTAssertTrue(summary.contains("speechModel=openai_whisper-large-v3_turbo"))
+    }
+
+    func testSummaryIncludesWhisperCppLargeV3TurboQuantizedSpeechModelID() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 400)
+        var trace = PerformanceTrace(sessionID: "session-4", startedAt: startedAt)
+        trace.hotkeyDetectedAt = startedAt
+        trace.micLiveAt = startedAt.addingTimeInterval(0.04)
+        trace.hotkeyLiftedAt = startedAt.addingTimeInterval(0.82)
+        trace.micColdAt = startedAt.addingTimeInterval(1.01)
+        trace.transcriptionStartAt = startedAt.addingTimeInterval(1.01)
+        trace.transcriptionEndAt = startedAt.addingTimeInterval(1.71)
+
+        let summary = trace.summary(
+            speechModelID: "ggml-large-v3-turbo-q5_0",
+            cleanupBackend: .localModels,
+            cleanupAttempted: false
+        )
+
+        XCTAssertTrue(summary.contains("speechModel=ggml-large-v3-turbo-q5_0"))
+    }
+
+    func testSummaryIncludesWhisperCppLargeV3TurboSpeechModelID() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 500)
+        var trace = PerformanceTrace(sessionID: "session-5", startedAt: startedAt)
+        trace.hotkeyDetectedAt = startedAt
+        trace.micLiveAt = startedAt.addingTimeInterval(0.06)
+        trace.hotkeyLiftedAt = startedAt.addingTimeInterval(0.95)
+        trace.micColdAt = startedAt.addingTimeInterval(1.16)
+        trace.transcriptionStartAt = startedAt.addingTimeInterval(1.16)
+        trace.transcriptionEndAt = startedAt.addingTimeInterval(1.89)
+
+        let summary = trace.summary(
+            speechModelID: "ggml-large-v3-turbo",
+            cleanupBackend: .localModels,
+            cleanupAttempted: false
+        )
+
+        XCTAssertTrue(summary.contains("speechModel=ggml-large-v3-turbo"))
+    }
 }

--- a/GhostPepperTests/RuntimeModelInventoryTests.swift
+++ b/GhostPepperTests/RuntimeModelInventoryTests.swift
@@ -18,6 +18,9 @@ final class RuntimeModelInventoryTests: XCTestCase {
         XCTAssertTrue(rows.map(\.name).contains("Whisper tiny.en (speed)"))
         XCTAssertTrue(rows.map(\.name).contains("Whisper small.en (accuracy)"))
         XCTAssertTrue(rows.map(\.name).contains("Whisper small (multilingual)"))
+        XCTAssertTrue(rows.map(\.name).contains("Whisper multilingual (large v3 turbo)"))
+        XCTAssertTrue(rows.map(\.name).contains("whisper.cpp Large v3 Turbo (q5_0 quantized)"))
+        XCTAssertTrue(rows.map(\.name).contains("whisper.cpp Large v3 Turbo (f16 full precision)"))
         XCTAssertTrue(rows.map(\.name).contains("Parakeet v3 (25 languages)"))
         XCTAssertTrue(rows.map(\.name).contains("Qwen 3.5 0.8B Q4_K_M (Very fast)"))
         XCTAssertTrue(rows.map(\.name).contains("Qwen 3.5 2B Q4_K_M (Fast)"))
@@ -31,6 +34,15 @@ final class RuntimeModelInventoryTests: XCTestCase {
 
         XCTAssertEqual(row(named: "Whisper small (multilingual)", in: rows)?.status, .notLoaded)
         XCTAssertEqual(row(named: "Whisper small (multilingual)", in: rows)?.isSelected, false)
+
+        XCTAssertEqual(row(named: "Whisper multilingual (large v3 turbo)", in: rows)?.status, .notLoaded)
+        XCTAssertEqual(row(named: "Whisper multilingual (large v3 turbo)", in: rows)?.isSelected, false)
+
+        XCTAssertEqual(row(named: "whisper.cpp Large v3 Turbo (q5_0 quantized)", in: rows)?.status, .notLoaded)
+        XCTAssertEqual(row(named: "whisper.cpp Large v3 Turbo (q5_0 quantized)", in: rows)?.isSelected, false)
+
+        XCTAssertEqual(row(named: "whisper.cpp Large v3 Turbo (f16 full precision)", in: rows)?.status, .notLoaded)
+        XCTAssertEqual(row(named: "whisper.cpp Large v3 Turbo (f16 full precision)", in: rows)?.isSelected, false)
 
         XCTAssertEqual(row(named: "Parakeet v3 (25 languages)", in: rows)?.status, .notLoaded)
         XCTAssertEqual(row(named: "Parakeet v3 (25 languages)", in: rows)?.isSelected, false)

--- a/GhostPepperTests/SpeechTranscriberTests.swift
+++ b/GhostPepperTests/SpeechTranscriberTests.swift
@@ -12,12 +12,18 @@ final class SpeechTranscriberTests: XCTestCase {
             "openai_whisper-tiny.en",
             "openai_whisper-small.en",
             "openai_whisper-small",
+            "openai_whisper-large-v3_turbo",
+            "ggml-large-v3-turbo-q5_0",
+            "ggml-large-v3-turbo",
             "fluid_parakeet-v3",
         ]
         let baseBackends: [SpeechBackendKind] = [
             .whisperKit,
             .whisperKit,
             .whisperKit,
+            .whisperKit,
+            .whisperCpp,
+            .whisperCpp,
             .fluidAudio,
         ]
 
@@ -32,13 +38,26 @@ final class SpeechTranscriberTests: XCTestCase {
         XCTAssertEqual(SpeechModelCatalog.defaultModelID, "openai_whisper-small.en")
     }
 
-    func testFluidAudioSpeechModelsSupportSpeakerFiltering() {
+    func testSpeechModelsOnlySupportSpeakerFilteringForParakeet() {
         XCTAssertFalse(SpeechModelCatalog.whisperTiny.supportsSpeakerFiltering)
         XCTAssertFalse(SpeechModelCatalog.whisperSmallEnglish.supportsSpeakerFiltering)
         XCTAssertFalse(SpeechModelCatalog.whisperSmallMultilingual.supportsSpeakerFiltering)
+        XCTAssertFalse(SpeechModelCatalog.whisperLargeV3Turbo.supportsSpeakerFiltering)
+        XCTAssertFalse(SpeechModelCatalog.whisperCppLargeV3TurboQuantized.supportsSpeakerFiltering)
+        XCTAssertFalse(SpeechModelCatalog.whisperCppLargeV3Turbo.supportsSpeakerFiltering)
         XCTAssertTrue(SpeechModelCatalog.parakeetV3.supportsSpeakerFiltering)
         // Qwen3-ASR is an encoder-decoder without a diarization output.
         XCTAssertFalse(SpeechModelCatalog.qwen3AsrInt8.supportsSpeakerFiltering)
+    }
+
+    func testWhisperLargeV3TurboDescriptor() {
+        let model = SpeechModelCatalog.whisperLargeV3Turbo
+        XCTAssertEqual(model.name, "openai_whisper-large-v3_turbo")
+        XCTAssertEqual(model.backend, .whisperKit)
+        XCTAssertNil(model.fluidAudioVariant)
+        XCTAssertTrue(model.pickerLabel.contains("Large v3 Turbo"))
+        XCTAssertTrue(model.pickerLabel.contains("multilingual"))
+        XCTAssertTrue(model.pickerLabel.contains("~954 MB"))
     }
 
     func testQwen3AsrInt8Descriptor() {
@@ -49,6 +68,26 @@ final class SpeechTranscriberTests: XCTestCase {
         XCTAssertTrue(model.pickerLabel.contains("Qwen3-ASR 0.6B"))
         XCTAssertTrue(model.pickerLabel.contains("int8"))
         XCTAssertTrue(model.pickerLabel.contains("~900 MB"))
+    }
+
+    func testWhisperCppLargeV3TurboQuantizedDescriptor() {
+        let model = SpeechModelCatalog.whisperCppLargeV3TurboQuantized
+        XCTAssertEqual(model.name, "ggml-large-v3-turbo-q5_0")
+        XCTAssertEqual(model.backend, .whisperCpp)
+        XCTAssertNil(model.fluidAudioVariant)
+        XCTAssertEqual(model.downloadURL, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin")
+        XCTAssertTrue(model.pickerLabel.contains("Q5_0 quantized"))
+        XCTAssertTrue(model.pickerLabel.contains("~574 MB"))
+    }
+
+    func testWhisperCppLargeV3TurboFullPrecisionDescriptor() {
+        let model = SpeechModelCatalog.whisperCppLargeV3Turbo
+        XCTAssertEqual(model.name, "ggml-large-v3-turbo")
+        XCTAssertEqual(model.backend, .whisperCpp)
+        XCTAssertNil(model.fluidAudioVariant)
+        XCTAssertEqual(model.downloadURL, "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo.bin")
+        XCTAssertTrue(model.pickerLabel.contains("F16 full precision"))
+        XCTAssertTrue(model.pickerLabel.contains("~1.5 GB"))
     }
 
     func testQwen3ModelLookupIsAvailableOnSupportedOS() {
@@ -117,7 +156,7 @@ final class SpeechTranscriberTests: XCTestCase {
         XCTAssertNil(result, "Should return nil when model is not loaded")
     }
 
-    // MARK: - Qwen3-ASR ModelManager Tests
+    // MARK: - Additional ModelManager Tests
 
     func testModelManagerLoadsQwen3AsrModelThroughOverride() async throws {
         guard #available(macOS 15, iOS 18, *) else {
@@ -140,6 +179,62 @@ final class SpeechTranscriberTests: XCTestCase {
         XCTAssertEqual(loadedDescriptors.count, 1)
         XCTAssertEqual(loadedDescriptors.first?.name, "fluid_qwen3-asr-0.6b-int8")
         XCTAssertEqual(loadedDescriptors.first?.fluidAudioVariant, .qwen3AsrInt8)
+    }
+
+    func testModelManagerLoadsWhisperCppQuantizedModelThroughOverride() async {
+        var loadedDescriptors: [SpeechModelDescriptor] = []
+        let manager = ModelManager(
+            modelName: "ggml-large-v3-turbo-q5_0",
+            modelLoadOverride: { descriptor in
+                loadedDescriptors.append(descriptor)
+            },
+            loadRetryDelayOverride: {}
+        )
+
+        await manager.loadModel()
+
+        XCTAssertEqual(manager.state, .ready)
+        XCTAssertNil(manager.error)
+        XCTAssertEqual(loadedDescriptors.map(\.name), ["ggml-large-v3-turbo-q5_0"])
+        XCTAssertEqual(loadedDescriptors.first?.backend, .whisperCpp)
+    }
+
+    func testModelManagerLoadsWhisperCppFullPrecisionModelThroughOverride() async {
+        var loadedDescriptors: [SpeechModelDescriptor] = []
+        let manager = ModelManager(
+            modelName: "ggml-large-v3-turbo",
+            modelLoadOverride: { descriptor in
+                loadedDescriptors.append(descriptor)
+            },
+            loadRetryDelayOverride: {}
+        )
+
+        await manager.loadModel()
+
+        XCTAssertEqual(manager.state, .ready)
+        XCTAssertNil(manager.error)
+        XCTAssertEqual(loadedDescriptors.map(\.name), ["ggml-large-v3-turbo"])
+        XCTAssertEqual(loadedDescriptors.first?.backend, .whisperCpp)
+    }
+
+    func testWhisperCppTranscriptionOverrideReturnsTrimmedTranscript() async {
+        let manager = ModelManager(
+            modelName: "ggml-large-v3-turbo-q5_0",
+            modelLoadOverride: { _ in },
+            loadRetryDelayOverride: {},
+            whisperCppTranscriptionOverride: { descriptor, modelURL, audioBuffer, language in
+                XCTAssertEqual(descriptor.name, "ggml-large-v3-turbo-q5_0")
+                XCTAssertTrue(modelURL.lastPathComponent.contains("ggml-large-v3-turbo-q5_0.bin"))
+                XCTAssertEqual(audioBuffer, [0.1, 0.2, 0.3])
+                XCTAssertEqual(language, "auto")
+                return " whisper.cpp transcript "
+            }
+        )
+
+        await manager.loadModel()
+        let result = await manager.transcribe(audioBuffer: [0.1, 0.2, 0.3], language: "auto")
+
+        XCTAssertEqual(result, "whisper.cpp transcript")
     }
 
     func testModelManagerSurfacesQwen3LoadFailure() async throws {

--- a/GhostPepperTests/TranscriptionLabControllerTests.swift
+++ b/GhostPepperTests/TranscriptionLabControllerTests.swift
@@ -87,6 +87,66 @@ final class TranscriptionLabControllerTests: XCTestCase {
         XCTAssertEqual(synchronizedCleanupModelKinds, [.qwen35_2b_q4_k_m])
     }
 
+    func testChangingRerunModelsSupportsWhisperLargeV3Turbo() {
+        var synchronizedSpeechModelIDs: [String] = []
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultCleanupModelKind: .qwen35_4b_q4_k_m,
+            loadStageTimings: { [:] },
+            loadEntries: { [] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, _ in "" },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            },
+            syncSelectedSpeechModelID: { synchronizedSpeechModelIDs.append($0) }
+        )
+
+        controller.selectedSpeechModelID = "openai_whisper-large-v3_turbo"
+
+        XCTAssertEqual(synchronizedSpeechModelIDs, ["openai_whisper-large-v3_turbo"])
+    }
+
+    func testChangingRerunModelsSupportsWhisperCppLargeV3TurboQuantized() {
+        var synchronizedSpeechModelIDs: [String] = []
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultCleanupModelKind: .qwen35_4b_q4_k_m,
+            loadStageTimings: { [:] },
+            loadEntries: { [] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, _ in "" },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            },
+            syncSelectedSpeechModelID: { synchronizedSpeechModelIDs.append($0) }
+        )
+
+        controller.selectedSpeechModelID = "ggml-large-v3-turbo-q5_0"
+
+        XCTAssertEqual(synchronizedSpeechModelIDs, ["ggml-large-v3-turbo-q5_0"])
+    }
+
+    func testChangingRerunModelsSupportsWhisperCppLargeV3Turbo() {
+        var synchronizedSpeechModelIDs: [String] = []
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultCleanupModelKind: .qwen35_4b_q4_k_m,
+            loadStageTimings: { [:] },
+            loadEntries: { [] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, _ in "" },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            },
+            syncSelectedSpeechModelID: { synchronizedSpeechModelIDs.append($0) }
+        )
+
+        controller.selectedSpeechModelID = "ggml-large-v3-turbo"
+
+        XCTAssertEqual(synchronizedSpeechModelIDs, ["ggml-large-v3-turbo"])
+    }
+
     func testStageRerunsUpdateExperimentOutputs() async {
         let entry = makeEntry(
             createdAt: Date(),
@@ -159,6 +219,99 @@ final class TranscriptionLabControllerTests: XCTestCase {
         XCTAssertEqual(controller.latestCleanupTranscript?.rawModelOutput, "clean rerun raw")
         XCTAssertNil(controller.errorMessage)
         XCTAssertNil(controller.runningStage)
+    }
+
+    func testStageRerunsUseWhisperLargeV3TurboSelection() async {
+        let entry = makeEntry(
+            createdAt: Date(),
+            speechModelID: "openai_whisper-small.en",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)"
+        )
+        var executedSpeechModelID: String?
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            loadStageTimings: { [:] },
+            loadEntries: { [entry] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, speechModelID in
+                executedSpeechModelID = speechModelID
+                return "raw rerun"
+            },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            }
+        )
+
+        controller.reloadEntries()
+        controller.selectEntry(entry.id)
+        controller.selectedSpeechModelID = "openai_whisper-large-v3_turbo"
+
+        await controller.rerunTranscription()
+
+        XCTAssertEqual(executedSpeechModelID, "openai_whisper-large-v3_turbo")
+        XCTAssertEqual(controller.experimentRawTranscription, "raw rerun")
+    }
+
+    func testStageRerunsUseWhisperCppLargeV3TurboQuantizedSelection() async {
+        let entry = makeEntry(
+            createdAt: Date(),
+            speechModelID: "openai_whisper-small.en",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)"
+        )
+        var executedSpeechModelID: String?
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            loadStageTimings: { [:] },
+            loadEntries: { [entry] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, speechModelID in
+                executedSpeechModelID = speechModelID
+                return "whisper.cpp rerun"
+            },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            }
+        )
+
+        controller.reloadEntries()
+        controller.selectEntry(entry.id)
+        controller.selectedSpeechModelID = "ggml-large-v3-turbo-q5_0"
+
+        await controller.rerunTranscription()
+
+        XCTAssertEqual(executedSpeechModelID, "ggml-large-v3-turbo-q5_0")
+        XCTAssertEqual(controller.experimentRawTranscription, "whisper.cpp rerun")
+    }
+
+    func testStageRerunsUseWhisperCppLargeV3TurboSelection() async {
+        let entry = makeEntry(
+            createdAt: Date(),
+            speechModelID: "openai_whisper-small.en",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)"
+        )
+        var executedSpeechModelID: String?
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            loadStageTimings: { [:] },
+            loadEntries: { [entry] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, speechModelID in
+                executedSpeechModelID = speechModelID
+                return "whisper.cpp full rerun"
+            },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            }
+        )
+
+        controller.reloadEntries()
+        controller.selectEntry(entry.id)
+        controller.selectedSpeechModelID = "ggml-large-v3-turbo"
+
+        await controller.rerunTranscription()
+
+        XCTAssertEqual(executedSpeechModelID, "ggml-large-v3-turbo")
+        XCTAssertEqual(controller.experimentRawTranscription, "whisper.cpp full rerun")
     }
 
     func testDisplayedExperimentOutputsDefaultToOriginalOutputs() {

--- a/GhostPepperTests/TranscriptionLabRunnerTests.swift
+++ b/GhostPepperTests/TranscriptionLabRunnerTests.swift
@@ -122,6 +122,126 @@ final class TranscriptionLabRunnerTests: XCTestCase {
         }
     }
 
+    func testRunnerLoadsWhisperLargeV3TurboForRerunTranscription() async throws {
+        let entry = TranscriptionLabEntry(
+            id: UUID(),
+            createdAt: Date(),
+            audioFileName: "sample.bin",
+            audioDuration: 1.5,
+            windowContext: OCRContext(windowContents: "Large v3 Turbo"),
+            rawTranscription: "raw",
+            correctedTranscription: "corrected",
+            speechModelID: "openai_whisper-small.en",
+            cleanupModelName: "Qwen 3.5 4B (full cleanup)",
+            cleanupUsedFallback: false
+        )
+        var loadedSpeechModels: [String] = []
+        let runner = TranscriptionLabRunner(
+            loadAudioBuffer: { _ in [0.1, 0.2] },
+            loadSpeechModel: { modelID in
+                loadedSpeechModels.append(modelID)
+            },
+            transcribe: { _ in "turbo raw text" },
+            clean: { _, _, _ in
+                TextCleanerResult(
+                    text: "",
+                    performance: TextCleanerPerformance(modelCallDuration: nil, postProcessDuration: nil)
+                )
+            },
+            correctionStore: CorrectionStore(defaults: UserDefaults(suiteName: #function)!)
+        )
+
+        let rawTranscription = try await runner.rerunTranscription(
+            entry: entry,
+            speechModelID: "openai_whisper-large-v3_turbo",
+            acquirePipeline: { true },
+            releasePipeline: {}
+        )
+
+        XCTAssertEqual(loadedSpeechModels, ["openai_whisper-large-v3_turbo"])
+        XCTAssertEqual(rawTranscription, "turbo raw text")
+    }
+
+    func testRunnerLoadsWhisperCppLargeV3TurboQuantizedForRerunTranscription() async throws {
+        let entry = TranscriptionLabEntry(
+            id: UUID(),
+            createdAt: Date(),
+            audioFileName: "sample.bin",
+            audioDuration: 1.5,
+            windowContext: OCRContext(windowContents: "whisper.cpp"),
+            rawTranscription: "raw",
+            correctedTranscription: "corrected",
+            speechModelID: "openai_whisper-small.en",
+            cleanupModelName: "Qwen 3.5 4B (full cleanup)",
+            cleanupUsedFallback: false
+        )
+        var loadedSpeechModels: [String] = []
+        let runner = TranscriptionLabRunner(
+            loadAudioBuffer: { _ in [0.1, 0.2] },
+            loadSpeechModel: { modelID in
+                loadedSpeechModels.append(modelID)
+            },
+            transcribe: { _ in "whisper.cpp raw text" },
+            clean: { _, _, _ in
+                TextCleanerResult(
+                    text: "",
+                    performance: TextCleanerPerformance(modelCallDuration: nil, postProcessDuration: nil)
+                )
+            },
+            correctionStore: CorrectionStore(defaults: UserDefaults(suiteName: #function)!)
+        )
+
+        let rawTranscription = try await runner.rerunTranscription(
+            entry: entry,
+            speechModelID: "ggml-large-v3-turbo-q5_0",
+            acquirePipeline: { true },
+            releasePipeline: {}
+        )
+
+        XCTAssertEqual(loadedSpeechModels, ["ggml-large-v3-turbo-q5_0"])
+        XCTAssertEqual(rawTranscription, "whisper.cpp raw text")
+    }
+
+    func testRunnerLoadsWhisperCppLargeV3TurboForRerunTranscription() async throws {
+        let entry = TranscriptionLabEntry(
+            id: UUID(),
+            createdAt: Date(),
+            audioFileName: "sample.bin",
+            audioDuration: 1.5,
+            windowContext: OCRContext(windowContents: "whisper.cpp full"),
+            rawTranscription: "raw",
+            correctedTranscription: "corrected",
+            speechModelID: "openai_whisper-small.en",
+            cleanupModelName: "Qwen 3.5 4B (full cleanup)",
+            cleanupUsedFallback: false
+        )
+        var loadedSpeechModels: [String] = []
+        let runner = TranscriptionLabRunner(
+            loadAudioBuffer: { _ in [0.1, 0.2] },
+            loadSpeechModel: { modelID in
+                loadedSpeechModels.append(modelID)
+            },
+            transcribe: { _ in "whisper.cpp full raw text" },
+            clean: { _, _, _ in
+                TextCleanerResult(
+                    text: "",
+                    performance: TextCleanerPerformance(modelCallDuration: nil, postProcessDuration: nil)
+                )
+            },
+            correctionStore: CorrectionStore(defaults: UserDefaults(suiteName: #function)!)
+        )
+
+        let rawTranscription = try await runner.rerunTranscription(
+            entry: entry,
+            speechModelID: "ggml-large-v3-turbo",
+            acquirePipeline: { true },
+            releasePipeline: {}
+        )
+
+        XCTAssertEqual(loadedSpeechModels, ["ggml-large-v3-turbo"])
+        XCTAssertEqual(rawTranscription, "whisper.cpp full raw text")
+    }
+
     func testRunnerReportsCleanupFallbackWhenModelDidNotRun() async throws {
         let runner = TranscriptionLabRunner(
             loadAudioBuffer: { _ in [0.1] },

--- a/GhostPepperTests/TranscriptionLabStoreTests.swift
+++ b/GhostPepperTests/TranscriptionLabStoreTests.swift
@@ -189,6 +189,66 @@ final class TranscriptionLabStoreTests: XCTestCase {
         XCTAssertEqual(decoded.speakerFilteringUsedFallback, false)
     }
 
+    func testEntryRoundTripsWhisperLargeV3TurboSpeechModelID() throws {
+        let entry = TranscriptionLabEntry(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000033")!,
+            createdAt: Date(timeIntervalSince1970: 987),
+            audioFileName: "turbo.wav",
+            audioDuration: 2.0,
+            windowContext: OCRContext(windowContents: "Turbo"),
+            rawTranscription: "turbo raw",
+            correctedTranscription: "turbo corrected",
+            speechModelID: "openai_whisper-large-v3_turbo",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)",
+            cleanupUsedFallback: false
+        )
+
+        let encoded = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(TranscriptionLabEntry.self, from: encoded)
+
+        XCTAssertEqual(decoded.speechModelID, "openai_whisper-large-v3_turbo")
+    }
+
+    func testEntryRoundTripsWhisperCppLargeV3TurboQuantizedSpeechModelID() throws {
+        let entry = TranscriptionLabEntry(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000034")!,
+            createdAt: Date(timeIntervalSince1970: 988),
+            audioFileName: "turbo-q5.wav",
+            audioDuration: 2.0,
+            windowContext: OCRContext(windowContents: "Turbo Q5"),
+            rawTranscription: "turbo q5 raw",
+            correctedTranscription: "turbo q5 corrected",
+            speechModelID: "ggml-large-v3-turbo-q5_0",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)",
+            cleanupUsedFallback: false
+        )
+
+        let encoded = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(TranscriptionLabEntry.self, from: encoded)
+
+        XCTAssertEqual(decoded.speechModelID, "ggml-large-v3-turbo-q5_0")
+    }
+
+    func testEntryRoundTripsWhisperCppLargeV3TurboSpeechModelID() throws {
+        let entry = TranscriptionLabEntry(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000035")!,
+            createdAt: Date(timeIntervalSince1970: 989),
+            audioFileName: "turbo-f16.wav",
+            audioDuration: 2.0,
+            windowContext: OCRContext(windowContents: "Turbo F16"),
+            rawTranscription: "turbo f16 raw",
+            correctedTranscription: "turbo f16 corrected",
+            speechModelID: "ggml-large-v3-turbo",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)",
+            cleanupUsedFallback: false
+        )
+
+        let encoded = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(TranscriptionLabEntry.self, from: encoded)
+
+        XCTAssertEqual(decoded.speechModelID, "ggml-large-v3-turbo")
+    }
+
     func testTranscriptionLabStorePersistsDiarizationSummary() throws {
         let fixture = makeFixture()
         let store = TranscriptionLabStore(

--- a/GhostPepperTests/WhisperCppSpeechBackendTests.swift
+++ b/GhostPepperTests/WhisperCppSpeechBackendTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class WhisperCppSpeechBackendTests: XCTestCase {
+    func testModelURLBuildsPathInsideWhisperCppCacheDirectory() {
+        let model = makeTestModel(cachePathComponents: ["unit-tests", "path-check", "model.bin"])
+
+        let modelURL = WhisperCppSpeechBackend.modelURL(for: model)
+
+        XCTAssertTrue(modelURL.path.contains("/Application Support/GhostPepper/whisper-cpp-models/"))
+        XCTAssertTrue(modelURL.path.hasSuffix("/unit-tests/path-check/model.bin"))
+    }
+
+    func testLoadModelFailsWhenUncachedModelHasNoDownloadURL() async {
+        let model = makeTestModel(
+            cachePathComponents: ["unit-tests", UUID().uuidString, "missing-download.bin"],
+            downloadURL: nil
+        )
+        let backend = WhisperCppSpeechBackend(executableURLOverride: {
+            URL(fileURLWithPath: "/usr/bin/true")
+        })
+
+        await XCTAssertThrowsErrorAsync(try await backend.loadModel(model) { _ in }) { error in
+            XCTAssertTrue(error.localizedDescription.contains("Missing download URL"))
+        }
+    }
+
+    func testLoadModelFailsBeforeDownloadingWhenRuntimeIsMissing() async {
+        let model = makeTestModel(
+            cachePathComponents: ["unit-tests", UUID().uuidString, "runtime-missing.bin"],
+            downloadURL: "https://example.com/should-not-download.bin"
+        )
+        let backend = WhisperCppSpeechBackend(executableURLOverride: { nil })
+
+        await XCTAssertThrowsErrorAsync(try await backend.loadModel(model) { _ in }) { error in
+            XCTAssertTrue(error.localizedDescription.contains("whisper.cpp runtime not found"))
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: WhisperCppSpeechBackend.modelURL(for: model).path))
+    }
+
+    func testLoadModelFailsWhenRuntimeIsMissingEvenIfModelIsCached() async throws {
+        let model = makeTestModel(cachePathComponents: ["unit-tests", UUID().uuidString, "cached.bin"])
+        let cachedURL = try cacheModelFile(for: model)
+        defer { try? FileManager.default.removeItem(at: cachedURL.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let backend = WhisperCppSpeechBackend(executableURLOverride: { nil })
+
+        await XCTAssertThrowsErrorAsync(try await backend.loadModel(model) { _ in }) { error in
+            XCTAssertTrue(error.localizedDescription.contains("whisper.cpp runtime not found"))
+        }
+    }
+
+    func testLoadModelReturnsCachedURLWhenRuntimeExists() async throws {
+        let model = makeTestModel(cachePathComponents: ["unit-tests", UUID().uuidString, "cached.bin"])
+        let cachedURL = try cacheModelFile(for: model)
+        defer { try? FileManager.default.removeItem(at: cachedURL.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let backend = WhisperCppSpeechBackend(executableURLOverride: {
+            URL(fileURLWithPath: "/usr/bin/true")
+        })
+
+        let loadedURL = try await backend.loadModel(model) { _ in }
+
+        XCTAssertEqual(loadedURL, cachedURL)
+    }
+
+    func testLoadModelFailsWhenValidationCommandReturnsNonZero() async throws {
+        let model = makeTestModel(cachePathComponents: ["unit-tests", UUID().uuidString, "invalid.bin"])
+        let cachedURL = try cacheModelFile(for: model)
+        defer { try? FileManager.default.removeItem(at: cachedURL.deletingLastPathComponent().deletingLastPathComponent()) }
+
+        let backend = WhisperCppSpeechBackend(executableURLOverride: {
+            URL(fileURLWithPath: "/usr/bin/false")
+        })
+
+        await XCTAssertThrowsErrorAsync(try await backend.loadModel(model) { _ in }) { error in
+            XCTAssertTrue(error.localizedDescription.contains("whisper.cpp exited with status"))
+        }
+    }
+
+    func testTranscriptionOverrideReceivesWhisperCppInputs() async throws {
+        let expectedModelURL = URL(fileURLWithPath: "/tmp/test-model.bin")
+        let backend = WhisperCppSpeechBackend(
+            transcriptionOverride: { model, modelURL, audioBuffer, language in
+                XCTAssertEqual(model.name, "ggml-large-v3-turbo-q5_0")
+                XCTAssertEqual(modelURL, expectedModelURL)
+                XCTAssertEqual(audioBuffer, [0.1, 0.2, 0.3])
+                XCTAssertEqual(language, "en")
+                return " override transcript "
+            },
+            executableURLOverride: { nil }
+        )
+
+        let transcript = try await backend.transcribe(
+            model: SpeechModelCatalog.whisperCppLargeV3TurboQuantized,
+            modelURL: expectedModelURL,
+            audioBuffer: [0.1, 0.2, 0.3],
+            language: "en"
+        )
+
+        XCTAssertEqual(transcript, " override transcript ")
+    }
+
+    private func makeTestModel(
+        cachePathComponents: [String],
+        downloadURL: String? = "https://example.com/test-model.bin"
+    ) -> SpeechModelDescriptor {
+        SpeechModelDescriptor(
+            name: "unit-test-whisper-cpp-model-\(UUID().uuidString)",
+            pickerTitle: "Test",
+            variantName: "test",
+            sizeDescription: "~1 MB",
+            backend: .whisperCpp,
+            cachePathComponents: cachePathComponents,
+            downloadURL: downloadURL,
+            fluidAudioVariant: nil
+        )
+    }
+
+    private func cacheModelFile(for model: SpeechModelDescriptor) throws -> URL {
+        let url = WhisperCppSpeechBackend.modelURL(for: model)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("test".utf8).write(to: url)
+        return url
+    }
+}
+
+private func XCTAssertThrowsErrorAsync<T>(
+    _ expression: @autoclosure () async throws -> T,
+    _ errorHandler: (Error) -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected expression to throw", file: file, line: line)
+    } catch {
+        errorHandler(error)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Ghost Pepper uses open-source models that run entirely on your Mac. Models downl
 | Whisper tiny.en | ~75 MB | Fastest, English only |
 | **Whisper small.en** (default) | ~466 MB | Best accuracy, English only |
 | Whisper small (multilingual) | ~466 MB | Multi-language support |
+| Whisper Large v3 Turbo | ~954 MB | High-accuracy multilingual Whisper |
+| whisper.cpp Large v3 Turbo (Q5_0 quantized) | ~574 MB | Smaller ggml download with local `whisper.cpp` runtime |
+| whisper.cpp Large v3 Turbo (F16 full precision) | ~1.5 GB | Full-precision ggml model for local `whisper.cpp` runtime |
 | Parakeet v3 (25 languages) | ~1.4 GB | Multi-language via [FluidAudio](https://github.com/FluidInference/FluidAudio) |
 | Qwen3-ASR 0.6B int8 (50+ languages) | ~900 MB | Highest multilingual quality, macOS 15+ required |
 
@@ -36,7 +39,7 @@ Ghost Pepper uses open-source models that run entirely on your Mac. Models downl
 | Qwen 3.5 2B | ~1.3 GB | Fast (~4-5s) |
 | Qwen 3.5 4B | ~2.8 GB | Full quality (~5-7s) |
 
-Speech models powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit). Cleanup models powered by [LLM.swift](https://github.com/eastriverlee/LLM.swift). All models served by [Hugging Face](https://huggingface.co/).
+Speech models are powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit), [whisper.cpp](https://github.com/ggml-org/whisper.cpp), and [FluidAudio](https://github.com/FluidInference/FluidAudio). Cleanup models powered by [LLM.swift](https://github.com/eastriverlee/LLM.swift). All models served by [Hugging Face](https://huggingface.co/).
 
 ## Getting started
 


### PR DESCRIPTION
## Summary
- add two new speech model options for `whisper.cpp` large-v3-turbo: quantized `ggml-large-v3-turbo-q5_0` and non-quantized `ggml-large-v3-turbo`
- route `whisper.cpp` loading/transcription through a dedicated `WhisperCppSpeechBackend` so the integration matches the repo's model/backend split more closely
- harden the backend so it fails before download when `whisper-cli` is missing, validates model readiness during load, and covers the new model IDs across inventory, rerun, persistence, and trace tests

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipMacroValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -project /Users/samir/projects/ghost-pepper/GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS,arch=arm64' -only-testing:GhostPepperTests/SpeechTranscriberTests -only-testing:GhostPepperTests/RuntimeModelInventoryTests -only-testing:GhostPepperTests/ModelManagerTests -only-testing:GhostPepperTests/WhisperCppSpeechBackendTests -only-testing:GhostPepperTests/GhostPepperTests/testRecordingSettingsDisablesIgnoreOtherSpeakersForWhisperModels -only-testing:GhostPepperTests/TranscriptionLabControllerTests -only-testing:GhostPepperTests/TranscriptionLabRunnerTests -only-testing:GhostPepperTests/TranscriptionLabStoreTests -only-testing:GhostPepperTests/PerformanceTraceTests`
- Result: `80 tests, 0 failures`

## Explicitly Excluded
- The media playback auto-resume bug is already tracked upstream in #50, and the related auto-pause feature landed in #35. I intentionally left that out of this PR so it stays focused on the new model integration.