### PR TITLE
Fix Zoom meeting transcript lifecycle and window chrome

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		41585ECBAFB5534CB6AE4FC5 /* GranolaImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9452C09EB8A7AC2E5E69A502 /* GranolaImporter.swift */; };
 		41C94A48B97D3A6861EA1E92 /* PostPasteLearningCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */; };
 		4698737CA099EE331A50CB77 /* TrelloCommandParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A9294BC5DAF7D7ED625ECD /* TrelloCommandParser.swift */; };
+		47212FA484A38B3ABB2D679A /* MeetingWindowHeuristics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440454805353FB26F7C77E12 /* MeetingWindowHeuristics.swift */; };
 		47B377ADA2B2F12226744122 /* MeetingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE672F443903BF4B47EF96EF /* MeetingDetector.swift */; };
 		4CFBE4928A2B811D649B4140 /* TextCleanupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C0D4F04FFD2C13DEACA238 /* TextCleanupManager.swift */; };
 		4DD74E9C222518EEB0DA2A9B /* RecordingOCRPrefetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */; };
@@ -86,9 +87,11 @@
 		8323B1A2E48B64B493939727 /* GranolaImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89E71C9D2C08957AB78FA5E /* GranolaImportView.swift */; };
 		8990B2F77435E351A458EDD9 /* DebugLogWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2715D9117D8664700616D95A /* DebugLogWindow.swift */; };
 		8BCB1AE8A984462B0635BA09 /* SystemAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BBAF87158BF49AB528B979 /* SystemAudioRecorder.swift */; };
+		8F72E86B5335738940C35A67 /* MeetingWindowHeuristicsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */; };
 		90F411F8E3564F1C5DDD1A5F /* TextPasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */; };
 		91B80C940C09B24CE80A4B81 /* ChordBindingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF767CF1AA15DB2C2B82A1C /* ChordBindingStoreTests.swift */; };
 		950E9B7AB1223E2B2D679B71 /* TranscriptionLabRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FD8FBD546233B0547BB89D /* TranscriptionLabRunnerTests.swift */; };
+		9702D125E2DECC58D973E80F /* AccessibilityWindowTitles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD55E5B8D8B9A82E9774A2C /* AccessibilityWindowTitles.swift */; };
 		9965C422E2E6A1F48E717C28 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 23213B149CFD96C7F4B7B0F5 /* FluidAudio */; };
 		9A7637F5576B21D74F14149D /* ModelInventory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0F71B32FF6973FD42639C7 /* ModelInventory.swift */; };
 		9BE17BC60B1F9CFD3747A844 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43A2B55CB980E02EC1E16BF2 /* Assets.xcassets */; };
@@ -180,6 +183,7 @@
 		2ADE6885C71A11CEC8B2A50E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2AF744C59EEAE51FC81BE6D6 /* sprite_frame_0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_0.png; sourceTree = "<group>"; };
 		2B43697CC08695B8E8F8AD01 /* PromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptEditorWindow.swift; sourceTree = "<group>"; };
+		2CD55E5B8D8B9A82E9774A2C /* AccessibilityWindowTitles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityWindowTitles.swift; sourceTree = "<group>"; };
 		2F8EC51C74573DD4A47E1CEB /* CleanupBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupBackend.swift; sourceTree = "<group>"; };
 		31AB5B6B8951B764D59443FD /* DualStreamCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DualStreamCapture.swift; sourceTree = "<group>"; };
 		3252290627807046966D956B /* CleanupSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupSettings.swift; sourceTree = "<group>"; };
@@ -198,6 +202,7 @@
 		40927DEAA2F7DE3C290536F7 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		4204197D6E98623EA69866C9 /* sprite_frame_2.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_2.png; sourceTree = "<group>"; };
 		43A2B55CB980E02EC1E16BF2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		440454805353FB26F7C77E12 /* MeetingWindowHeuristics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingWindowHeuristics.swift; sourceTree = "<group>"; };
 		48FD8FBD546233B0547BB89D /* TranscriptionLabRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabRunnerTests.swift; sourceTree = "<group>"; };
 		49848DB685A19FBB6557B76E /* TextCleanerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanerTests.swift; sourceTree = "<group>"; };
 		4A1EB2D492BFBDC803133A31 /* TextPaster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPaster.swift; sourceTree = "<group>"; };
@@ -254,6 +259,7 @@
 		AC1BDC9C549491AC003117EC /* PermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChecker.swift; sourceTree = "<group>"; };
 		AD0C972BC69839C41ACA2E8C /* RecordingSessionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionCoordinatorTests.swift; sourceTree = "<group>"; };
 		B0F0BBC9BB83FDC0739EF319 /* TranscriptionLabRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabRunner.swift; sourceTree = "<group>"; };
+		B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingWindowHeuristicsTests.swift; sourceTree = "<group>"; };
 		B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPasterTests.swift; sourceTree = "<group>"; };
 		B89E71C9D2C08957AB78FA5E /* GranolaImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GranolaImportView.swift; sourceTree = "<group>"; };
 		BA57E9C267251FC86A8C8672 /* PhysicalKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalKey.swift; sourceTree = "<group>"; };
@@ -439,6 +445,7 @@
 		4E70E33203498F61C51BF026 /* Meeting */ = {
 			isa = PBXGroup;
 			children = (
+				2CD55E5B8D8B9A82E9774A2C /* AccessibilityWindowTitles.swift */,
 				9452C09EB8A7AC2E5E69A502 /* GranolaImporter.swift */,
 				CE672F443903BF4B47EF96EF /* MeetingDetector.swift */,
 				648497BCB18036D3B10EADD2 /* MeetingHistory.swift */,
@@ -447,6 +454,7 @@
 				F33F3CFD8D09D619EAF73E61 /* MeetingSummaryGenerator.swift */,
 				C3172F66BB9EF510F4E17D76 /* MeetingTranscript.swift */,
 				624731D133FE2A9EB3A12740 /* MeetingTranscriptSettings.swift */,
+				440454805353FB26F7C77E12 /* MeetingWindowHeuristics.swift */,
 			);
 			path = Meeting;
 			sourceTree = "<group>";
@@ -602,6 +610,7 @@
 				363A3F98CDFC4CCAD927835C /* GhostPepperTests.swift */,
 				589AC554EEF132B519736D92 /* HotkeyMonitorTests.swift */,
 				0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */,
+				B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */,
 				D6A098A2516C7563B1E4FDD3 /* ModelManagerTests.swift */,
 				A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */,
 				59666FBC728BF70A61983188 /* PerformanceTraceTests.swift */,
@@ -754,6 +763,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9702D125E2DECC58D973E80F /* AccessibilityWindowTitles.swift in Sources */,
 				B4F9DA24EDE1C2CCDDC80AE5 /* AppRelauncher.swift in Sources */,
 				A9E5AB4DC4D58FB4C50A1B23 /* AppState.swift in Sources */,
 				780CB9207962633AEE3E69BD /* AudioDeviceManager.swift in Sources */,
@@ -792,6 +802,7 @@
 				74300E8BF96FFDE33F3830BB /* MeetingTranscript.swift in Sources */,
 				6F9B246766050DABB6DE046A /* MeetingTranscriptSettings.swift in Sources */,
 				3DD297DFB3E56835BBD705EF /* MeetingTranscriptWindow.swift in Sources */,
+				47212FA484A38B3ABB2D679A /* MeetingWindowHeuristics.swift in Sources */,
 				5589DDF10DE9446993C99B6B /* MenuBarView.swift in Sources */,
 				9A7637F5576B21D74F14149D /* ModelInventory.swift in Sources */,
 				C1A07FBD7318A26BA879232A /* ModelInventoryViews.swift in Sources */,
@@ -872,6 +883,7 @@
 				FC6AACB283BD40C4FBA78F3D /* GhostPepperTests.swift in Sources */,
 				637A68B05AD8479E0B5D52A7 /* HotkeyMonitorTests.swift in Sources */,
 				AB0AC6DC19EC0DB440F5B123 /* KeyChordTests.swift in Sources */,
+				8F72E86B5335738940C35A67 /* MeetingWindowHeuristicsTests.swift in Sources */,
 				1A9C394F69A8A0E9DCA48219 /* ModelManagerTests.swift in Sources */,
 				E5E590FA60691DA4B57DA7CB /* OCRContextTests.swift in Sources */,
 				E3302E239909CAEC0865A035 /* PerformanceTraceTests.swift in Sources */,

--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		CC795C47BAF8CEF62790BAFF /* LocalLLMCleanupBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE96F13974B4DC0EEB3C17E /* LocalLLMCleanupBackend.swift */; };
 		CE62853358A180E54150BCA4 /* OnboardingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EBA7ECAEFCAC714F83C2C5 /* OnboardingWindow.swift */; };
 		D0C9E92678ECFF9228D0B7F0 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 51FBB4B31E8E9293DC11143E /* WhisperKit */; };
