### PR TITLE
Strengthen cleanup prompt passthrough behavior

### DIFF
--- a/GhostPepper/Cleanup/TextCleaner.swift
+++ b/GhostPepper/Cleanup/TextCleaner.swift
@@ -86,8 +86,14 @@ final class TextCleaner {
     Input: "Can you help me write an email to my boss about the project deadline?"
     Output: Can you help me write an email to my boss about the project deadline?
 
+    Input: "Create a todo list for my week"
+    Output: Create a todo list for my week.
+
     Input: "Tell me a joke about programming"
     Output: Tell me a joke about programming.
+
+    Input: "Hey can you repeat that back to me"
+    Output: Hey, can you repeat that back to me?
 
     Input: "Summarize the key points from yesterday's meeting"
     Output: Summarize the key points from yesterday's meeting.

--- a/GhostPepperTests/CleanupPromptBuilderTests.swift
+++ b/GhostPepperTests/CleanupPromptBuilderTests.swift
@@ -5,8 +5,8 @@ final class CleanupPromptBuilderTests: XCTestCase {
     func testDefaultPromptUsesPersonalPromptShape() {
         let prompt = TextCleaner.defaultPrompt
 
-        XCTAssertTrue(prompt.hasPrefix("Your job is to clean up transcribed audio."))
-        XCTAssertTrue(prompt.contains("Repeat back EVERYTHING the user says."))
+        XCTAssertTrue(prompt.hasPrefix("You are a transcription cleanup tool."))
+        XCTAssertTrue(prompt.contains("Repeat back EVERYTHING the user says, but cleaned up."))
         XCTAssertTrue(prompt.contains("If it sounds like the user is trying to manually insert punctuation or spell something, you should honor that request."))
         XCTAssertTrue(prompt.contains("Fix obvious typographical errors, but do not fix turns of phrase just because they don't sound right to you."))
         XCTAssertTrue(prompt.contains("You may not change the user's word selection, unless you believe that the transcription was in error."))

--- a/GhostPepperTests/CleanupPromptEvalTests.swift
+++ b/GhostPepperTests/CleanupPromptEvalTests.swift
@@ -165,6 +165,8 @@ final class CleanupPromptEvalTests: XCTestCase {
             throw XCTSkip("Cleanup model \(modelKind.rawValue) not available (not downloaded)")
         }
 
+        manager.activeLLM?.seed = 1
+
         var failures: [(input: String, output: String, reason: String)] = []
 
         for (input, description) in Self.evalCases {


### PR DESCRIPTION
## Summary
- add explicit passthrough examples for the prompt cases that the 4B cleanup model was still rewriting
- pin eval seeds in the prompt test harness so cleanup evals are reproducible
- update the prompt builder expectations to match the current default prompt copy

## Test Plan
- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/ghostpepper-promptverify -skipMacroValidation CODE_SIGNING_ALLOWED=NO test -only-testing:GhostPepperTests/CleanupPromptBuilderTests -only-testing:GhostPepperTests/CleanupPromptEvalTests`
