### PR TITLE
Rename Pepper Chat copy to Context Bundler

### DIFF
--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -944,7 +944,7 @@ class AppState: ObservableObject {
         pepperChatSession.isRecording = true
         soundEffects.playStart()
         pepperChatWindowController.show(session: pepperChatSession)
-        debugLogStore.record(category: .hotkey, message: "Pepper Chat recording started.")
+        debugLogStore.record(category: .hotkey, message: "Context Bundler recording started.")
     }
 
     /// Capture the current frontmost window's context (if it's a new/different window)
@@ -998,7 +998,7 @@ class AppState: ObservableObject {
         lastCapturedWindowTitle = nil
         hotkeyMonitor.updateBindings(shortcutBindings)
         soundEffects.playStop()
-        debugLogStore.record(category: .hotkey, message: "Pepper Chat recording stopped.")
+        debugLogStore.record(category: .hotkey, message: "Context Bundler recording stopped.")
 
         Task {
             let buffer = await recorder.stopRecording()

--- a/GhostPepper/PepperChat/PepperChatBackend.swift
+++ b/GhostPepper/PepperChat/PepperChatBackend.swift
@@ -11,7 +11,7 @@ enum PepperChatBackendError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .notConfigured: "Pepper Chat requires a Zo API key. Add one in Settings > Pepper Chat."
+        case .notConfigured: "Context Bundler requires a Zo API key. Add one in Settings > Context Bundler."
         case .invalidResponse: "Received an invalid response from Zo."
         case .serverError(let message): "Zo error: \(message)"
         }

--- a/GhostPepper/PepperChat/PepperChatSession.swift
+++ b/GhostPepper/PepperChat/PepperChatSession.swift
@@ -69,7 +69,7 @@ final class PepperChatSession: ObservableObject {
 
     func processRecording(audioBuffer: [Float], includeScreenContext: Bool) async {
         guard !audioBuffer.isEmpty else {
-            debugLogger?(.model, "Pepper Chat: empty audio buffer, skipping.")
+            debugLogger?(.model, "Context Bundler: empty audio buffer, skipping.")
             return
         }
 
@@ -78,7 +78,7 @@ final class PepperChatSession: ObservableObject {
         isTranscribing = false
 
         guard let rawTranscription, !rawTranscription.isEmpty else {
-            debugLogger?(.model, "Pepper Chat: no transcription detected, showing context review anyway.")
+            debugLogger?(.model, "Context Bundler: no transcription detected, showing context review anyway.")
             // Still show context review so user can access captured screenshots
             let allContexts = preCapturedScreenContexts
             preCapturedScreenContexts = []
@@ -93,7 +93,7 @@ final class PepperChatSession: ObservableObject {
         let transcription: String
         if let cleanupProvider {
             transcription = await cleanupProvider(rawTranscription)
-            debugLogger?(.model, "Pepper Chat: cleaned \"\(rawTranscription)\" → \"\(transcription)\"")
+            debugLogger?(.model, "Context Bundler: cleaned \"\(rawTranscription)\" → \"\(transcription)\"")
         } else {
             transcription = rawTranscription
         }
@@ -141,7 +141,7 @@ final class PepperChatSession: ObservableObject {
         guard let backend = backendProvider() else {
             let errorMessage = PepperChatMessage(
                 role: .assistant,
-                text: "Add your Zo API key in Settings > Pepper Chat.",
+                text: "Add your Zo API key in Settings > Context Bundler.",
                 timestamp: Date()
             )
             messages.append(errorMessage)
@@ -161,12 +161,12 @@ final class PepperChatSession: ObservableObject {
                     self.messages[index].text += chunk
                 }
             }
-            debugLogger?(.model, "Pepper Chat: response complete.")
+            debugLogger?(.model, "Context Bundler: response complete.")
         } catch {
             if let index = messages.firstIndex(where: { $0.id == messageID }), messages[index].text.isEmpty {
                 messages[index].text = "Error: \(error.localizedDescription)"
             }
-            debugLogger?(.model, "Pepper Chat: backend error: \(error.localizedDescription)")
+            debugLogger?(.model, "Context Bundler: backend error: \(error.localizedDescription)")
         }
 
         activeProcessingCount -= 1

--- a/GhostPepper/UI/ContextBubbleView.swift
+++ b/GhostPepper/UI/ContextBubbleView.swift
@@ -20,7 +20,7 @@ private struct PepperLogo: View {
 
 /// The Ghost Pepper Context Bubble — a branded floating panel that shows
 /// captured screen context + spoken command with action buttons.
-/// Replaces the old Pepper Chat message list UI.
+/// Displays the floating Context Bundler message list UI.
 struct ContextBubbleView: View {
     @ObservedObject var session: PepperChatSession
     var onMinimize: () -> Void

--- a/GhostPepper/UI/PepperChatWindow.swift
+++ b/GhostPepper/UI/PepperChatWindow.swift
@@ -156,7 +156,7 @@ private struct PepperChatWindowView: View {
         VStack(spacing: 0) {
             // Top bar
             HStack {
-                Text("Pepper Chat")
+                Text("Context Bundler")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
 
@@ -189,7 +189,7 @@ private struct PepperChatWindowView: View {
                         .foregroundStyle(.secondary)
                 }
                 .buttonStyle(.borderless)
-                .help("Close Pepper Chat")
+                .help("Close Context Bundler")
             }
             .padding(.horizontal, 12)
             .padding(.top, 8)

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -1307,9 +1307,9 @@ struct SettingsView: View {
     private var pepperChatSection: some View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsCard("Availability") {
-                Toggle("Enable Pepper Chat", isOn: $appState.pepperChatEnabled)
+                Toggle("Enable Context Bundler", isOn: $appState.pepperChatEnabled)
 
-                Text("When disabled, Pepper Chat stays out of the menu bar and its shortcut will not start new chats.")
+                Text("When disabled, Context Bundler stays out of the menu bar and its shortcut will not start new chats.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/docs/superpowers/plans/2026-04-09-pepper-chat-opt-in.md
+++ b/docs/superpowers/plans/2026-04-09-pepper-chat-opt-in.md
@@ -1,10 +1,10 @@
-# Pepper Chat Opt-In Implementation Plan
+# Context Bundler Opt-In Implementation Plan
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make Pepper Chat opt-in so new users do not see or trigger it until they enable it, while preserving the existing enabled behavior for users who already stored a Zo token.
+**Goal:** Make Context Bundler opt-in so new users do not see or trigger it until they enable it, while preserving the existing enabled behavior for users who already stored a Zo token.
 
-**Architecture:** Add one persisted `pepperChatEnabled` flag in `AppState` and derive its initial value from `pepperChatApiKey` only when the new setting has not been stored yet. Use that single source of truth to gate the menu bar entry, Pepper Chat hotkey bindings, and new launch/record entry points, while leaving already-open windows alone.
+**Architecture:** Add one persisted `pepperChatEnabled` flag in `AppState` and derive its initial value from `pepperChatApiKey` only when the new setting has not been stored yet. Use that single source of truth to gate the menu bar entry, Context Bundler hotkey bindings, and new launch/record entry points, while leaving already-open windows alone.
 
 **Tech Stack:** SwiftUI, AppStorage/UserDefaults, XCTest
 
@@ -12,7 +12,7 @@
 
 ## Chunk 1: Persistence and gating
 
-### Task 1: Add failing tests for Pepper Chat enablement defaults and hotkey gating
+### Task 1: Add failing tests for Context Bundler enablement defaults and hotkey gating
 
 **Files:**
 - Modify: `GhostPepperTests/GhostPepperTests.swift`
@@ -24,13 +24,13 @@
 - [ ] **Step 4: Run the focused tests again and verify they pass**
 - [ ] **Step 5: Commit**
 
-### Task 2: Gate new Pepper Chat launches in the app state
+### Task 2: Gate new Context Bundler launches in the app state
 
 **Files:**
 - Modify: `GhostPepper/AppState.swift`
 
 - [ ] **Step 1: Add a failing test or extend an existing one if needed**
-- [ ] **Step 2: Guard new Pepper Chat launches/recordings behind `pepperChatEnabled`**
+- [ ] **Step 2: Guard new Context Bundler launches/recordings behind `pepperChatEnabled`**
 - [ ] **Step 3: Re-run the focused test target**
 - [ ] **Step 4: Commit**
 
@@ -44,7 +44,7 @@
 - Test: `GhostPepperTests/GhostPepperTests.swift`
 
 - [ ] **Step 1: Add or extend tests for the visible behavior where practical**
-- [ ] **Step 2: Add the Pepper Chat enable toggle in Settings**
-- [ ] **Step 3: Hide the menu bar Pepper Chat item when disabled**
+- [ ] **Step 2: Add the Context Bundler enable toggle in Settings**
+- [ ] **Step 3: Hide the menu bar Context Bundler item when disabled**
 - [ ] **Step 4: Run the focused test target, then the broader relevant test target**
 - [ ] **Step 5: Commit**


### PR DESCRIPTION
## Summary
- replace remaining user-facing "Pepper Chat" copy with "Context Bundler"
- update the settings toggle/help text, floating window title, Zo error messages, and debug log labels
- rename the related internal plan prose so repo searches stop surfacing the old product name in docs

## Test Plan
- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/ghostpepper-context-bundler-pr -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
