### PR TITLE
Reduce dictation latency with streamed transcription and cleanup prefill

### DIFF
--- a/GhostPepper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GhostPepper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/obra/LLM.swift.git",
       "state" : {
         "branch" : "main",
-        "revision" : "f1e1e11982dbc59662be191b8bed408dfb48e9df"
+        "revision" : "c2144e1a0e29c280ec6080b7da85e876d51f8509"
       }
     },
     {

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -127,9 +127,11 @@ class AppState: ObservableObject {
     let transcriptionLabStore: TranscriptionLabStore
     let appRelauncher: AppRelaunching
     var recordingSessionCoordinatorFactory: (() -> RecordingSessionCoordinator?)?
+    var recordingTranscriptionSessionFactory: ((SpeechModelDescriptor) -> RecordingTranscriptionSession?)?
     var transcribeAudioBufferOverride: (([Float]) -> String?)?
     var cleanedTranscriptionResultOverride: ((String, OCRContext?) async -> CleanupResult)?
     private(set) var activeRecordingSessionCoordinator: RecordingSessionCoordinator?
+    private(set) var activeRecordingTranscriptionSession: RecordingTranscriptionSession?
 
     var isReady: Bool {
         status == .ready
@@ -555,8 +557,28 @@ class AppState: ObservableObject {
     func prepareRecordingSessionIfNeeded() async {
         audioRecorder.onConvertedAudioChunk = nil
         activeRecordingSessionCoordinator = nil
+        activeRecordingTranscriptionSession = nil
+
+        if let speechModelDescriptor = SpeechModelCatalog.model(named: speechModel) {
+            if let recordingTranscriptionSessionFactory {
+                activeRecordingTranscriptionSession = recordingTranscriptionSessionFactory(
+                    speechModelDescriptor
+                )
+            } else if speechModelDescriptor.backend == .fluidAudio {
+                activeRecordingTranscriptionSession = ChunkedRecordingTranscriptionSession(
+                    transcribeChunk: { [weak self] samples in
+                        await self?.transcribeAudioBuffer(samples)
+                    }
+                )
+            }
+        }
 
         guard ignoreOtherSpeakers, selectedSpeechModelSupportsSpeakerFiltering else {
+            if let activeRecordingTranscriptionSession {
+                audioRecorder.onConvertedAudioChunk = { [weak activeRecordingTranscriptionSession] samples in
+                    activeRecordingTranscriptionSession?.appendAudioChunk(samples)
+                }
+            }
             return
         }
 
@@ -568,18 +590,26 @@ class AppState: ObservableObject {
         }
 
         guard let coordinator else {
+            if let activeRecordingTranscriptionSession {
+                audioRecorder.onConvertedAudioChunk = { [weak activeRecordingTranscriptionSession] samples in
+                    activeRecordingTranscriptionSession?.appendAudioChunk(samples)
+                }
+            }
             return
         }
 
         activeRecordingSessionCoordinator = coordinator
-        audioRecorder.onConvertedAudioChunk = { [weak coordinator] samples in
+        audioRecorder.onConvertedAudioChunk = {
+            [weak coordinator, weak activeRecordingTranscriptionSession] samples in
             coordinator?.appendAudioChunk(samples)
+            activeRecordingTranscriptionSession?.appendAudioChunk(samples)
         }
     }
 
     private func clearRecordingSessionCoordinator() {
         audioRecorder.onConvertedAudioChunk = nil
         activeRecordingSessionCoordinator = nil
+        activeRecordingTranscriptionSession = nil
     }
 
     private var selectedSpeechModelSupportsSpeakerFiltering: Bool {
@@ -616,6 +646,15 @@ class AppState: ObservableObject {
             } else {
                 recordingOCRPrefetch.cancel()
             }
+            if cleanupEnabled && canAttemptCleanup {
+                let promptComponents = activeCleanupPromptComponents(windowContext: nil)
+                textCleanupManager.startPromptPrefill(
+                    systemPromptPrefix: promptComponents.stablePromptPrefix,
+                    modelKind: textCleanupManager.selectedCleanupModelKind
+                )
+            } else {
+                textCleanupManager.cancelPromptPrefill()
+            }
             mediaPlaybackController.pauseIfPlaying()
             audioRecorder.targetDeviceID = AudioDeviceManager.selectedInputDeviceID()
             try audioRecorder.startRecording()
@@ -643,6 +682,7 @@ class AppState: ObservableObject {
         debugLogStore.record(category: .hotkey, message: "Recording stopped. Starting transcription.")
         let buffer = await audioRecorder.stopRecording()
         let recordingSessionCoordinator = activeRecordingSessionCoordinator
+        let recordingTranscriptionSession = activeRecordingTranscriptionSession
         clearRecordingSessionCoordinator()
         soundEffects.playStop()
         mediaPlaybackController.resumeIfPaused()
@@ -665,6 +705,7 @@ class AppState: ObservableObject {
         let didProduceTranscript = await processRecordingResult(
             audioBuffer: buffer,
             recordingSessionCoordinator: recordingSessionCoordinator,
+            recordingTranscriptionSession: recordingTranscriptionSession,
             archivedWindowContext: archivedWindowContext,
             shouldPaste: true,
             shouldRecordDebugSnapshot: true
@@ -692,11 +733,13 @@ class AppState: ObservableObject {
     func finishRecordingForTesting(
         audioBuffer: [Float],
         recordingSessionCoordinator: RecordingSessionCoordinator?,
+        recordingTranscriptionSession: RecordingTranscriptionSession? = nil,
         archivedWindowContext: OCRContext?
     ) async {
         _ = await processRecordingResult(
             audioBuffer: audioBuffer,
             recordingSessionCoordinator: recordingSessionCoordinator,
+            recordingTranscriptionSession: recordingTranscriptionSession,
             archivedWindowContext: archivedWindowContext,
             shouldPaste: false,
             shouldRecordDebugSnapshot: false
@@ -706,13 +749,15 @@ class AppState: ObservableObject {
     private func processRecordingResult(
         audioBuffer: [Float],
         recordingSessionCoordinator: RecordingSessionCoordinator?,
+        recordingTranscriptionSession: RecordingTranscriptionSession?,
         archivedWindowContext: OCRContext?,
         shouldPaste: Bool,
         shouldRecordDebugSnapshot: Bool
     ) async -> Bool {
         let transcriptionResult = await transcribedTextForRecording(
             audioBuffer,
-            recordingSessionCoordinator: recordingSessionCoordinator
+            recordingSessionCoordinator: recordingSessionCoordinator,
+            recordingTranscriptionSession: recordingTranscriptionSession
         )
 
         guard let text = transcriptionResult.rawTranscription else {
@@ -731,7 +776,7 @@ class AppState: ObservableObject {
         }
 
         activePerformanceTrace?.transcriptionEndAt = Date()
-        var windowContext = archivedWindowContext
+        let windowContext = archivedWindowContext
         if cleanupEnabled && canAttemptCleanup {
             activeCleanupAttempted = true
             activePerformanceTrace?.cleanupStartAt = Date()
@@ -783,7 +828,8 @@ class AppState: ObservableObject {
 
     private func transcribedTextForRecording(
         _ audioBuffer: [Float],
-        recordingSessionCoordinator: RecordingSessionCoordinator?
+        recordingSessionCoordinator: RecordingSessionCoordinator?,
+        recordingTranscriptionSession: RecordingTranscriptionSession?
     ) async -> RecordingTranscriptionResult {
         var diarizationSummary: DiarizationSummary?
 
@@ -794,12 +840,24 @@ class AppState: ObservableObject {
             if summary.usedFallback == false,
                let filteredTranscript = recordingSessionCoordinator.filteredTranscript,
                filteredTranscript.isEmpty == false {
+                recordingTranscriptionSession?.cancel()
                 return RecordingTranscriptionResult(
                     rawTranscription: filteredTranscript,
                     speakerFilteringRan: true,
                     diarizationSummary: summary
                 )
             }
+        }
+
+        if let recordingTranscriptionSession,
+           let streamedTranscript = await recordingTranscriptionSession.finishTranscription()?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           streamedTranscript.isEmpty == false {
+            return RecordingTranscriptionResult(
+                rawTranscription: streamedTranscript,
+                speakerFilteringRan: recordingSessionCoordinator != nil,
+                diarizationSummary: diarizationSummary
+            )
         }
 
         return RecordingTranscriptionResult(
@@ -1182,27 +1240,13 @@ class AppState: ObservableObject {
             return (text: text, prompt: cleanupPrompt, attemptedCleanup: false, cleanupUsedFallback: false)
         }
 
-        let languageAwarePrompt: String
-        if preferredLanguage != "auto" && preferredLanguage != "en" {
-            let langName = Locale.current.localizedString(forLanguageCode: preferredLanguage) ?? preferredLanguage
-            languageAwarePrompt = cleanupPrompt + "\n\nThe transcription is in \(langName). Preserve the original language — do not translate to English."
-        } else {
-            languageAwarePrompt = cleanupPrompt
-        }
-
         let activeCleanupPrompt: String
         if canAttemptCleanup {
             let promptBuildStart = Date()
-            activeCleanupPrompt = cleanupPromptBuilder.buildPrompt(
-                basePrompt: languageAwarePrompt,
-                windowContext: windowContext,
-                preferredTranscriptions: correctionStore.preferredTranscriptions,
-                commonlyMisheard: correctionStore.commonlyMisheard,
-                includeWindowContext: frontmostWindowContextEnabled
-            )
+            activeCleanupPrompt = activeCleanupPromptComponents(windowContext: windowContext).fullPrompt
             activePerformanceTrace?.promptBuildDuration = Date().timeIntervalSince(promptBuildStart)
         } else {
-            activeCleanupPrompt = languageAwarePrompt
+            activeCleanupPrompt = languageAwareCleanupPrompt
         }
 
         let cleanedResult = await textCleaner.cleanWithPerformance(
@@ -1217,6 +1261,25 @@ class AppState: ObservableObject {
             prompt: activeCleanupPrompt,
             attemptedCleanup: canAttemptCleanup,
             cleanupUsedFallback: cleanedResult.usedFallback
+        )
+    }
+
+    private var languageAwareCleanupPrompt: String {
+        if preferredLanguage != "auto" && preferredLanguage != "en" {
+            let langName = Locale.current.localizedString(forLanguageCode: preferredLanguage) ?? preferredLanguage
+            return cleanupPrompt + "\n\nThe transcription is in \(langName). Preserve the original language — do not translate to English."
+        }
+
+        return cleanupPrompt
+    }
+
+    private func activeCleanupPromptComponents(windowContext: OCRContext?) -> CleanupPromptComponents {
+        cleanupPromptBuilder.buildPromptComponents(
+            basePrompt: languageAwareCleanupPrompt,
+            windowContext: windowContext,
+            preferredTranscriptions: correctionStore.preferredTranscriptions,
+            commonlyMisheard: correctionStore.commonlyMisheard,
+            includeWindowContext: frontmostWindowContextEnabled
         )
     }
 

--- a/GhostPepper/Cleanup/CleanupPromptBuilder.swift
+++ b/GhostPepper/Cleanup/CleanupPromptBuilder.swift
@@ -1,5 +1,52 @@
 import Foundation
 
+struct CleanupPromptComponents: Equatable {
+    let stablePromptPrefix: String
+    let promptSuffix: String
+
+    var fullPrompt: String {
+        stablePromptPrefix + promptSuffix
+    }
+}
+
+struct CleanupPromptPrefillPlan: Equatable {
+    let systemPromptPrefix: String
+    let contextPrefix: String
+    let promptSuffixAfterPrefix: String
+    let suffixAfterUserInput: String
+
+    init?(
+        systemPromptPrefix: String,
+        processedPrompt: String,
+        systemPromptSentinel: String,
+        userInputSentinel: String
+    ) {
+        guard let systemSplitRange = processedPrompt.range(of: systemPromptSentinel) else {
+            return nil
+        }
+
+        let contextPrefix = String(processedPrompt[..<systemSplitRange.lowerBound])
+        let afterSystemSplit = String(processedPrompt[systemSplitRange.upperBound...])
+        guard let userSplitRange = afterSystemSplit.range(of: userInputSentinel) else {
+            return nil
+        }
+
+        self.systemPromptPrefix = systemPromptPrefix
+        self.contextPrefix = contextPrefix
+        self.promptSuffixAfterPrefix = String(afterSystemSplit[..<userSplitRange.lowerBound])
+        self.suffixAfterUserInput = String(afterSystemSplit[userSplitRange.upperBound...])
+    }
+
+    func completionInput(for prompt: String, userInput: String) -> String? {
+        guard prompt.hasPrefix(systemPromptPrefix) else {
+            return nil
+        }
+
+        let dynamicPromptSuffix = String(prompt.dropFirst(systemPromptPrefix.count))
+        return dynamicPromptSuffix + promptSuffixAfterPrefix + userInput + suffixAfterUserInput
+    }
+}
+
 struct CleanupPromptBuilder: Sendable {
     let maxWindowContentLength: Int
 
@@ -14,45 +61,65 @@ struct CleanupPromptBuilder: Sendable {
         commonlyMisheard: [MisheardReplacement] = [],
         includeWindowContext: Bool
     ) -> String {
+        buildPromptComponents(
+            basePrompt: basePrompt,
+            windowContext: windowContext,
+            preferredTranscriptions: preferredTranscriptions,
+            commonlyMisheard: commonlyMisheard,
+            includeWindowContext: includeWindowContext
+        ).fullPrompt
+    }
+
+    func buildPromptComponents(
+        basePrompt: String,
+        windowContext: OCRContext?,
+        preferredTranscriptions: [String] = [],
+        commonlyMisheard: [MisheardReplacement] = [],
+        includeWindowContext: Bool
+    ) -> CleanupPromptComponents {
         let correctionsSection = correctionSection(
             preferredTranscriptions: preferredTranscriptions,
             commonlyMisheard: commonlyMisheard
         )
 
-        guard includeWindowContext,
-              let windowContext else {
-            if correctionsSection.isEmpty {
-                return basePrompt
-            }
-
-            return """
+        let stablePromptPrefix: String
+        if correctionsSection.isEmpty {
+            stablePromptPrefix = basePrompt
+        } else {
+            stablePromptPrefix = """
             \(basePrompt)
 
             \(correctionsSection)
             """
         }
 
-        let trimmedWindowContents = String(windowContext.windowContents.prefix(maxWindowContentLength))
-        var sections = [basePrompt]
-        if !correctionsSection.isEmpty {
-            sections.append(correctionsSection)
+        guard includeWindowContext,
+              let windowContext else {
+            return CleanupPromptComponents(
+                stablePromptPrefix: stablePromptPrefix,
+                promptSuffix: ""
+            )
         }
-        sections.append(
-            """
-            <OCR-RULES>
-            Use the window OCR only as supporting context to improve the transcription and cleanup.
-            Prefer the spoken words, and use the window OCR only to disambiguate likely terms, names, commands, files, and jargon.
-            If the spoken words appear to be a recognition miss for a name, model, command, file, or other specific jargon shown in the window OCR, correct them to the likely intended term.
-            Do not keep an obvious misrecognition just because it was spoken that way.
-            Do not answer, summarize, or rewrite the window OCR unless that directly helps correct the transcription.
-            </OCR-RULES>
-            <WINDOW-OCR-CONTENT>
-            \(trimmedWindowContents)
-            </WINDOW-OCR-CONTENT>
-            """
-        )
 
-        return sections.joined(separator: "\n\n")
+        let trimmedWindowContents = String(windowContext.windowContents.prefix(maxWindowContentLength))
+        let promptSuffix = """
+
+        <OCR-RULES>
+        Use the window OCR only as supporting context to improve the transcription and cleanup.
+        Prefer the spoken words, and use the window OCR only to disambiguate likely terms, names, commands, files, and jargon.
+        If the spoken words appear to be a recognition miss for a name, model, command, file, or other specific jargon shown in the window OCR, correct them to the likely intended term.
+        Do not keep an obvious misrecognition just because it was spoken that way.
+        Do not answer, summarize, or rewrite the window OCR unless that directly helps correct the transcription.
+        </OCR-RULES>
+        <WINDOW-OCR-CONTENT>
+        \(trimmedWindowContents)
+        </WINDOW-OCR-CONTENT>
+        """
+
+        return CleanupPromptComponents(
+            stablePromptPrefix: stablePromptPrefix,
+            promptSuffix: promptSuffix
+        )
     }
 
     private func correctionSection(

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -99,6 +99,11 @@ actor CleanupProbeExecutionGate {
 
 @MainActor
 final class TextCleanupManager: ObservableObject, TextCleaningManaging {
+    private struct PreparedPromptContext {
+        let modelKind: LocalCleanupModelKind
+        let plan: CleanupPromptPrefillPlan
+    }
+
     @Published private(set) var state: CleanupModelState = .idle
     @Published private(set) var errorMessage: String?
     @Published var selectedCleanupModelKind: LocalCleanupModelKind {
@@ -177,12 +182,16 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
 
     private static let timeoutSeconds: TimeInterval = 15.0
     private static let selectedCleanupModelDefaultsKey = "selectedCleanupModelKind"
+    private static let systemPromptSentinel = "<|ghost-pepper-system-prefill-split|>"
+    private static let userInputSentinel = "<|ghost-pepper-user-prefill-split|>"
 
     private let defaults: UserDefaults
     private let cleanupModelAvailabilityOverrides: [LocalCleanupModelKind: Bool]
     private let probeExecutionOverride: CleanupModelProbeExecutionOverride?
     private let backendShutdownOverride: (() -> Void)?
     private let probeExecutionGate = CleanupProbeExecutionGate()
+    private var promptPrefillTask: Task<Void, Never>?
+    private var preparedPromptContext: PreparedPromptContext?
 
     init(
         defaults: UserDefaults = .standard,
@@ -297,6 +306,36 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         }
     }
 
+    func startPromptPrefill(systemPromptPrefix: String, modelKind: LocalCleanupModelKind? = nil) {
+        let requestedModelKind = modelKind ?? selectedCleanupModelKind
+        guard systemPromptPrefix.isEmpty == false else {
+            preparedPromptContext = nil
+            promptPrefillTask?.cancel()
+            promptPrefillTask = nil
+            return
+        }
+
+        if let preparedPromptContext,
+           preparedPromptContext.modelKind == requestedModelKind,
+           preparedPromptContext.plan.systemPromptPrefix == systemPromptPrefix {
+            return
+        }
+
+        promptPrefillTask?.cancel()
+        promptPrefillTask = Task { @MainActor [weak self] in
+            await self?.prefillPromptContext(
+                systemPromptPrefix: systemPromptPrefix,
+                modelKind: requestedModelKind
+            )
+        }
+    }
+
+    func cancelPromptPrefill() {
+        promptPrefillTask?.cancel()
+        promptPrefillTask = nil
+        preparedPromptContext = nil
+    }
+
     func probe(
         text: String,
         prompt: String,
@@ -320,14 +359,37 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
                 throw CleanupModelProbeError.modelUnavailable(modelKind)
             }
 
-            llm.useResolvedTemplate(systemPrompt: prompt)
-            llm.history = []
-
             let start = Date()
             do {
-                let rawOutput = try await withTimeout(seconds: Self.timeoutSeconds) {
-                    await llm.respond(to: text, thinking: thinkingMode.llmThinkingMode)
-                    return llm.output
+                let preparedCompletionInput: String?
+                if let preparedPromptContext,
+                   preparedPromptContext.modelKind == modelKind,
+                   let completionInput = preparedPromptContext.plan.completionInput(
+                    for: prompt,
+                    userInput: text
+                   ) {
+                    preparedCompletionInput = completionInput
+                    self.preparedPromptContext = nil
+                } else {
+                    preparedCompletionInput = nil
+                }
+
+                let rawOutput: String
+                if let preparedCompletionInput {
+                    rawOutput = try await withTimeout(seconds: Self.timeoutSeconds) { [self] in
+                        await generateFromPreparedContext(
+                            llm: llm,
+                            completionInput: preparedCompletionInput,
+                            thinkingMode: thinkingMode
+                        )
+                    }
+                } else {
+                    rawOutput = try await withTimeout(seconds: Self.timeoutSeconds) {
+                        llm.useResolvedTemplate(systemPrompt: prompt)
+                        llm.history = []
+                        await llm.respond(to: text, thinking: thinkingMode.llmThinkingMode)
+                        return llm.output
+                    }
                 }
                 let elapsed = Date().timeIntervalSince(start)
                 debugLogger?(
@@ -537,6 +599,67 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
             group.cancelAll()
             return result
         }
+    }
+
+    private func prefillPromptContext(
+        systemPromptPrefix: String,
+        modelKind: LocalCleanupModelKind
+    ) async {
+        await loadModel(kind: modelKind)
+        await probeExecutionGate.acquire()
+        guard let llm = model(for: modelKind) else {
+            preparedPromptContext = nil
+            await probeExecutionGate.release()
+            return
+        }
+
+        let sentinelPrompt = systemPromptPrefix + Self.systemPromptSentinel
+        llm.useResolvedTemplate(systemPrompt: sentinelPrompt)
+        llm.history = []
+        let processedPrompt = llm.preprocess(
+            Self.userInputSentinel,
+            [],
+            .suppressed
+        )
+        guard let plan = CleanupPromptPrefillPlan(
+            systemPromptPrefix: systemPromptPrefix,
+            processedPrompt: processedPrompt,
+            systemPromptSentinel: Self.systemPromptSentinel,
+            userInputSentinel: Self.userInputSentinel
+        ) else {
+            preparedPromptContext = nil
+            await probeExecutionGate.release()
+            return
+        }
+
+        await llm.core.resetContext()
+        let prepared = await llm.core.prepareContext(for: plan.contextPrefix)
+        preparedPromptContext = prepared
+            ? PreparedPromptContext(modelKind: modelKind, plan: plan)
+            : nil
+        await probeExecutionGate.release()
+    }
+
+    private func generateFromPreparedContext(
+        llm: LLM,
+        completionInput: String,
+        thinkingMode: CleanupModelProbeThinkingMode
+    ) async -> String {
+        llm.setOutput(to: "")
+        llm.setThinking(to: "")
+
+        let response = await llm.core.generateResponseStream(
+            from: completionInput,
+            thinking: thinkingMode.llmThinkingMode
+        )
+
+        var output = ""
+        for await content in response {
+            output += content
+        }
+
+        llm.setOutput(to: output)
+        return output
     }
 
     private func isModelAvailable(_ modelKind: LocalCleanupModelKind) -> Bool {

--- a/GhostPepper/Transcription/RecordingSessionCoordinator.swift
+++ b/GhostPepper/Transcription/RecordingSessionCoordinator.swift
@@ -1,5 +1,191 @@
 import Foundation
 
+protocol RecordingTranscriptionSession: AnyObject {
+    func appendAudioChunk(_ samples: [Float])
+    func finishTranscription() async -> String?
+    func cancel()
+}
+
+final class ChunkedRecordingTranscriptionSession: RecordingTranscriptionSession, @unchecked Sendable {
+    private let chunkSizeSamples: Int
+    private let shiftSamples: Int
+    private let transcribeChunk: @Sendable ([Float]) async -> String?
+    private let stateQueue = DispatchQueue(
+        label: "GhostPepper.ChunkedRecordingTranscriptionSession.state"
+    )
+    private let group = DispatchGroup()
+    private let tailWordCount = 10
+
+    private var bufferedSamples: [Float] = []
+    private var previousTail = ""
+    private var transcriptSegments: [String] = []
+    private var pendingChunkTranscripts: [Int: String] = [:]
+    private var nextEnqueuedChunkIndex = 0
+    private var nextTranscriptChunkIndex = 0
+    private var isCancelled = false
+    private var isFinishing = false
+
+    init(
+        chunkSizeSamples: Int = 17_920,
+        shiftSamples: Int = 8_960,
+        transcribeChunk: @escaping @Sendable ([Float]) async -> String?
+    ) {
+        self.chunkSizeSamples = chunkSizeSamples
+        self.shiftSamples = shiftSamples
+        self.transcribeChunk = transcribeChunk
+    }
+
+    func appendAudioChunk(_ samples: [Float]) {
+        guard samples.isEmpty == false else {
+            return
+        }
+
+        let chunks = stateQueue.sync { () -> [[Float]] in
+            guard isCancelled == false, isFinishing == false else {
+                return []
+            }
+
+            bufferedSamples.append(contentsOf: samples)
+            return drainReadyChunks()
+        }
+
+        chunks.forEach(enqueueChunk)
+    }
+
+    func finishTranscription() async -> String? {
+        let finalChunk = stateQueue.sync { () -> [Float]? in
+            guard isCancelled == false else {
+                return nil
+            }
+
+            isFinishing = true
+            guard bufferedSamples.isEmpty == false else {
+                return nil
+            }
+
+            let chunk = bufferedSamples
+            bufferedSamples = []
+            return chunk
+        }
+
+        if let finalChunk {
+            enqueueChunk(finalChunk)
+        }
+
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async { [group] in
+                group.wait()
+                continuation.resume()
+            }
+        }
+
+        return stateQueue.sync {
+            guard isCancelled == false else {
+                return nil
+            }
+
+            let transcript = transcriptSegments.joined(separator: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            return transcript.isEmpty ? nil : transcript
+        }
+    }
+
+    func cancel() {
+        stateQueue.sync {
+            isCancelled = true
+            isFinishing = true
+            bufferedSamples = []
+            transcriptSegments = []
+            pendingChunkTranscripts = [:]
+            nextEnqueuedChunkIndex = 0
+            nextTranscriptChunkIndex = 0
+            previousTail = ""
+        }
+    }
+
+    private func drainReadyChunks() -> [[Float]] {
+        var drainedChunks: [[Float]] = []
+
+        while bufferedSamples.count >= chunkSizeSamples {
+            drainedChunks.append(Array(bufferedSamples.prefix(chunkSizeSamples)))
+            let samplesToRemove = min(shiftSamples, bufferedSamples.count)
+            bufferedSamples.removeFirst(samplesToRemove)
+        }
+
+        return drainedChunks
+    }
+
+    private func enqueueChunk(_ chunk: [Float]) {
+        let chunkIndex = stateQueue.sync { () -> Int in
+            let chunkIndex = nextEnqueuedChunkIndex
+            nextEnqueuedChunkIndex += 1
+            return chunkIndex
+        }
+        group.enter()
+
+        Task {
+            let transcript = await transcribeChunk(chunk)
+            stateQueue.async {
+                defer { self.group.leave() }
+                self.storeCompletedTranscript(transcript, for: chunkIndex)
+            }
+        }
+    }
+
+    private func storeCompletedTranscript(_ transcript: String?, for chunkIndex: Int) {
+        guard isCancelled == false else {
+            return
+        }
+
+        pendingChunkTranscripts[chunkIndex] = transcript?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        flushCompletedTranscripts()
+    }
+
+    private func flushCompletedTranscripts() {
+        while let cleaned = pendingChunkTranscripts.removeValue(forKey: nextTranscriptChunkIndex) {
+            nextTranscriptChunkIndex += 1
+
+            guard cleaned.isEmpty == false else {
+                continue
+            }
+
+            let deduplicated = deduplicateOverlap(previous: previousTail, current: cleaned)
+            guard deduplicated.isEmpty == false else {
+                continue
+            }
+
+            transcriptSegments.append(deduplicated)
+            previousTail = deduplicated
+                .split(separator: " ")
+                .suffix(tailWordCount)
+                .joined(separator: " ")
+        }
+    }
+
+    private func deduplicateOverlap(previous: String, current: String) -> String {
+        guard previous.isEmpty == false else {
+            return current
+        }
+
+        let previousWords = previous.lowercased().split(separator: " ")
+        let currentWords = current.split(separator: " ")
+        let currentWordsLower = currentWords.map { $0.lowercased() }
+        let maxOverlap = min(previousWords.count, currentWordsLower.count, 8)
+
+        for overlapLength in stride(from: maxOverlap, through: 1, by: -1) {
+            let previousTail = previousWords.suffix(overlapLength)
+            let currentHead = currentWordsLower.prefix(overlapLength)
+
+            if Array(previousTail) == Array(currentHead).map({ Substring($0) }) {
+                return currentWords.dropFirst(overlapLength).joined(separator: " ")
+            }
+        }
+
+        return current
+    }
+}
+
 final class RecordingSessionCoordinator {
     typealias FinalizationResult = (filteredTranscript: String?, summary: DiarizationSummary)
 

--- a/GhostPepperTests/CleanupPromptBuilderTests.swift
+++ b/GhostPepperTests/CleanupPromptBuilderTests.swift
@@ -102,4 +102,89 @@ final class CleanupPromptBuilderTests: XCTestCase {
         XCTAssertFalse(prompt.contains("<HEARD>"))
         XCTAssertFalse(prompt.contains("<INTENDED>"))
     }
+
+    func testBuilderSeparatesStablePromptPrefixFromOCRSuffix() {
+        let builder = CleanupPromptBuilder()
+        let components = builder.buildPromptComponents(
+            basePrompt: "Base prompt",
+            windowContext: OCRContext(windowContents: "Frontmost text"),
+            preferredTranscriptions: ["Ghost Pepper"],
+            commonlyMisheard: [MisheardReplacement(wrong: "just see", right: "Jesse")],
+            includeWindowContext: true
+        )
+
+        XCTAssertTrue(components.stablePromptPrefix.contains("Base prompt"))
+        XCTAssertTrue(components.stablePromptPrefix.contains("<CORRECTION-HINTS>"))
+        XCTAssertFalse(components.stablePromptPrefix.contains("<OCR-RULES>"))
+        XCTAssertTrue(components.promptSuffix.contains("<OCR-RULES>"))
+        XCTAssertTrue(components.promptSuffix.contains("Frontmost text"))
+        XCTAssertEqual(components.fullPrompt, builder.buildPrompt(
+            basePrompt: "Base prompt",
+            windowContext: OCRContext(windowContents: "Frontmost text"),
+            preferredTranscriptions: ["Ghost Pepper"],
+            commonlyMisheard: [MisheardReplacement(wrong: "just see", right: "Jesse")],
+            includeWindowContext: true
+        ))
+    }
+
+    func testBuilderReturnsStablePromptOnlyWhenWindowContextIsUnavailable() {
+        let builder = CleanupPromptBuilder()
+        let components = builder.buildPromptComponents(
+            basePrompt: "Base prompt",
+            windowContext: nil,
+            preferredTranscriptions: ["Ghost Pepper"],
+            commonlyMisheard: [],
+            includeWindowContext: true
+        )
+
+        XCTAssertEqual(components.promptSuffix, "")
+        XCTAssertEqual(components.fullPrompt, components.stablePromptPrefix)
+        XCTAssertTrue(components.stablePromptPrefix.contains("Base prompt"))
+        XCTAssertTrue(components.stablePromptPrefix.contains("<CORRECTION-HINTS>"))
+    }
+
+    func testPrefillPlanExtractsContextPrefixAndReconstructsRemainingInput() throws {
+        let processedPrompt = """
+        <|im_start|>system
+        Base prompt
+        <|gp-system-split|>
+        <|im_end|>
+        <|im_start|>user
+        <|gp-user-split|><|im_end|>
+        <|im_start|>assistant
+        """
+
+        let plan = try XCTUnwrap(
+            CleanupPromptPrefillPlan(
+                systemPromptPrefix: "Base prompt",
+                processedPrompt: processedPrompt,
+                systemPromptSentinel: "<|gp-system-split|>",
+                userInputSentinel: "<|gp-user-split|>"
+            )
+        )
+
+        XCTAssertEqual(plan.contextPrefix, "<|im_start|>system\nBase prompt\n")
+        XCTAssertEqual(
+            plan.completionInput(
+                for: "Base prompt\n\n<OCR-RULES>screen context</OCR-RULES>",
+                userInput: "<USER-INPUT>\nhello world\n</USER-INPUT>"
+            ),
+            "\n\n<OCR-RULES>screen context</OCR-RULES>\n<|im_end|>\n<|im_start|>user\n<USER-INPUT>\nhello world\n</USER-INPUT><|im_end|>\n<|im_start|>assistant"
+        )
+    }
+
+    func testPrefillPlanRejectsPromptsThatDoNotShareThePrefilledPrefix() {
+        let processedPrompt = """
+        prefix<|gp-system-split|>middle<|gp-user-split|>suffix
+        """
+
+        let plan = CleanupPromptPrefillPlan(
+            systemPromptPrefix: "Base prompt",
+            processedPrompt: processedPrompt,
+            systemPromptSentinel: "<|gp-system-split|>",
+            userInputSentinel: "<|gp-user-split|>"
+        )
+
+        XCTAssertNil(plan?.completionInput(for: "Different prompt", userInput: "hello"))
+    }
 }

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -47,6 +47,30 @@ private final class FakeAppRelauncher: AppRelaunching {
     }
 }
 
+private final class FakeRecordingTranscriptionSession: RecordingTranscriptionSession {
+    private(set) var appendedChunks: [[Float]] = []
+    private(set) var finishCallCount = 0
+    private(set) var cancelCallCount = 0
+    var finalTranscript: String?
+
+    init(finalTranscript: String?) {
+        self.finalTranscript = finalTranscript
+    }
+
+    func appendAudioChunk(_ samples: [Float]) {
+        appendedChunks.append(samples)
+    }
+
+    func finishTranscription() async -> String? {
+        finishCallCount += 1
+        return finalTranscript
+    }
+
+    func cancel() {
+        cancelCallCount += 1
+    }
+}
+
 @MainActor
 final class GhostPepperTests: XCTestCase {
     private let pepperChatAppStorageKeys = [
@@ -534,6 +558,127 @@ final class GhostPepperTests: XCTestCase {
         )
 
         XCTAssertFalse(reloadedAppState.playSounds)
+    }
+
+    func testPrepareRecordingSessionStreamsChunksToDiarizationAndTranscriptionSessions() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let transcriptionSession = FakeRecordingTranscriptionSession(finalTranscript: "streamed transcript")
+        var diarizationChunks: [[Float]] = []
+
+        appState.speechModel = SpeechModelCatalog.parakeetV3.id
+        appState.ignoreOtherSpeakers = true
+        appState.recordingTranscriptionSessionFactory = { descriptor in
+            XCTAssertEqual(descriptor, SpeechModelCatalog.parakeetV3)
+            return transcriptionSession
+        }
+        appState.recordingSessionCoordinatorFactory = {
+            RecordingSessionCoordinator(
+                appendAudioChunk: { samples in
+                    diarizationChunks.append(samples)
+                },
+                finish: {
+                    (nil, Self.makeDiarizationSummary(usedFallback: true))
+                }
+            )
+        }
+
+        await appState.prepareRecordingSessionIfNeeded()
+        appState.audioRecorder.onConvertedAudioChunk?([1, 2, 3, 4])
+
+        XCTAssertNotNil(appState.activeRecordingSessionCoordinator)
+        XCTAssertEqual(diarizationChunks, [[1, 2, 3, 4]])
+        XCTAssertEqual(transcriptionSession.appendedChunks, [[1, 2, 3, 4]])
+    }
+
+    func testAppStateUsesRecordingTranscriptionSessionBeforeBatchFallback() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let transcriptionSession = FakeRecordingTranscriptionSession(finalTranscript: "streamed transcript")
+        let cleanedInputs = LockedValue<[String]>([])
+        var batchTranscriptionCallCount = 0
+
+        appState.speechModel = SpeechModelCatalog.parakeetV3.id
+        appState.recordingTranscriptionSessionFactory = { descriptor in
+            XCTAssertEqual(descriptor, SpeechModelCatalog.parakeetV3)
+            return transcriptionSession
+        }
+        appState.transcribeAudioBufferOverride = { _ in
+            batchTranscriptionCallCount += 1
+            return "batch transcript"
+        }
+        appState.cleanedTranscriptionResultOverride = { text, _ in
+            await cleanedInputs.append(text)
+            return (text: text, prompt: "", attemptedCleanup: false, cleanupUsedFallback: false)
+        }
+
+        await appState.prepareRecordingSessionIfNeeded()
+        appState.audioRecorder.onConvertedAudioChunk?([1, 2, 3])
+        appState.audioRecorder.onConvertedAudioChunk?([4, 5, 6])
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: appState.activeRecordingTranscriptionSession,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertEqual(transcriptionSession.appendedChunks, [[1, 2, 3], [4, 5, 6]])
+        XCTAssertEqual(transcriptionSession.finishCallCount, 1)
+        XCTAssertEqual(batchTranscriptionCallCount, 0)
+        let recordedCleanupInputs = await cleanedInputs.get()
+        XCTAssertEqual(recordedCleanupInputs, ["streamed transcript"])
+    }
+
+    func testAppStatePrefersFilteredSpeakerTranscriptOverStreamedTranscript() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let transcriptionSession = FakeRecordingTranscriptionSession(finalTranscript: "streamed transcript")
+        let cleanedInputs = LockedValue<[String]>([])
+        var batchTranscriptionCallCount = 0
+        let coordinator = RecordingSessionCoordinator(
+            appendAudioChunk: { _ in },
+            finish: {
+                ("speaker filtered transcript", Self.makeDiarizationSummary(usedFallback: false))
+            }
+        )
+
+        appState.transcribeAudioBufferOverride = { _ in
+            batchTranscriptionCallCount += 1
+            return "batch transcript"
+        }
+        appState.cleanedTranscriptionResultOverride = { text, _ in
+            await cleanedInputs.append(text)
+            return (text: text, prompt: "", attemptedCleanup: false, cleanupUsedFallback: false)
+        }
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4],
+            recordingSessionCoordinator: coordinator,
+            recordingTranscriptionSession: transcriptionSession,
+            archivedWindowContext: nil
+        )
+
+        let recordedCleanupInputs = await cleanedInputs.get()
+        XCTAssertEqual(recordedCleanupInputs, ["speaker filtered transcript"])
+        XCTAssertEqual(transcriptionSession.cancelCallCount, 1)
+        XCTAssertEqual(transcriptionSession.finishCallCount, 0)
+        XCTAssertEqual(batchTranscriptionCallCount, 0)
     }
 
     func testAppStatePipelineOwnershipAllowsSingleOwnerAtATime() throws {

--- a/GhostPepperTests/RecordingSessionCoordinatorTests.swift
+++ b/GhostPepperTests/RecordingSessionCoordinatorTests.swift
@@ -80,6 +80,57 @@ final class RecordingSessionCoordinatorTests: XCTestCase {
             [15, 16, 17, 18, 19],
         ])
     }
+
+    func testChunkedRecordingTranscriptionSessionTranscribesDuringRecordingAndDeduplicatesOverlap() async {
+        let transcribedChunks = LockedValue<[String]>([])
+        let session = ChunkedRecordingTranscriptionSession(
+            chunkSizeSamples: 4,
+            shiftSamples: 2,
+            transcribeChunk: { samples in
+                switch samples {
+                case [1, 2, 3, 4]:
+                    await transcribedChunks.append("hello there")
+                    return "hello there"
+                case [3, 4, 5, 6]:
+                    await transcribedChunks.append("there world")
+                    return "there world"
+                case [5, 6]:
+                    await transcribedChunks.append("world again")
+                    return "world again"
+                default:
+                    return nil
+                }
+            }
+        )
+
+        session.appendAudioChunk([1, 2])
+        session.appendAudioChunk([3, 4])
+        session.appendAudioChunk([5, 6])
+
+        let transcript = await session.finishTranscription()
+
+        XCTAssertEqual(transcript, "hello there world again")
+        let processed = await transcribedChunks.get()
+        XCTAssertEqual(Set(processed), Set(["hello there", "there world", "world again"]))
+    }
+
+    func testChunkedRecordingTranscriptionSessionCancelPreventsPendingTranscriptFromReturning() async {
+        let session = ChunkedRecordingTranscriptionSession(
+            chunkSizeSamples: 4,
+            shiftSamples: 4,
+            transcribeChunk: { _ in
+                try? await Task.sleep(nanoseconds: 50_000_000)
+                return "should not be returned"
+            }
+        )
+
+        session.appendAudioChunk([1, 2, 3, 4])
+        session.cancel()
+
+        let transcript = await session.finishTranscription()
+
+        XCTAssertNil(transcript)
+    }
 }
 
 private actor LockedValue<Value> {
@@ -95,5 +146,9 @@ private actor LockedValue<Value> {
 
     func set(_ value: Value) {
         self.value = value
+    }
+
+    func append<Element>(_ newElement: Element) where Value == [Element] {
+        value.append(newElement)
     }
 }


### PR DESCRIPTION
## Summary
- start cleanup prompt prefill when recording begins so the stable system prompt is already in context before transcription finishes
- transcribe FluidAudio recordings incrementally during capture and use that streamed transcript before falling back to the old batch path
- preserve the existing streaming diarization path by feeding converted audio chunks to both the diarization coordinator and the live transcription session, while still preferring filtered-speaker output when diarization succeeds
- pin Ghost Pepper to `obra/LLM.swift` `main` at `c2144e1`, which exposes the minimal `LLMCore` APIs needed for prompt-context prefill

## Verification
- `xcodebuild test -project GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS' -clonedSourcePackagesDirPath /Users/jesse/Library/Developer/Xcode/DerivedData/GhostPepper-stable-signed/SourcePackages -disableAutomaticPackageResolution -skipMacroValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -only-testing:GhostPepperTests/CleanupPromptBuilderTests/testBuilderSeparatesStablePromptPrefixFromOCRSuffix -only-testing:GhostPepperTests/CleanupPromptBuilderTests/testBuilderReturnsStablePromptOnlyWhenWindowContextIsUnavailable -only-testing:GhostPepperTests/CleanupPromptBuilderTests/testPrefillPlanExtractsContextPrefixAndReconstructsRemainingInput -only-testing:GhostPepperTests/CleanupPromptBuilderTests/testPrefillPlanRejectsPromptsThatDoNotShareThePrefilledPrefix -only-testing:GhostPepperTests/RecordingSessionCoordinatorTests/testChunkedRecordingTranscriptionSessionTranscribesDuringRecordingAndDeduplicatesOverlap -only-testing:GhostPepperTests/RecordingSessionCoordinatorTests/testChunkedRecordingTranscriptionSessionCancelPreventsPendingTranscriptFromReturning -only-testing:GhostPepperTests/GhostPepperTests/testPrepareRecordingSessionStreamsChunksToDiarizationAndTranscriptionSessions -only-testing:GhostPepperTests/GhostPepperTests/testAppStateUsesRecordingTranscriptionSessionBeforeBatchFallback -only-testing:GhostPepperTests/GhostPepperTests/testAppStatePrefersFilteredSpeakerTranscriptOverStreamedTranscript`