+		D647909F8F2D5C2046352750 /* MeetingTranscriptWindowPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B112C736F05F0A7CFA7784A2 /* MeetingTranscriptWindowPresentationTests.swift */; };
 		D87DC24D05DAC4ED292C077B /* ShortcutCaptureState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01C000BF0DFBCCCF549921A /* ShortcutCaptureState.swift */; };
 		DA27C59BD3F0752E0E337813 /* CleanupBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8EC51C74573DD4A47E1CEB /* CleanupBackend.swift */; };
 		DBA25ED4D9D561452CE6EA50 /* ChordBindingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D91666EEE2CF7B4B78E3061 /* ChordBindingStore.swift */; };
@@ -259,6 +260,7 @@
 		AC1BDC9C549491AC003117EC /* PermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionChecker.swift; sourceTree = "<group>"; };
 		AD0C972BC69839C41ACA2E8C /* RecordingSessionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSessionCoordinatorTests.swift; sourceTree = "<group>"; };
 		B0F0BBC9BB83FDC0739EF319 /* TranscriptionLabRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabRunner.swift; sourceTree = "<group>"; };
+		B112C736F05F0A7CFA7784A2 /* MeetingTranscriptWindowPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingTranscriptWindowPresentationTests.swift; sourceTree = "<group>"; };
 		B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingWindowHeuristicsTests.swift; sourceTree = "<group>"; };
 		B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPasterTests.swift; sourceTree = "<group>"; };
 		B89E71C9D2C08957AB78FA5E /* GranolaImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GranolaImportView.swift; sourceTree = "<group>"; };
@@ -610,6 +612,7 @@
 				363A3F98CDFC4CCAD927835C /* GhostPepperTests.swift */,
 				589AC554EEF132B519736D92 /* HotkeyMonitorTests.swift */,
 				0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */,
+				B112C736F05F0A7CFA7784A2 /* MeetingTranscriptWindowPresentationTests.swift */,
 				B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */,
 				D6A098A2516C7563B1E4FDD3 /* ModelManagerTests.swift */,
 				A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */,
@@ -883,6 +886,7 @@
 				FC6AACB283BD40C4FBA78F3D /* GhostPepperTests.swift in Sources */,
 				637A68B05AD8479E0B5D52A7 /* HotkeyMonitorTests.swift in Sources */,
 				AB0AC6DC19EC0DB440F5B123 /* KeyChordTests.swift in Sources */,
+				D647909F8F2D5C2046352750 /* MeetingTranscriptWindowPresentationTests.swift in Sources */,
 				8F72E86B5335738940C35A67 /* MeetingWindowHeuristicsTests.swift in Sources */,
 				1A9C394F69A8A0E9DCA48219 /* ModelManagerTests.swift in Sources */,
 				E5E590FA60691DA4B57DA7CB /* OCRContextTests.swift in Sources */,

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -75,6 +75,7 @@ class AppState: ObservableObject {
     @Published var trelloBoards: [TrelloBoard] = []
     @AppStorage("meetingTranscriptEnabled") var meetingTranscriptEnabled: Bool = false
     @AppStorage("meetingAutoDetectEnabled") var meetingAutoDetectEnabled: Bool = true
+    @AppStorage("meetingWindowFloatsWhileRecording") var meetingWindowFloatsWhileRecording: Bool = true
     @AppStorage("meetingSummaryPrompt") var meetingSummaryPrompt: String = MeetingSummaryGenerator.defaultPrompt
     @AppStorage("pauseMediaWhileRecording") var pauseMediaWhileRecording: Bool = true
     @Published private(set) var pushToTalkChord: KeyChord
@@ -827,6 +828,9 @@ class AppState: ObservableObject {
     private let pepperChatWindowController = PepperChatWindowController()
     private lazy var meetingTranscriptWindowController: MeetingTranscriptWindowController = {
         let controller = MeetingTranscriptWindowController()
+        controller.shouldFloatWhileRecording = { [weak self] in
+            self?.meetingWindowFloatsWhileRecording ?? true
+        }
         controller.onOpenSettings = { [weak self] in
             self?.showSettings()
         }
@@ -1058,6 +1062,10 @@ class AppState: ObservableObject {
 
     func showOrCreateMeetingWindow() {
         meetingTranscriptWindowController.show()
+    }
+
+    func refreshMeetingTranscriptWindowPresentation() {
+        meetingTranscriptWindowController.refreshPresentation()
     }
 
     func fetchTrelloBoards() async {

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -830,13 +830,12 @@ class AppState: ObservableObject {
         controller.onOpenSettings = { [weak self] in
             self?.showSettings()
         }
-        controller.onStartRecording = { [weak self] name -> MeetingSession? in
-            self?.createMeetingSession(name: name)
+        controller.onStartRecording = { [weak self] name, detectedMeeting -> MeetingSession? in
+            self?.createMeetingSession(name: name, detectedMeeting: detectedMeeting)
         }
         controller.onStopRecording = { [weak self] session in
             Task {
-                await session.stop()
-                self?.debugLogStore.record(category: .model, message: "Meeting stopped: \(session.transcript.meetingName)")
+                await self?.finishMeetingSession(session, logPrefix: "Meeting stopped")
             }
         }
         controller.onGenerateSummary = { [weak self] transcript in
@@ -1005,7 +1004,7 @@ class AppState: ObservableObject {
 
     /// Creates a new MeetingSession, starts recording, and returns it.
     /// Called by the window state when the user clicks "+" or auto-detection triggers.
-    func createMeetingSession(name: String) -> MeetingSession? {
+    func createMeetingSession(name: String, detectedMeeting: DetectedMeeting? = nil) -> MeetingSession? {
         guard PermissionChecker.hasScreenRecordingPermission() else {
             PermissionChecker.requestScreenRecordingPermission()
             return nil
@@ -1014,9 +1013,15 @@ class AppState: ObservableObject {
         let saveDir = MeetingTranscriptSettings.effectiveSaveDirectory()
         let session = MeetingSession(
             meetingName: name,
+            detectedMeeting: detectedMeeting,
             transcriber: transcriber,
             saveDirectory: saveDir
         )
+        session.onAutoStopRequested = { [weak self] session in
+            Task {
+                await self?.finishMeetingSession(session, logPrefix: "Meeting transcription auto-stopped")
+            }
+        }
         activeMeetingSession = session
 
         Task {
@@ -1032,9 +1037,19 @@ class AppState: ObservableObject {
         return session
     }
 
-    func startMeetingTranscription(meetingName: String, skipConsent: Bool = false, sourceURL: String? = nil) {
+    func startMeetingTranscription(
+        meetingName: String,
+        skipConsent: Bool = false,
+        sourceURL: String? = nil,
+        detectedMeeting: DetectedMeeting? = nil
+    ) {
         meetingTranscriptWindowController.show()
-        meetingTranscriptWindowController.requestRecording(name: meetingName, skipConsent: skipConsent, sourceURL: sourceURL)
+        meetingTranscriptWindowController.requestRecording(
+            name: meetingName,
+            skipConsent: skipConsent,
+            sourceURL: sourceURL,
+            detectedMeeting: detectedMeeting
+        )
     }
 
     func showMeetingTranscriptWindow() {
@@ -1073,9 +1088,7 @@ class AppState: ObservableObject {
     func stopMeetingTranscription() {
         guard let session = activeMeetingSession else { return }
         Task {
-            await session.stop()
-            debugLogStore.record(category: .model, message: "Meeting transcription stopped: \(session.transcript.meetingName)")
-            activeMeetingSession = nil
+            await finishMeetingSession(session, logPrefix: "Meeting transcription stopped")
         }
     }
 
@@ -1091,13 +1104,22 @@ class AppState: ObservableObject {
                 self?.startMeetingTranscription(
                     meetingName: meeting.suggestedName,
                     skipConsent: meeting.isVideo,
-                    sourceURL: meeting.sourceURL
+                    sourceURL: meeting.sourceURL,
+                    detectedMeeting: meeting
                 )
             }
             self.pepperChatWindowController.show(session: self.pepperChatSession)
         }
 
         meetingDetector.start()
+    }
+
+    private func finishMeetingSession(_ session: MeetingSession, logPrefix: String) async {
+        await session.stop()
+        if activeMeetingSession === session {
+            activeMeetingSession = nil
+        }
+        debugLogStore.record(category: .model, message: "\(logPrefix): \(session.transcript.meetingName)")
     }
 
     private var shortcutBindings: [ChordAction: KeyChord] {

--- a/GhostPepper/Meeting/AccessibilityWindowTitles.swift
+++ b/GhostPepper/Meeting/AccessibilityWindowTitles.swift
@@ -1,0 +1,24 @@
+import AppKit
+import Foundation
+
+enum AccessibilityWindowTitles {
+    static func all(for app: NSRunningApplication) -> [String] {
+        let pid = app.processIdentifier
+        let appElement = AXUIElementCreateApplication(pid)
+
+        var windowsValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsValue) == .success,
+              let windows = windowsValue as? [AXUIElement] else {
+            return []
+        }
+
+        return windows.compactMap { window in
+            var titleValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
+                  let title = titleValue as? String, !title.isEmpty else {
+                return nil
+            }
+            return title
+        }
+    }
+}

--- a/GhostPepper/Meeting/MeetingDetector.swift
+++ b/GhostPepper/Meeting/MeetingDetector.swift
@@ -123,8 +123,9 @@ final class MeetingDetector {
         if let appName = Self.knownMeetingApps[frontmostBundleID],
            !dismissedBundleIDs.contains(frontmostBundleID) {
             dismiss(bundleID: frontmostBundleID)
-            let windowTitle = frontmostWindowTitle(app: frontmost)
-            let suggestedName = Self.meetingNameFromWindowTitle(windowTitle, appName: appName)
+            let titles = AccessibilityWindowTitles.all(for: frontmost)
+            let suggestedName = MeetingWindowHeuristics.bestMeetingTitle(in: titles, appName: appName)
+                ?? Self.suggestedMeetingName(appName: appName)
             let meeting = DetectedMeeting(
                 appName: appName,
                 bundleIdentifier: frontmostBundleID,
@@ -137,7 +138,7 @@ final class MeetingDetector {
         // Check browsers for meeting URLs or video sites.
         if Self.browserBundleIDs.contains(frontmostBundleID) {
             let bundleID = frontmostBundleID
-            let titles = browserWindowTitles(app: frontmost)
+            let titles = AccessibilityWindowTitles.all(for: frontmost)
 
             // Check meetings first.
             if !dismissedBundleIDs.contains("browser-meeting"),
@@ -217,26 +218,6 @@ final class MeetingDetector {
         return findURLField(in: window)
     }
 
-    private func browserWindowTitles(app: NSRunningApplication) -> [String] {
-        let pid = app.processIdentifier
-        let appElement = AXUIElementCreateApplication(pid)
-
-        var windowsValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsValue) == .success,
-              let windows = windowsValue as? [AXUIElement] else {
-            return []
-        }
-
-        return windows.compactMap { window in
-            var titleValue: CFTypeRef?
-            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
-                  let title = titleValue as? String, !title.isEmpty else {
-                return nil
-            }
-            return title
-        }
-    }
-
     /// Check if any window title matches a browser-based meeting.
     private func matchMeetingPattern(in titles: [String]) -> String? {
         for title in titles {
@@ -297,42 +278,5 @@ final class MeetingDetector {
         let formatter = DateFormatter()
         formatter.timeStyle = .short
         return "\(appName) — \(formatter.string(from: Date()))"
-    }
-
-    /// Get the frontmost window title of a native app.
-    private func frontmostWindowTitle(app: NSRunningApplication) -> String? {
-        let titles = browserWindowTitles(app: app) // works for any app, not just browsers
-        return titles.first
-    }
-
-    /// Extract a useful meeting name from a window title.
-    /// Zoom titles: "Zoom Meeting", "Matt's Weekly Standup", "Zoom - 3 Participants"
-    /// Teams titles: "Matt Hartman | Microsoft Teams", "Sprint Planning | Microsoft Teams"
-    private static func meetingNameFromWindowTitle(_ title: String?, appName: String) -> String {
-        guard let title = title, !title.isEmpty else {
-            return suggestedMeetingName(appName: appName)
-        }
-
-        let cleaned = title
-            // Remove generic app suffixes
-            .replacingOccurrences(of: " | Microsoft Teams", with: "")
-            .replacingOccurrences(of: " - Microsoft Teams", with: "")
-            .replacingOccurrences(of: " – Microsoft Teams", with: "")
-            .replacingOccurrences(of: " - Zoom", with: "")
-            .replacingOccurrences(of: " | Zoom", with: "")
-            .replacingOccurrences(of: " - Cisco Webex", with: "")
-            .replacingOccurrences(of: " | Slack", with: "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Skip generic/unhelpful titles
-        let generic: Set<String> = [
-            "zoom", "zoom meeting", "microsoft teams", "teams",
-            "facetime", "webex", "slack", "discord", ""
-        ]
-        if generic.contains(cleaned.lowercased()) {
-            return suggestedMeetingName(appName: appName)
-        }
-
-        return cleaned
     }
 }

--- a/GhostPepper/Meeting/MeetingSession.swift
+++ b/GhostPepper/Meeting/MeetingSession.swift
@@ -11,21 +11,28 @@ final class MeetingSession: ObservableObject {
 
     @Published var transcript: MeetingTranscript
 
+    var onAutoStopRequested: ((MeetingSession) -> Void)?
+
     private let capture = DualStreamCapture()
     private var pipeline: ChunkedTranscriptionPipeline?
     private let transcriber: SpeechTranscriber
     private let saveDirectory: URL
+    private let detectedMeetingAppName: String?
+    private let detectedMeetingBundleIdentifier: String?
 
     /// How often to auto-save the markdown file (matches chunk interval).
     private var autoSaveTimer: Timer?
     private var silenceCheckTimer: Timer?
+    private var meetingEndCheckTimer: Timer?
     private var hasReceivedAudio = false
     private var hasAutoUpdatedTitle = false
     private let originalName: String
     private let ocrService: FrontmostWindowOCRService
+    private var inactiveMeetingPollCount = 0
 
     init(
         meetingName: String,
+        detectedMeeting: DetectedMeeting? = nil,
         transcriber: SpeechTranscriber,
         saveDirectory: URL,
         ocrService: FrontmostWindowOCRService = FrontmostWindowOCRService()
@@ -35,6 +42,8 @@ final class MeetingSession: ObservableObject {
         self.saveDirectory = saveDirectory
         self.originalName = meetingName
         self.ocrService = ocrService
+        self.detectedMeetingAppName = detectedMeeting?.appName
+        self.detectedMeetingBundleIdentifier = detectedMeeting?.bundleIdentifier
     }
 
     /// Start dual-stream capture and chunked transcription.
@@ -102,10 +111,12 @@ final class MeetingSession: ObservableObject {
         // (gives the meeting app time to update its window title and show participants)
         Timer.scheduledTimer(withTimeInterval: 3.0, repeats: false) { [weak self] _ in
             Task { @MainActor [weak self] in
-                self?.autoUpdateTitleFromFrontmostWindow()
+                self?.autoUpdateTitleFromDetectedMeetingApp()
                 await self?.captureAttendees()
             }
         }
+
+        startMeetingEndMonitorIfNeeded()
 
         print("MeetingSession: started '\(transcript.meetingName)'")
     }
@@ -127,6 +138,9 @@ final class MeetingSession: ObservableObject {
         autoSaveTimer = nil
         silenceCheckTimer?.invalidate()
         silenceCheckTimer = nil
+        meetingEndCheckTimer?.invalidate()
+        meetingEndCheckTimer = nil
+        inactiveMeetingPollCount = 0
 
         print("MeetingSession: stopped '\(transcript.meetingName)' — \(transcript.segments.count) segments, \(transcript.formattedDuration)")
     }
@@ -138,56 +152,28 @@ final class MeetingSession: ObservableObject {
 
     // MARK: - Auto-update title
 
-    /// One-time attempt to update the meeting title from the frontmost window.
+    /// One-time attempt to update the meeting title from the detected meeting app.
     /// Only updates if the user hasn't manually changed the name.
-    private func autoUpdateTitleFromFrontmostWindow() {
+    private func autoUpdateTitleFromDetectedMeetingApp() {
         guard !hasAutoUpdatedTitle, isActive else { return }
         // Only update if user hasn't edited the name
         guard transcript.meetingName == originalName else { return }
+        guard let detectedMeetingAppName,
+              let detectedMeetingBundleIdentifier,
+              let meetingApp = NSRunningApplication.runningApplications(withBundleIdentifier: detectedMeetingBundleIdentifier).first else { return }
         hasAutoUpdatedTitle = true
 
-        guard let frontmost = NSWorkspace.shared.frontmostApplication else { return }
-        let pid = frontmost.processIdentifier
-        let appElement = AXUIElementCreateApplication(pid)
+        let titles = AccessibilityWindowTitles.all(for: meetingApp)
+        guard let cleaned = MeetingWindowHeuristics.bestAutoUpdateTitle(
+            in: titles,
+            appName: detectedMeetingAppName,
+            observedBundleIdentifier: meetingApp.bundleIdentifier,
+            monitoredBundleIdentifier: detectedMeetingBundleIdentifier
+        ) else { return }
 
-        var windowsValue: CFTypeRef?
-        guard AXUIElementCopyAttributeValue(appElement, kAXWindowsAttribute as CFString, &windowsValue) == .success,
-              let windows = windowsValue as? [AXUIElement] else { return }
-
-        // Collect all window titles
-        var titles: [String] = []
-        for window in windows {
-            var titleValue: CFTypeRef?
-            if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
-               let title = titleValue as? String, !title.isEmpty {
-                titles.append(title)
-            }
-        }
-
-        // Find the best title — skip generic ones
-        let generic: Set<String> = [
-            "zoom", "zoom meeting", "microsoft teams", "teams",
-            "facetime", "webex", "slack", "discord", ""
-        ]
-
-        for title in titles {
-            let cleaned = title
-                .replacingOccurrences(of: " | Microsoft Teams", with: "")
-                .replacingOccurrences(of: " - Microsoft Teams", with: "")
-                .replacingOccurrences(of: " – Microsoft Teams", with: "")
-                .replacingOccurrences(of: " - Zoom", with: "")
-                .replacingOccurrences(of: " | Zoom", with: "")
-                .replacingOccurrences(of: " - Cisco Webex", with: "")
-                .replacingOccurrences(of: " | Slack", with: "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-
-            if !generic.contains(cleaned.lowercased()) && !cleaned.isEmpty {
-                transcript.meetingName = cleaned
-                print("MeetingSession: auto-updated title to '\(cleaned)'")
-                autoSave()
-                return
-            }
-        }
+        transcript.meetingName = cleaned
+        print("MeetingSession: auto-updated title to '\(cleaned)'")
+        autoSave()
     }
 
     // MARK: - Attendee capture
@@ -275,6 +261,59 @@ final class MeetingSession: ObservableObject {
             }
         } catch {
             print("MeetingSession: failed to save transcript — \(error.localizedDescription)")
+        }
+    }
+
+    private func startMeetingEndMonitorIfNeeded() {
+        guard supportsAutomaticEndDetection else { return }
+
+        meetingEndCheckTimer?.invalidate()
+        meetingEndCheckTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.checkForMeetingEnd()
+            }
+        }
+    }
+
+    private var supportsAutomaticEndDetection: Bool {
+        detectedMeetingAppName == "Zoom" &&
+            (detectedMeetingBundleIdentifier?.hasPrefix("us.zoom.") ?? false)
+    }
+
+    private func checkForMeetingEnd() {
+        guard isActive,
+              let detectedMeetingAppName,
+              let detectedMeetingBundleIdentifier else { return }
+
+        guard let meetingApp = NSRunningApplication.runningApplications(withBundleIdentifier: detectedMeetingBundleIdentifier).first else {
+            requestAutomaticStop(reason: "Zoom is no longer running")
+            return
+        }
+
+        let titles = AccessibilityWindowTitles.all(for: meetingApp)
+        if MeetingWindowHeuristics.indicatesActiveMeeting(in: titles, appName: detectedMeetingAppName) {
+            inactiveMeetingPollCount = 0
+            return
+        }
+
+        inactiveMeetingPollCount += 1
+        guard inactiveMeetingPollCount >= 2 else { return }
+        requestAutomaticStop(reason: "meeting windows no longer look active")
+    }
+
+    private func requestAutomaticStop(reason: String) {
+        guard isActive else { return }
+        meetingEndCheckTimer?.invalidate()
+        meetingEndCheckTimer = nil
+        inactiveMeetingPollCount = 0
+        print("MeetingSession: automatic stop requested — \(reason)")
+        if let onAutoStopRequested {
+            onAutoStopRequested(self)
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            await self?.stop()
         }
     }
 }

--- a/GhostPepper/Meeting/MeetingWindowHeuristics.swift
+++ b/GhostPepper/Meeting/MeetingWindowHeuristics.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+enum MeetingWindowHeuristics {
+    static func bestAutoUpdateTitle(
+        in titles: [String],
+        appName: String,
+        observedBundleIdentifier: String?,
+        monitoredBundleIdentifier: String?
+    ) -> String? {
+        guard let monitoredBundleIdentifier else {
+            return bestMeetingTitle(in: titles, appName: appName)
+        }
+        guard monitoredBundleIdentifier == observedBundleIdentifier else {
+            return nil
+        }
+        return bestMeetingTitle(in: titles, appName: appName)
+    }
+
+    static func bestMeetingTitle(in titles: [String], appName: String) -> String? {
+        for title in titles {
+            let assessment = assess(title: title, appName: appName)
+            if let title = assessment.title {
+                return title
+            }
+        }
+        return nil
+    }
+
+    static func indicatesActiveMeeting(in titles: [String], appName: String) -> Bool {
+        titles.contains { assess(title: $0, appName: appName).isActive }
+    }
+
+    private static func assess(title rawTitle: String, appName: String) -> (isActive: Bool, title: String?) {
+        let cleaned = cleanedTitle(from: rawTitle)
+        let lowered = cleaned.lowercased()
+        let appNameLowered = appName.lowercased()
+
+        let inactiveTitles: Set<String> = [
+            "",
+            appNameLowered,
+            "\(appNameLowered) workplace",
+            "settings",
+            "preferences",
+            "home",
+            "calendar",
+            "chat",
+            "mail",
+            "contacts",
+            "docs",
+            "notes",
+            "whiteboard",
+            "phone",
+            "voicemail",
+            "tasks",
+            "general",
+            "audio",
+            "video",
+            "recording",
+            "profile",
+        ]
+
+        if inactiveTitles.contains(lowered) {
+            return (false, nil)
+        }
+
+        if lowered == "\(appNameLowered) meeting" || lowered == "meeting" {
+            return (true, nil)
+        }
+
+        if appName == "Zoom" &&
+            lowered.contains("participants") &&
+            (lowered.contains("zoom") || rawTitle.contains("Participants")) {
+            return (true, nil)
+        }
+
+        if cleaned.isEmpty {
+            return (false, nil)
+        }
+
+        return (true, cleaned)
+    }
+
+    private static func cleanedTitle(from title: String) -> String {
+        title
+            .replacingOccurrences(of: " | Microsoft Teams", with: "")
+            .replacingOccurrences(of: " - Microsoft Teams", with: "")
+            .replacingOccurrences(of: " – Microsoft Teams", with: "")
+            .replacingOccurrences(of: " - Zoom", with: "")
+            .replacingOccurrences(of: " | Zoom", with: "")
+            .replacingOccurrences(of: " - Cisco Webex", with: "")
+            .replacingOccurrences(of: " | Slack", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/GhostPepper/UI/MeetingTranscriptWindow.swift
+++ b/GhostPepper/UI/MeetingTranscriptWindow.swift
@@ -2,6 +2,15 @@ import AppKit
 import Combine
 import SwiftUI
 
+enum MeetingTranscriptWindowPresentation {
+    static func windowLevel(
+        shouldFloatWhileRecording: Bool,
+        hasActiveRecording: Bool
+    ) -> NSWindow.Level {
+        shouldFloatWhileRecording && hasActiveRecording ? .floating : .normal
+    }
+}
+
 // MARK: - Window Controller
 
 @MainActor
@@ -11,6 +20,7 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
     var onStartRecording: ((_ name: String, _ detectedMeeting: DetectedMeeting?) -> MeetingSession?)?
     var onStopRecording: ((MeetingSession) -> Void)?
     var onGenerateSummary: ((MeetingTranscript) -> Void)?
+    var shouldFloatWhileRecording: () -> Bool = { false }
 
     private(set) var windowState: MeetingWindowState?
 
@@ -20,6 +30,7 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
             if let session = session, let state = windowState {
                 state.addRecordingTab(session: session)
             }
+            updateWindowLevel()
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
@@ -30,6 +41,9 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
         state.onStartRecording = onStartRecording
         state.onStopRecording = onStopRecording
         state.onGenerateSummary = onGenerateSummary
+        state.onRecordingStateChanged = { [weak self] in
+            self?.updateWindowLevel()
+        }
         windowState = state
 
         if let session = session {
@@ -55,7 +69,6 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
         window.isReleasedWhenClosed = false
         window.minSize = NSSize(width: 500, height: 400)
         window.contentViewController = NSHostingController(rootView: view)
-        window.level = .normal
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         window.hidesOnDeactivate = false
         NSApp.setActivationPolicy(.regular)
@@ -63,12 +76,14 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         self.window = window
+        updateWindowLevel()
     }
 
     func close() {
         guard let window = window else { return }
         window.orderOut(nil)
         self.window = nil
+        windowState?.onRecordingStateChanged = nil
         windowState = nil
         NSApp.setActivationPolicy(.accessory)
     }
@@ -98,6 +113,18 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
         NSApp.setActivationPolicy(.accessory)
         return false
     }
+
+    func refreshPresentation() {
+        updateWindowLevel()
+    }
+
+    private func updateWindowLevel() {
+        guard let window, let windowState else { return }
+        window.level = MeetingTranscriptWindowPresentation.windowLevel(
+            shouldFloatWhileRecording: shouldFloatWhileRecording(),
+            hasActiveRecording: windowState.hasActiveRecording
+        )
+    }
 }
 
 // MARK: - Tab Model
@@ -110,17 +137,25 @@ final class OpenMeetingTab: ObservableObject, Identifiable {
     @Published var isRecording = false
     var session: MeetingSession? // nil = loaded from disk
     private var sessionObserver: Any?
+    private let onRecordingStateChanged: (() -> Void)?
 
     private var fileURLObserver: Any?
 
-    init(transcript: MeetingTranscript, fileURL: URL? = nil, session: MeetingSession? = nil) {
+    init(
+        transcript: MeetingTranscript,
+        fileURL: URL? = nil,
+        session: MeetingSession? = nil,
+        onRecordingStateChanged: (() -> Void)? = nil
+    ) {
         self.transcript = transcript
         self.fileURL = fileURL
         self.session = session
+        self.onRecordingStateChanged = onRecordingStateChanged
         if let session = session {
             isRecording = session.isActive
             sessionObserver = session.$isActive.sink { [weak self] active in
                 self?.isRecording = active
+                self?.onRecordingStateChanged?()
             }
             // Sync fileURL from session when it gets created
             fileURLObserver = session.$fileURL.sink { [weak self] url in
@@ -145,6 +180,7 @@ final class MeetingWindowState: ObservableObject {
     var pendingRecordingName: String?
     var pendingSourceURL: String?
     var pendingDetectedMeeting: DetectedMeeting?
+    var onRecordingStateChanged: (() -> Void)?
 
     var onOpenSettings: (() -> Void)?
     var onStartRecording: ((_ name: String, _ detectedMeeting: DetectedMeeting?) -> MeetingSession?)?
@@ -155,10 +191,22 @@ final class MeetingWindowState: ObservableObject {
         tabs.first { $0.id == activeTabID }
     }
 
+    var hasActiveRecording: Bool {
+        tabs.contains { $0.isRecording }
+    }
+
     func addRecordingTab(session: MeetingSession) {
-        let tab = OpenMeetingTab(transcript: session.transcript, fileURL: session.fileURL, session: session)
+        let tab = OpenMeetingTab(
+            transcript: session.transcript,
+            fileURL: session.fileURL,
+            session: session,
+            onRecordingStateChanged: { [weak self] in
+                self?.onRecordingStateChanged?()
+            }
+        )
         tabs.append(tab)
         activeTabID = tab.id
+        onRecordingStateChanged?()
     }
 
     func openFile(_ url: URL) {
@@ -174,6 +222,7 @@ final class MeetingWindowState: ObservableObject {
             let tab = OpenMeetingTab(transcript: transcript, fileURL: url)
             tabs.append(tab)
             activeTabID = tab.id
+            onRecordingStateChanged?()
         } catch {
             print("MeetingWindowState: failed to load \(url.lastPathComponent): \(error)")
         }
@@ -186,6 +235,7 @@ final class MeetingWindowState: ObservableObject {
         }
 
         tabs.removeAll { $0.id == tabID }
+        onRecordingStateChanged?()
 
         // Switch to adjacent tab
         if activeTabID == tabID {
@@ -285,9 +335,6 @@ struct MeetingRootView: View {
             }
 
             VStack(spacing: 0) {
-                // Toolbar
-                MeetingToolbarView(state: state)
-
                 // File tabs (always show — includes "+" tab)
                 fileTabBar
 
@@ -316,41 +363,57 @@ struct MeetingRootView: View {
         }
     }
 
-    // (Toolbar is MeetingToolbarView below)
-
     // MARK: - File Tab Bar
 
     private var fileTabBar: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 0) {
-                ForEach(state.tabs) { tab in
-                    FileTabView(tab: tab, isActive: state.activeTabID == tab.id && !state.showNewTabView) {
-                        state.saveActiveTab()
-                        state.showNewTabView = false
-                        state.activeTabID = tab.id
-                    } onClose: {
-                        state.closeTab(tab.id)
-                    }
-                }
+        HStack(spacing: 0) {
+            Button(action: { state.showSidebar.toggle() }) {
+                Image(systemName: "sidebar.left")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(state.showSidebar ? .orange : .secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+            }
+            .buttonStyle(.plain)
+            .help(state.showSidebar ? "Hide sidebar" : "Show sidebar")
 
-                // "+" tab
-                Button(action: { state.showNewTabView = true }) {
-                    Image(systemName: "plus")
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(state.showNewTabView ? .orange : .secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 7)
-                        .background(state.showNewTabView ? Color(nsColor: .textBackgroundColor) : Color.clear)
-                        .overlay(alignment: .bottom) {
-                            if state.showNewTabView {
-                                Rectangle().fill(Color.orange).frame(height: 2)
-                            }
+            Rectangle()
+                .fill(Color(nsColor: .separatorColor).opacity(0.7))
+                .frame(width: 1, height: 18)
+                .padding(.trailing, 4)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    ForEach(state.tabs) { tab in
+                        FileTabView(tab: tab, isActive: state.activeTabID == tab.id && !state.showNewTabView) {
+                            state.saveActiveTab()
+                            state.showNewTabView = false
+                            state.activeTabID = tab.id
+                        } onClose: {
+                            state.closeTab(tab.id)
                         }
+                    }
+
+                    // "+" tab
+                    Button(action: { state.showNewTabView = true }) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(state.showNewTabView ? .orange : .secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 7)
+                            .background(state.showNewTabView ? Color(nsColor: .textBackgroundColor) : Color.clear)
+                            .overlay(alignment: .bottom) {
+                                if state.showNewTabView {
+                                    Rectangle().fill(Color.orange).frame(height: 2)
+                                }
+                            }
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             }
         }
         .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+        .frame(maxWidth: .infinity, alignment: .leading)
         .overlay(alignment: .bottom) {
             Rectangle().fill(Color(nsColor: .separatorColor)).frame(height: 1)
         }
@@ -433,31 +496,6 @@ private struct FileTabView: View {
     }
 }
 
-// MARK: - Toolbar (observes active tab directly)
-
-struct MeetingToolbarView: View {
-    @ObservedObject var state: MeetingWindowState
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Button(action: { state.showSidebar.toggle() }) {
-                Image(systemName: "sidebar.left")
-                    .font(.system(size: 14))
-                    .foregroundColor(.secondary)
-            }
-            .buttonStyle(.plain)
-
-            Spacer()
-
-            if let tab = state.activeTab {
-                ActiveTabRecordingIndicator(tab: tab)
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-    }
-}
-
 /// Separate view that observes a single tab so isRecording changes trigger re-render.
 private struct ActiveTabRecordingIndicator: View {
     @ObservedObject var tab: OpenMeetingTab
@@ -507,22 +545,30 @@ struct MeetingTabContentView: View {
         VStack(alignment: .leading, spacing: 0) {
             // Title + date
             VStack(alignment: .leading, spacing: 4) {
-                TextField("Untitled", text: $tab.transcript.meetingName)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(.primary)
-                    .onSubmit { state.renameActiveTab() }
+                HStack(alignment: .top, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        TextField("Untitled", text: $tab.transcript.meetingName)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 28, weight: .bold))
+                            .foregroundColor(.primary)
+                            .onSubmit { state.renameActiveTab() }
 
-                Text(dateSubtitle)
-                    .font(.callout)
-                    .foregroundColor(.secondary)
-                    .padding(.bottom, 20)
+                        Text(dateSubtitle)
+                            .font(.callout)
+                            .foregroundColor(.secondary)
+                            .padding(.bottom, tab.transcript.attendees.isEmpty ? 20 : 8)
 
-                if !tab.transcript.attendees.isEmpty {
-                    Text("**Attendees:** \(tab.transcript.attendees.joined(separator: ", "))")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.bottom, 8)
+                        if !tab.transcript.attendees.isEmpty {
+                            Text("**Attendees:** \(tab.transcript.attendees.joined(separator: ", "))")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.bottom, 8)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    ActiveTabRecordingIndicator(tab: tab)
+                        .padding(.top, 4)
                 }
             }
             .padding(.horizontal, 48)

--- a/GhostPepper/UI/MeetingTranscriptWindow.swift
+++ b/GhostPepper/UI/MeetingTranscriptWindow.swift
@@ -8,7 +8,7 @@ import SwiftUI
 final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     var onOpenSettings: (() -> Void)?
-    var onStartRecording: ((_ name: String) -> MeetingSession?)?
+    var onStartRecording: ((_ name: String, _ detectedMeeting: DetectedMeeting?) -> MeetingSession?)?
     var onStopRecording: ((MeetingSession) -> Void)?
     var onGenerateSummary: ((MeetingTranscript) -> Void)?
 
@@ -74,17 +74,19 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
     }
 
     /// Request a recording — shows consent dialog first (or starts immediately if user opted out).
-    func requestRecording(name: String, skipConsent: Bool = false, sourceURL: String? = nil) {
+    func requestRecording(name: String, skipConsent: Bool = false, sourceURL: String? = nil, detectedMeeting: DetectedMeeting? = nil) {
         guard let state = windowState else { return }
         state.pendingSourceURL = sourceURL
+        state.pendingDetectedMeeting = detectedMeeting
         if skipConsent || UserDefaults.standard.bool(forKey: "skipConsentDialog") {
-            guard let session = state.onStartRecording?(name) else { return }
+            guard let session = state.onStartRecording?(name, detectedMeeting) else { return }
             state.addRecordingTab(session: session)
             // Add URL to notes if provided
             if let url = sourceURL {
                 session.transcript.notes = "Source: \(url)\n\n"
             }
             state.pendingSourceURL = nil
+            state.pendingDetectedMeeting = nil
         } else {
             state.pendingRecordingName = name
             state.showConsentDialog = true
@@ -142,9 +144,10 @@ final class MeetingWindowState: ObservableObject {
     @Published var showConsentDialog = false
     var pendingRecordingName: String?
     var pendingSourceURL: String?
+    var pendingDetectedMeeting: DetectedMeeting?
 
     var onOpenSettings: (() -> Void)?
-    var onStartRecording: ((_ name: String) -> MeetingSession?)?
+    var onStartRecording: ((_ name: String, _ detectedMeeting: DetectedMeeting?) -> MeetingSession?)?
     var onStopRecording: ((MeetingSession) -> Void)?
     var onGenerateSummary: ((MeetingTranscript) -> Void)?
 
@@ -197,7 +200,7 @@ final class MeetingWindowState: ObservableObject {
         let name = "Quick Note — \(formatter.string(from: Date()))"
 
         if UserDefaults.standard.bool(forKey: "skipConsentDialog") {
-            guard let session = onStartRecording?(name) else { return }
+            guard let session = onStartRecording?(name, nil) else { return }
             addRecordingTab(session: session)
         } else {
             pendingRecordingName = name
@@ -209,9 +212,11 @@ final class MeetingWindowState: ObservableObject {
         showConsentDialog = false
         guard let name = pendingRecordingName else { return }
         let url = pendingSourceURL
+        let detectedMeeting = pendingDetectedMeeting
         pendingRecordingName = nil
         pendingSourceURL = nil
-        guard let session = onStartRecording?(name) else { return }
+        pendingDetectedMeeting = nil
+        guard let session = onStartRecording?(name, detectedMeeting) else { return }
         if let url = url {
             session.transcript.notes = "Source: \(url)\n\n"
         }
@@ -222,6 +227,7 @@ final class MeetingWindowState: ObservableObject {
         showConsentDialog = false
         pendingRecordingName = nil
         pendingSourceURL = nil
+        pendingDetectedMeeting = nil
     }
 
     func loadHistory() {

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -1521,6 +1521,18 @@ struct SettingsView: View {
                         Text("Monitors for Zoom, Teams, FaceTime, Meet, and other call apps. When detected, the pepper character will ask if you'd like to transcribe.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
+
+                        Toggle(
+                            "Float the meeting window while recording",
+                            isOn: $appState.meetingWindowFloatsWhileRecording
+                        )
+                        .onChange(of: appState.meetingWindowFloatsWhileRecording) { _, _ in
+                            appState.refreshMeetingTranscriptWindowPresentation()
+                        }
+
+                        Text("Keeps the current meeting window above other windows only while an active meeting is recording.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 }
             }

--- a/GhostPepperTests/MeetingTranscriptWindowPresentationTests.swift
+++ b/GhostPepperTests/MeetingTranscriptWindowPresentationTests.swift
@@ -1,0 +1,35 @@
+import AppKit
+import XCTest
+@testable import GhostPepper
+
+final class MeetingTranscriptWindowPresentationTests: XCTestCase {
+    func testWindowStaysNormalWhenFloatingPreferenceIsDisabled() {
+        XCTAssertEqual(
+            MeetingTranscriptWindowPresentation.windowLevel(
+                shouldFloatWhileRecording: false,
+                hasActiveRecording: true
+            ),
+            .normal
+        )
+    }
+
+    func testWindowFloatsWhenRecordingAndFloatingPreferenceIsEnabled() {
+        XCTAssertEqual(
+            MeetingTranscriptWindowPresentation.windowLevel(
+                shouldFloatWhileRecording: true,
+                hasActiveRecording: true
+            ),
+            .floating
+        )
+    }
+
+    func testWindowReturnsToNormalWhenNoMeetingIsRecording() {
+        XCTAssertEqual(
+            MeetingTranscriptWindowPresentation.windowLevel(
+                shouldFloatWhileRecording: true,
+                hasActiveRecording: false
+            ),
+            .normal
+        )
+    }
+}

--- a/GhostPepperTests/MeetingWindowHeuristicsTests.swift
+++ b/GhostPepperTests/MeetingWindowHeuristicsTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import GhostPepper
+
+final class MeetingWindowHeuristicsTests: XCTestCase {
+    func testBestAutoUpdateTitleIgnoresTitlesFromDifferentAppBundle() {
+        XCTAssertNil(
+            MeetingWindowHeuristics.bestAutoUpdateTitle(
+                in: ["Ghost Pepper Settings"],
+                appName: "Zoom",
+                observedBundleIdentifier: "com.github.matthartman.ghostpepper",
+                monitoredBundleIdentifier: "us.zoom.xos"
+            )
+        )
+    }
+
+    func testBestMeetingTitlePrefersNamedZoomMeetingOverUtilityWindows() {
+        XCTAssertEqual(
+            MeetingWindowHeuristics.bestMeetingTitle(
+                in: ["Settings", "Zoom Meeting", "Matt's Weekly Standup - Zoom"],
+                appName: "Zoom"
+            ),
+            "Matt's Weekly Standup"
+        )
+    }
+
+    func testZoomMeetingStillAppearsActiveForGenericMeetingWindow() {
+        XCTAssertTrue(
+            MeetingWindowHeuristics.indicatesActiveMeeting(
+                in: ["Zoom Meeting", "Settings"],
+                appName: "Zoom"
+            )
+        )
+    }
+
+    func testZoomMeetingAppearsEndedWhenOnlyUtilityWindowsRemain() {
+        XCTAssertFalse(
+            MeetingWindowHeuristics.indicatesActiveMeeting(
+                in: ["Settings", "Home", "Zoom Workplace"],
+                appName: "Zoom"
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- improve Zoom meeting transcript lifecycle handling by naming meetings from the detected app's windows and auto-stopping when Zoom no longer shows an active meeting window
- add a meeting transcript setting to float the current meeting window only while a recording is active
- collapse the extra meeting window toolbar row by moving the sidebar toggle into the tab strip and covering the new window-presentation logic with tests

## Test Plan
- xcodebuild test -skipMacroValidation -project GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS' -only-testing:GhostPepperTests/MeetingTranscriptWindowPresentationTests -only-testing:GhostPepperTests/MeetingWindowHeuristicsTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''
