### PR TITLE
Reduce transcription latency and improve speaker tagging

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -730,7 +730,7 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					5EBC085BD56A3725D371FB1A = {
-						DevelopmentTeam = BBVMGXR9AY;
+						DevelopmentTeam = 87WJ58S66M;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -955,7 +955,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = BBVMGXR9AY;
+				DEVELOPMENT_TEAM = 87WJ58S66M;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				INFOPLIST_FILE = GhostPepper/Info.plist;
@@ -1102,7 +1102,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = BBVMGXR9AY;
+				DEVELOPMENT_TEAM = 87WJ58S66M;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				INFOPLIST_FILE = GhostPepper/Info.plist;

--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		056C454F3BD1A9795C6775A5 /* ScreenRecordingPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4B61BA7270EEC11A8AC69 /* ScreenRecordingPermissionController.swift */; };
 		0606E11E6F102BBB44ED08B6 /* ScreenRecordingPermissionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9ECBFE04804AA79262A07B /* ScreenRecordingPermissionControllerTests.swift */; };
 		09DA02222FFAFD8F32DB0212 /* TranscriptionLabStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */; };
+		09DA02222FFAFD8F32DB0213 /* RecognizedVoiceStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EC6EEC8F041DE99399C3E4 /* RecognizedVoiceStoreTests.swift */; };
+		09DA02222FFAFD8F32DB0214 /* TranscriptionLabSpeakerProfileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EC6EEC8F041DE99399C3E5 /* TranscriptionLabSpeakerProfileStoreTests.swift */; };
+		09DA02222FFAFD8F32DB0215 /* RecognizedVoiceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EC6EEC8F041DE99399C3E6 /* RecognizedVoiceStore.swift */; };
+		09DA02222FFAFD8F32DB0217 /* SpeakerIdentityResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EC6EEC8F041DE99399C3E7 /* SpeakerIdentityResolverTests.swift */; };
+		09DA02222FFAFD8F32DB0218 /* SpeakerIdentityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EC6EEC8F041DE99399C3E8 /* SpeakerIdentityResolver.swift */; };
 		0A1823314AE4FF4E17DCF627 /* sprite_frame_0.png in Resources */ = {isa = PBXBuildFile; fileRef = 2AF744C59EEAE51FC81BE6D6 /* sprite_frame_0.png */; };
 		0BC5D4645D21CA8AA000972E /* RecordingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3540C6212101C885EA22CD /* RecordingOverlay.swift */; };
 		0CDA12F05A7C7464334FDD37 /* RecordingOCRPrefetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E9AADC67C525B0A9E382AB /* RecordingOCRPrefetch.swift */; };
@@ -280,6 +285,11 @@
 		D6A098A2516C7563B1E4FDD3 /* ModelManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagerTests.swift; sourceTree = "<group>"; };
 		D7E1E5A0F12FE2B2FB5CD874 /* TranscriptionLabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabController.swift; sourceTree = "<group>"; };
 		D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabStoreTests.swift; sourceTree = "<group>"; };
+		D7EC6EEC8F041DE99399C3E4 /* RecognizedVoiceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizedVoiceStoreTests.swift; sourceTree = "<group>"; };
+		D7EC6EEC8F041DE99399C3E5 /* TranscriptionLabSpeakerProfileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabSpeakerProfileStoreTests.swift; sourceTree = "<group>"; };
+		D7EC6EEC8F041DE99399C3E6 /* RecognizedVoiceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizedVoiceStore.swift; sourceTree = "<group>"; };
+		D7EC6EEC8F041DE99399C3E7 /* SpeakerIdentityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerIdentityResolverTests.swift; sourceTree = "<group>"; };
+		D7EC6EEC8F041DE99399C3E8 /* SpeakerIdentityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerIdentityResolver.swift; sourceTree = "<group>"; };
 		DB753C40197FA7255E1DEA29 /* PepperChatWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PepperChatWindow.swift; sourceTree = "<group>"; };
 		DBE6E6C11EA04C058C642573 /* MeetingSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSession.swift; sourceTree = "<group>"; };
 		DD3CB656299CBD7D3F6613F3 /* sprite_frame_3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_3.png; sourceTree = "<group>"; };
@@ -382,6 +392,7 @@
 				4E70E33203498F61C51BF026 /* Meeting */,
 				FA20193940C27BBC6AFB5ADB /* PepperChat */,
 				4694A9A6CDA9C5FA6623F377 /* Resources */,
+				09DA02222FFAFD8F32DB0216 /* SpeakerIdentity */,
 				B242BF76D6E42784C2A05EB5 /* Transcription */,
 				50C964CA46111D1FD8AFE84B /* UI */,
 			);
@@ -431,6 +442,15 @@
 				E0BBD0F5DD1B827D03F0F8F6 /* sprite_frame_4@2x.png */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		09DA02222FFAFD8F32DB0216 /* SpeakerIdentity */ = {
+			isa = PBXGroup;
+			children = (
+				D7EC6EEC8F041DE99399C3E6 /* RecognizedVoiceStore.swift */,
+				D7EC6EEC8F041DE99399C3E8 /* SpeakerIdentityResolver.swift */,
+			);
+			path = SpeakerIdentity;
 			sourceTree = "<group>";
 		};
 		4E59EAEBA3CA7C181A8ECEBA /* Lab */ = {
@@ -618,17 +638,20 @@
 				A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */,
 				59666FBC728BF70A61983188 /* PerformanceTraceTests.swift */,
 				ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */,
+				D7EC6EEC8F041DE99399C3E4 /* RecognizedVoiceStoreTests.swift */,
 				80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */,
 				AD0C972BC69839C41ACA2E8C /* RecordingSessionCoordinatorTests.swift */,
 				38C742095D3934D70BCE44E4 /* RuntimeModelInventoryTests.swift */,
 				9C9ECBFE04804AA79262A07B /* ScreenRecordingPermissionControllerTests.swift */,
 				231812B1BF8E3F2D5E0209F3 /* ShortcutCaptureStateTests.swift */,
+				D7EC6EEC8F041DE99399C3E7 /* SpeakerIdentityResolverTests.swift */,
 				6B1A6E1B8F3D8C8F234BD408 /* SpeechTranscriberTests.swift */,
 				49848DB685A19FBB6557B76E /* TextCleanerTests.swift */,
 				770403076BA384F3E35AA7A1 /* TextCleanupManagerTests.swift */,
 				B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */,
 				335E3F3AA3803E2274CF6197 /* TranscriptionLabControllerTests.swift */,
 				48FD8FBD546233B0547BB89D /* TranscriptionLabRunnerTests.swift */,
+				D7EC6EEC8F041DE99399C3E5 /* TranscriptionLabSpeakerProfileStoreTests.swift */,
 				D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */,
 			);
 			path = GhostPepperTests;
@@ -825,6 +848,8 @@
 				0CDA12F05A7C7464334FDD37 /* RecordingOCRPrefetch.swift in Sources */,
 				0BC5D4645D21CA8AA000972E /* RecordingOverlay.swift in Sources */,
 				759A9AD44DEF66C03D435B0F /* RecordingSessionCoordinator.swift in Sources */,
+				09DA02222FFAFD8F32DB0215 /* RecognizedVoiceStore.swift in Sources */,
+				09DA02222FFAFD8F32DB0218 /* SpeakerIdentityResolver.swift in Sources */,
 				056C454F3BD1A9795C6775A5 /* ScreenRecordingPermissionController.swift in Sources */,
 				80C9E55FF57A1A03033DDDAE /* SettingsWindow.swift in Sources */,
 				D87DC24D05DAC4ED292C077B /* ShortcutCaptureState.swift in Sources */,
@@ -892,17 +917,20 @@
 				E5E590FA60691DA4B57DA7CB /* OCRContextTests.swift in Sources */,
 				E3302E239909CAEC0865A035 /* PerformanceTraceTests.swift in Sources */,
 				41C94A48B97D3A6861EA1E92 /* PostPasteLearningCoordinatorTests.swift in Sources */,
+				09DA02222FFAFD8F32DB0213 /* RecognizedVoiceStoreTests.swift in Sources */,
 				4DD74E9C222518EEB0DA2A9B /* RecordingOCRPrefetchTests.swift in Sources */,
 				2E80774D95EAC6D6B53A226D /* RecordingSessionCoordinatorTests.swift in Sources */,
 				571085951E318B0ADD2B00EA /* RuntimeModelInventoryTests.swift in Sources */,
 				0606E11E6F102BBB44ED08B6 /* ScreenRecordingPermissionControllerTests.swift in Sources */,
 				BE7701382D2CC62C1CEBF29C /* ShortcutCaptureStateTests.swift in Sources */,
+				09DA02222FFAFD8F32DB0217 /* SpeakerIdentityResolverTests.swift in Sources */,
 				BEC965DB305742A9F42897F8 /* SpeechTranscriberTests.swift in Sources */,
 				EE25B297BB7834C3C90423B9 /* TextCleanerTests.swift in Sources */,
 				E061E99A8C7A3977245EAEC5 /* TextCleanupManagerTests.swift in Sources */,
 				90F411F8E3564F1C5DDD1A5F /* TextPasterTests.swift in Sources */,
 				F43D0549F804473CD7C8A6A6 /* TranscriptionLabControllerTests.swift in Sources */,
 				950E9B7AB1223E2B2D679B71 /* TranscriptionLabRunnerTests.swift in Sources */,
+				09DA02222FFAFD8F32DB0214 /* TranscriptionLabSpeakerProfileStoreTests.swift in Sources */,
 				09DA02222FFAFD8F32DB0212 /* TranscriptionLabStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -564,6 +564,8 @@ class AppState: ObservableObject {
                 activeRecordingTranscriptionSession = recordingTranscriptionSessionFactory(
                     speechModelDescriptor
                 )
+            } else if let recordingTranscriptionSession = modelManager.makeRecordingTranscriptionSession() {
+                activeRecordingTranscriptionSession = recordingTranscriptionSession
             } else if speechModelDescriptor.backend == .fluidAudio {
                 activeRecordingTranscriptionSession = ChunkedRecordingTranscriptionSession(
                     transcribeChunk: { [weak self] samples in
@@ -831,22 +833,52 @@ class AppState: ObservableObject {
         recordingSessionCoordinator: RecordingSessionCoordinator?,
         recordingTranscriptionSession: RecordingTranscriptionSession?
     ) async -> RecordingTranscriptionResult {
+        let diarizationTask = recordingSessionCoordinator.map { coordinator in
+            Task {
+                await coordinator.finishResult()
+            }
+        }
+        let concurrentRecordingTranscriptionSession: RecordingTranscriptionSession?
+        if let recordingTranscriptionSession,
+           recordingTranscriptionSession.supportsConcurrentFinalization {
+            concurrentRecordingTranscriptionSession = recordingTranscriptionSession
+        } else {
+            concurrentRecordingTranscriptionSession = nil
+        }
+
+        let streamedTranscriptTask = concurrentRecordingTranscriptionSession.map { session in
+            Task<String?, Never> {
+                await session.finishTranscription()?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+        }
+
         var diarizationSummary: DiarizationSummary?
+        if let diarizationTask {
+            let diarizationResult = await diarizationTask.value
+            diarizationSummary = diarizationResult.summary
 
-        if let recordingSessionCoordinator {
-            let summary = await recordingSessionCoordinator.finish()
-            diarizationSummary = summary
-
-            if summary.usedFallback == false,
-               let filteredTranscript = recordingSessionCoordinator.filteredTranscript,
+            if diarizationResult.summary.usedFallback == false,
+               let filteredTranscript = diarizationResult.filteredTranscript?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
                filteredTranscript.isEmpty == false {
                 recordingTranscriptionSession?.cancel()
                 return RecordingTranscriptionResult(
                     rawTranscription: filteredTranscript,
                     speakerFilteringRan: true,
-                    diarizationSummary: summary
+                    diarizationSummary: diarizationResult.summary
                 )
             }
+        }
+
+        if let streamedTranscriptTask,
+           let streamedTranscript = await streamedTranscriptTask.value,
+           streamedTranscript.isEmpty == false {
+            return RecordingTranscriptionResult(
+                rawTranscription: streamedTranscript,
+                speakerFilteringRan: recordingSessionCoordinator != nil,
+                diarizationSummary: diarizationSummary
+            )
         }
 
         if let recordingTranscriptionSession,

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -892,7 +892,8 @@ class AppState: ObservableObject {
             )
         }
 
-        if let recordingTranscriptionSession,
+        if concurrentRecordingTranscriptionSession == nil,
+           let recordingTranscriptionSession,
            let streamedTranscript = await recordingTranscriptionSession.finishTranscription()?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            streamedTranscript.isEmpty == false {

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -574,6 +574,12 @@ class AppState: ObservableObject {
                 )
             } else if let recordingTranscriptionSession = modelManager.makeRecordingTranscriptionSession() {
                 activeRecordingTranscriptionSession = recordingTranscriptionSession
+            } else if speechModelDescriptor.backend == .fluidAudio {
+                activeRecordingTranscriptionSession = ChunkedRecordingTranscriptionSession(
+                    transcribeChunk: { [weak self] samples in
+                        await self?.transcribeAudioBuffer(samples)
+                    }
+                )
             }
         }
 

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1470,8 +1470,9 @@ class AppState: ObservableObject {
 
     func rerunTranscriptionLabTranscription(
         _ entry: TranscriptionLabEntry,
-        speechModelID: String
-    ) async throws -> String {
+        speechModelID: String,
+        speakerTaggingEnabled: Bool
+    ) async throws -> TranscriptionLabTranscriptionResult {
         guard acquirePipeline(for: .transcriptionLab) else {
             throw TranscriptionLabRunnerError.pipelineBusy
         }
@@ -1483,6 +1484,7 @@ class AppState: ObservableObject {
             let result = try await runner.rerunTranscription(
                 entry: entry,
                 speechModelID: speechModelID,
+                speakerTaggingEnabled: speakerTaggingEnabled,
                 acquirePipeline: { true },
                 releasePipeline: {}
             )
@@ -1633,6 +1635,10 @@ class AppState: ObservableObject {
             },
             transcribe: { [transcriber] audioBuffer in
                 await transcriber.transcribe(audioBuffer: audioBuffer)
+            },
+            runSpeakerTagging: { [weak self] audioBuffer in
+                guard let self else { return nil }
+                return await self.modelManager.transcribeWithSpeakerTagging(audioBuffer: audioBuffer)
             },
             clean: { [textCleaner] text, activePrompt, modelKind in
                 await textCleaner.cleanWithPerformance(

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -29,6 +29,7 @@ class AppState: ObservableObject {
         attemptedCleanup: Bool,
         cleanupUsedFallback: Bool
     )
+    typealias WindowContextProvider = @MainActor () async -> RecordingOCRPrefetchResult?
 
     private struct RecordingTranscriptionResult {
         let rawTranscription: String?
@@ -692,23 +693,21 @@ class AppState: ObservableObject {
         status = .transcribing
         overlay.show(message: .transcribing)
         activePerformanceTrace?.transcriptionStartAt = Date()
-
-        let archivedWindowContext: OCRContext?
+        let windowContextProvider: WindowContextProvider?
         if frontmostWindowContextEnabled {
-            let prefetchedContext = await recordingOCRPrefetch.resolve()
-            archivedWindowContext = prefetchedContext?.context
-            if activeCleanupAttempted == false {
-                activePerformanceTrace?.ocrCaptureDuration = prefetchedContext?.elapsed
+            windowContextProvider = { [weak self] in
+                await self?.recordingOCRPrefetch.resolve()
             }
         } else {
-            archivedWindowContext = nil
+            windowContextProvider = nil
         }
 
         let didProduceTranscript = await processRecordingResult(
             audioBuffer: buffer,
             recordingSessionCoordinator: recordingSessionCoordinator,
             recordingTranscriptionSession: recordingTranscriptionSession,
-            archivedWindowContext: archivedWindowContext,
+            archivedWindowContext: nil,
+            windowContextProvider: windowContextProvider,
             shouldPaste: true,
             shouldRecordDebugSnapshot: true
         )
@@ -736,13 +735,15 @@ class AppState: ObservableObject {
         audioBuffer: [Float],
         recordingSessionCoordinator: RecordingSessionCoordinator?,
         recordingTranscriptionSession: RecordingTranscriptionSession? = nil,
-        archivedWindowContext: OCRContext?
+        archivedWindowContext: OCRContext?,
+        windowContextProvider: WindowContextProvider? = nil
     ) async {
         _ = await processRecordingResult(
             audioBuffer: audioBuffer,
             recordingSessionCoordinator: recordingSessionCoordinator,
             recordingTranscriptionSession: recordingTranscriptionSession,
             archivedWindowContext: archivedWindowContext,
+            windowContextProvider: windowContextProvider,
             shouldPaste: false,
             shouldRecordDebugSnapshot: false
         )
@@ -753,6 +754,7 @@ class AppState: ObservableObject {
         recordingSessionCoordinator: RecordingSessionCoordinator?,
         recordingTranscriptionSession: RecordingTranscriptionSession?,
         archivedWindowContext: OCRContext?,
+        windowContextProvider: WindowContextProvider?,
         shouldPaste: Bool,
         shouldRecordDebugSnapshot: Bool
     ) async -> Bool {
@@ -763,6 +765,7 @@ class AppState: ObservableObject {
         )
 
         guard let text = transcriptionResult.rawTranscription else {
+            recordingOCRPrefetch.cancel()
             await archiveRecordingForLab(
                 audioBuffer: audioBuffer,
                 windowContext: archivedWindowContext,
@@ -778,9 +781,15 @@ class AppState: ObservableObject {
         }
 
         activePerformanceTrace?.transcriptionEndAt = Date()
-        let windowContext = archivedWindowContext
+        var windowContext = archivedWindowContext
         if cleanupEnabled && canAttemptCleanup {
             activeCleanupAttempted = true
+            if frontmostWindowContextEnabled,
+               windowContext == nil,
+               let resolvedWindowContext = await windowContextProvider?() {
+                windowContext = resolvedWindowContext.context
+                activePerformanceTrace?.ocrCaptureDuration = resolvedWindowContext.elapsed
+            }
             activePerformanceTrace?.cleanupStartAt = Date()
             status = .cleaningUp
             if shouldPaste {
@@ -789,6 +798,8 @@ class AppState: ObservableObject {
             if frontmostWindowContextEnabled, windowContext == nil {
                 debugLogStore.record(category: .ocr, message: "No frontmost-window OCR context was captured.")
             }
+        } else {
+            recordingOCRPrefetch.cancel()
         }
 
         let cleanupResult = await cleanedTranscriptionResult(text, windowContext: windowContext)
@@ -887,6 +898,15 @@ class AppState: ObservableObject {
            streamedTranscript.isEmpty == false {
             return RecordingTranscriptionResult(
                 rawTranscription: streamedTranscript,
+                speakerFilteringRan: recordingSessionCoordinator != nil,
+                diarizationSummary: diarizationSummary
+            )
+        }
+
+        if let recordingTranscriptionSession,
+           recordingTranscriptionSession.allowsBatchFallback == false {
+            return RecordingTranscriptionResult(
+                rawTranscription: nil,
                 speakerFilteringRan: recordingSessionCoordinator != nil,
                 diarizationSummary: diarizationSummary
             )

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -126,6 +126,8 @@ class AppState: ObservableObject {
     let postPasteLearningCoordinator: PostPasteLearningCoordinator
     let debugLogStore: DebugLogStore
     let transcriptionLabStore: TranscriptionLabStore
+    let recognizedVoiceStore: RecognizedVoiceStore
+    let transcriptionLabSpeakerProfileStore: TranscriptionLabSpeakerProfileStore
     let appRelauncher: AppRelaunching
     var recordingSessionCoordinatorFactory: (() -> RecordingSessionCoordinator?)?
     var recordingTranscriptionSessionFactory: ((SpeechModelDescriptor) -> RecordingTranscriptionSession?)?
@@ -149,6 +151,7 @@ class AppState: ObservableObject {
     private var cleanupStateObserver: AnyCancellable?
     private var modelStateObserver: AnyCancellable?
     private let recordingOCRPrefetch: RecordingOCRPrefetch
+    private let speakerIdentityResolver = SpeakerIdentityResolver()
     private var activePerformanceTrace: PerformanceTrace?
     private var activeCleanupAttempted = false
     private var pipelineOwner: PipelineOwner?
@@ -200,6 +203,8 @@ class AppState: ObservableObject {
         textPaster: TextPaster = TextPaster(),
         debugLogStore: DebugLogStore = DebugLogStore(),
         transcriptionLabStore: TranscriptionLabStore = TranscriptionLabStore(),
+        recognizedVoiceStore: RecognizedVoiceStore = RecognizedVoiceStore(),
+        transcriptionLabSpeakerProfileStore: TranscriptionLabSpeakerProfileStore = TranscriptionLabSpeakerProfileStore(),
         appRelauncher: AppRelaunching? = nil,
         inputMonitoringChecker: @escaping () -> Bool = PermissionChecker.checkInputMonitoring,
         inputMonitoringPrompter: @escaping () -> Void = PermissionChecker.promptInputMonitoring
@@ -211,6 +216,8 @@ class AppState: ObservableObject {
         self.textPaster = textPaster
         self.debugLogStore = debugLogStore
         self.transcriptionLabStore = transcriptionLabStore
+        self.recognizedVoiceStore = recognizedVoiceStore
+        self.transcriptionLabSpeakerProfileStore = transcriptionLabSpeakerProfileStore
         self.appRelauncher = appRelauncher ?? AppRelauncher()
         self.inputMonitoringChecker = inputMonitoringChecker
         self.inputMonitoringPrompter = inputMonitoringPrompter
@@ -1464,6 +1471,50 @@ class AppState: ObservableObject {
         try transcriptionLabStore.loadStageTimings()
     }
 
+    func loadRecognizedVoiceProfiles() throws -> [RecognizedVoiceProfile] {
+        try recognizedVoiceStore.loadProfiles()
+    }
+
+    func upsertRecognizedVoiceProfile(_ profile: RecognizedVoiceProfile) throws {
+        try recognizedVoiceStore.upsert(profile)
+    }
+
+    func loadTranscriptionLabSpeakerProfiles(
+        for entryID: UUID
+    ) throws -> [TranscriptionLabSpeakerProfile] {
+        try transcriptionLabSpeakerProfileStore.loadProfiles(for: entryID)
+    }
+
+    func upsertTranscriptionLabSpeakerProfile(_ profile: TranscriptionLabSpeakerProfile) throws {
+        try transcriptionLabSpeakerProfileStore.upsert(profile)
+    }
+
+    func updateGlobalVoiceProfile(
+        from localProfile: TranscriptionLabSpeakerProfile
+    ) throws -> RecognizedVoiceProfile? {
+        guard let recognizedVoiceID = localProfile.recognizedVoiceID else {
+            return nil
+        }
+
+        let normalizedName = localProfile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            var recognizedVoice = try recognizedVoiceStore.loadProfiles().first(where: { $0.id == recognizedVoiceID })
+        else {
+            return nil
+        }
+
+        if normalizedName.isEmpty == false {
+            recognizedVoice.displayName = normalizedName
+        }
+        recognizedVoice.isMe = localProfile.isMe
+        if localProfile.evidenceTranscript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            recognizedVoice.evidenceTranscript = localProfile.evidenceTranscript
+        }
+        recognizedVoice.updatedAt = Date()
+        try recognizedVoiceStore.upsert(recognizedVoice)
+        return recognizedVoice
+    }
+
     func transcriptionLabAudioURL(for entry: TranscriptionLabEntry) -> URL {
         transcriptionLabStore.audioURL(for: entry.audioFileName)
     }
@@ -1623,6 +1674,145 @@ class AppState: ObservableObject {
         objectWillChange.send()
     }
 
+    private func resolveTranscriptionLabSpeakerProfiles(
+        entryID: UUID,
+        audioBuffer: [Float],
+        diarizationSummary: DiarizationSummary,
+        speakerTaggedTranscript: SpeakerTaggedTranscript?
+    ) async -> [TranscriptionLabSpeakerProfile] {
+        do {
+            let recognizedVoices = try recognizedVoiceStore.loadProfiles()
+            let existingLocalProfiles = try transcriptionLabSpeakerProfileStore.loadProfiles(for: entryID)
+            let speakerInputs = await makeSpeakerIdentityInputs(
+                audioBuffer: audioBuffer,
+                diarizationSummary: diarizationSummary,
+                speakerTaggedTranscript: speakerTaggedTranscript
+            )
+            let resolution = speakerIdentityResolver.resolve(
+                entryID: entryID,
+                speakers: speakerInputs,
+                existingLocalProfiles: existingLocalProfiles,
+                recognizedVoices: recognizedVoices
+            )
+
+            for profile in resolution.recognizedVoices {
+                try recognizedVoiceStore.upsert(profile)
+            }
+            for profile in resolution.localProfiles {
+                try transcriptionLabSpeakerProfileStore.upsert(profile)
+            }
+
+            return resolution.localProfiles
+        } catch {
+            return []
+        }
+    }
+
+    private func makeSpeakerIdentityInputs(
+        audioBuffer: [Float],
+        diarizationSummary: DiarizationSummary,
+        speakerTaggedTranscript: SpeakerTaggedTranscript?
+    ) async -> [SpeakerIdentityInput] {
+        let speakerIDs = diarizationSummary.spans.reduce(into: [String]()) { orderedIDs, span in
+            if orderedIDs.contains(span.speakerID) == false {
+                orderedIDs.append(span.speakerID)
+            }
+        }
+
+        var inputs: [SpeakerIdentityInput] = []
+        inputs.reserveCapacity(speakerIDs.count)
+
+        for speakerID in speakerIDs {
+            let speakerSpans = mergedSpeakerSpans(
+                from: diarizationSummary.spans.filter { $0.speakerID == speakerID }
+            )
+            let speakerAudio = extractSpeakerAudio(
+                from: audioBuffer,
+                spans: speakerSpans
+            )
+            let evidenceTranscript = speakerTaggedTranscript?.segments
+                .filter { $0.speakerID == speakerID }
+                .map(\.text)
+                .joined(separator: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let audioDuration = speakerSpans.reduce(into: 0.0) { total, span in
+                total += span.duration
+            }
+            let embedding: [Float]?
+            if audioDuration >= speakerIdentityResolver.minimumEmbeddingDuration,
+               speakerAudio.isEmpty == false {
+                embedding = try? await modelManager.extractSpeakerEmbedding(from: speakerAudio)
+            } else {
+                embedding = nil
+            }
+
+            inputs.append(
+                SpeakerIdentityInput(
+                    speakerID: speakerID,
+                    audioDuration: audioDuration,
+                    evidenceTranscript: evidenceTranscript,
+                    embedding: embedding
+                )
+            )
+        }
+
+        return inputs
+    }
+
+    private func mergedSpeakerSpans(
+        from spans: [DiarizationSummary.Span]
+    ) -> [DiarizationSummary.MergedSpan] {
+        let sortedSpans = spans.sorted { lhs, rhs in
+            if lhs.startTime == rhs.startTime {
+                return lhs.endTime < rhs.endTime
+            }
+            return lhs.startTime < rhs.startTime
+        }
+
+        var mergedSpans: [DiarizationSummary.MergedSpan] = []
+        for span in sortedSpans where span.duration > 0 {
+            if let lastSpan = mergedSpans.last,
+               span.startTime <= lastSpan.endTime {
+                mergedSpans[mergedSpans.count - 1] = DiarizationSummary.MergedSpan(
+                    startTime: lastSpan.startTime,
+                    endTime: max(lastSpan.endTime, span.endTime)
+                )
+            } else {
+                mergedSpans.append(
+                    DiarizationSummary.MergedSpan(
+                        startTime: span.startTime,
+                        endTime: span.endTime
+                    )
+                )
+            }
+        }
+
+        return mergedSpans
+    }
+
+    private func extractSpeakerAudio(
+        from audioBuffer: [Float],
+        spans: [DiarizationSummary.MergedSpan],
+        sampleRate: Double = 16_000
+    ) -> [Float] {
+        guard audioBuffer.isEmpty == false else {
+            return []
+        }
+
+        var extractedAudio: [Float] = []
+        for span in spans where span.duration > 0 {
+            let startIndex = max(Int((span.startTime * sampleRate).rounded(.down)), 0)
+            let endIndex = min(Int((span.endTime * sampleRate).rounded(.up)), audioBuffer.count)
+            guard startIndex < endIndex else {
+                continue
+            }
+
+            extractedAudio.append(contentsOf: audioBuffer[startIndex..<endIndex])
+        }
+
+        return extractedAudio
+    }
+
     private func makeTranscriptionLabRunner() -> TranscriptionLabRunner {
         TranscriptionLabRunner(
             loadAudioBuffer: { [transcriptionLabStore] entry in
@@ -1639,6 +1829,15 @@ class AppState: ObservableObject {
             runSpeakerTagging: { [weak self] audioBuffer in
                 guard let self else { return nil }
                 return await self.modelManager.transcribeWithSpeakerTagging(audioBuffer: audioBuffer)
+            },
+            resolveSpeakerProfiles: { [weak self] entryID, audioBuffer, diarizationSummary, speakerTaggedTranscript in
+                guard let self else { return [] }
+                return await self.resolveTranscriptionLabSpeakerProfiles(
+                    entryID: entryID,
+                    audioBuffer: audioBuffer,
+                    diarizationSummary: diarizationSummary,
+                    speakerTaggedTranscript: speakerTaggedTranscript
+                )
             },
             clean: { [textCleaner] text, activePrompt, modelKind in
                 await textCleaner.cleanWithPerformance(

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -574,12 +574,6 @@ class AppState: ObservableObject {
                 )
             } else if let recordingTranscriptionSession = modelManager.makeRecordingTranscriptionSession() {
                 activeRecordingTranscriptionSession = recordingTranscriptionSession
-            } else if speechModelDescriptor.backend == .fluidAudio {
-                activeRecordingTranscriptionSession = ChunkedRecordingTranscriptionSession(
-                    transcribeChunk: { [weak self] samples in
-                        await self?.transcribeAudioBuffer(samples)
-                    }
-                )
             }
         }
 

--- a/GhostPepper/Audio/AudioRecorder.swift
+++ b/GhostPepper/Audio/AudioRecorder.swift
@@ -15,6 +15,7 @@ final class AudioRecorder {
     private var engine = AVAudioEngine()
     private var configuredTargetDeviceID: AudioDeviceID?
     private let bufferLock = NSLock()
+    private let tapStateLock = NSLock()
 
     /// The accumulated audio samples captured during recording.
     /// Accessible for reading within the module (internal) so tests can inspect it.
@@ -24,6 +25,11 @@ final class AudioRecorder {
     private lazy var targetFormat: AVAudioFormat = {
         AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
     }()
+    private let stopFlushSlackNanoseconds: UInt64 = 5_000_000
+    private var tapBufferDurationNanoseconds: UInt64 = 20_000_000
+    private var lastConvertedChunkAtNanoseconds: UInt64?
+    private var inFlightTapCallbacks = 0
+    private var stopWaitContinuation: CheckedContinuation<Void, Never>?
 
     /// Pre-warm the audio engine so the first recording starts faster.
     func prewarm() {
@@ -134,14 +140,18 @@ final class AudioRecorder {
             throw AudioRecorderError.noInputAvailable
         }
 
-        // Roughly 100ms of audio at the actual HW rate.
-        let bufferSize: AVAudioFrameCount = AVAudioFrameCount(hwFormat.sampleRate * 0.1)
+        // Keep the tap interval short so stop-time tail flushes stay cheap.
+        let bufferDuration = 0.02
+        let bufferSize = max(1, AVAudioFrameCount(hwFormat.sampleRate * bufferDuration))
+        resetTapDrainState(bufferDurationSeconds: Double(bufferSize) / hwFormat.sampleRate)
 
         cachedConverter = nil
         cachedConverterSourceFormat = nil
 
         inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: hwFormat) { [weak self] pcmBuffer, _ in
             guard let self = self else { return }
+            self.beginTapCallback()
+            defer { self.endTapCallback() }
 
             // For devices with >2 channels (e.g. aggregate devices), AVAudioConverter
             // can't downmix to mono. Manually downmix to mono first, then convert.
@@ -212,13 +222,17 @@ final class AudioRecorder {
     }
 
     /// Stops capturing audio and returns the recorded buffer.
-    /// Waits briefly to flush any remaining audio in the engine's buffer.
+    /// Waits only for the remainder of the active tap interval plus any
+    /// in-flight conversion work so stop latency tracks the tap size.
     func stopRecording() async -> [Float] {
-        // Wait 200ms to let the last audio buffers flush through
-        try? await Task.sleep(nanoseconds: 200_000_000)
+        let flushDelay = stopFlushDelayNanoseconds()
+        if flushDelay > 0 {
+            try? await Task.sleep(nanoseconds: flushDelay)
+        }
 
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
+        await waitForTapCallbacksToDrain()
         onRecordingStopped?()
 
         let result = snapshotBuffer()
@@ -336,7 +350,87 @@ final class AudioRecorder {
         audioBuffer.append(contentsOf: frames)
         bufferLock.unlock()
 
+        recordConvertedChunkArrival()
         onConvertedAudioChunk?(frames)
+    }
+
+    private func resetTapDrainState(bufferDurationSeconds: TimeInterval) {
+        tapStateLock.lock()
+        defer { tapStateLock.unlock() }
+        tapBufferDurationNanoseconds = UInt64(bufferDurationSeconds * 1_000_000_000)
+        lastConvertedChunkAtNanoseconds = nil
+        inFlightTapCallbacks = 0
+        stopWaitContinuation = nil
+    }
+
+    private func beginTapCallback() {
+        tapStateLock.lock()
+        inFlightTapCallbacks += 1
+        tapStateLock.unlock()
+    }
+
+    private func endTapCallback() {
+        var continuation: CheckedContinuation<Void, Never>?
+        tapStateLock.lock()
+        inFlightTapCallbacks = max(0, inFlightTapCallbacks - 1)
+        if inFlightTapCallbacks == 0 {
+            continuation = stopWaitContinuation
+            stopWaitContinuation = nil
+        }
+        tapStateLock.unlock()
+        continuation?.resume()
+    }
+
+    private func recordConvertedChunkArrival() {
+        tapStateLock.lock()
+        lastConvertedChunkAtNanoseconds = DispatchTime.now().uptimeNanoseconds
+        tapStateLock.unlock()
+    }
+
+    private func stopFlushDelayNanoseconds() -> UInt64 {
+        tapStateLock.lock()
+        let tapBufferDurationNanoseconds = self.tapBufferDurationNanoseconds
+        let lastConvertedChunkAtNanoseconds = self.lastConvertedChunkAtNanoseconds
+        tapStateLock.unlock()
+
+        guard tapBufferDurationNanoseconds > 0 else {
+            return 0
+        }
+
+        guard let lastConvertedChunkAtNanoseconds else {
+            return tapBufferDurationNanoseconds + stopFlushSlackNanoseconds
+        }
+
+        let now = DispatchTime.now().uptimeNanoseconds
+        let elapsed = now >= lastConvertedChunkAtNanoseconds
+            ? now - lastConvertedChunkAtNanoseconds
+            : 0
+        let remaining = elapsed >= tapBufferDurationNanoseconds
+            ? 0
+            : tapBufferDurationNanoseconds - elapsed
+        return remaining + stopFlushSlackNanoseconds
+    }
+
+    private func waitForTapCallbacksToDrain() async {
+        let hasInFlightCallbacks = tapStateLock.withLock { inFlightTapCallbacks > 0 }
+        guard hasInFlightCallbacks else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            let shouldResumeImmediately = tapStateLock.withLock {
+                if inFlightTapCallbacks == 0 {
+                    return true
+                }
+
+                stopWaitContinuation = continuation
+                return false
+            }
+
+            if shouldResumeImmediately {
+                continuation.resume()
+            }
+        }
     }
 }
 

--- a/GhostPepper/Audio/AudioRecorder.swift
+++ b/GhostPepper/Audio/AudioRecorder.swift
@@ -336,8 +336,10 @@ final class AudioRecorder {
 
         buffer.frameLength = AVAudioFrameCount(samples.count)
         if let channelData = buffer.floatChannelData?.pointee {
-            for (index, sample) in samples.enumerated() {
-                channelData[index] = sample
+            samples.withUnsafeBufferPointer { source in
+                if let baseAddress = source.baseAddress {
+                    channelData.update(from: baseAddress, count: samples.count)
+                }
             }
         }
 

--- a/GhostPepper/Lab/TranscriptionLabController.swift
+++ b/GhostPepper/Lab/TranscriptionLabController.swift
@@ -230,13 +230,12 @@ final class TranscriptionLabController: ObservableObject {
     }
 
     var speakerProfilesInDisplayOrder: [TranscriptionLabSpeakerProfile] {
-        let profilesBySpeakerID = Dictionary(uniqueKeysWithValues: speakerProfiles.map { ($0.speakerID, $0) })
         let orderedSpeakerIDs = diarizationVisualization?.speakerIDsInDisplayOrder ?? speakerProfiles.map(\.speakerID)
 
-        var orderedProfiles = orderedSpeakerIDs.compactMap { profilesBySpeakerID[$0] }
-        let remainingProfiles = speakerProfiles.filter { profile in
-            orderedSpeakerIDs.contains(profile.speakerID) == false
-        }
+        var orderedProfiles = orderedSpeakerIDs.compactMap { effectiveSpeakerProfile(for: $0) }
+        let remainingProfiles = speakerProfiles
+            .filter { orderedSpeakerIDs.contains($0.speakerID) == false }
+            .map(mergedSpeakerProfile)
         orderedProfiles.append(contentsOf: remainingProfiles)
         return orderedProfiles
     }
@@ -301,30 +300,31 @@ final class TranscriptionLabController: ObservableObject {
     }
 
     func displayName(for speakerID: String) -> String? {
-        if let profile = speakerProfile(for: speakerID) {
-            let normalizedLocalName = normalizedDisplayName(profile.displayName)
-            if normalizedLocalName.isEmpty == false {
-                return normalizedLocalName
-            }
-
-            if let recognizedVoice = recognizedVoice(for: profile) {
-                let normalizedGlobalName = normalizedDisplayName(recognizedVoice.displayName)
-                if normalizedGlobalName.isEmpty == false {
-                    return normalizedGlobalName
-                }
+        if let profile = effectiveSpeakerProfile(for: speakerID) {
+            let normalizedName = normalizedDisplayName(profile.displayName)
+            if normalizedName.isEmpty == false {
+                return normalizedName
             }
         }
 
         return nil
     }
 
-    func speakerProfile(for speakerID: String) -> TranscriptionLabSpeakerProfile? {
+    private func storedSpeakerProfile(for speakerID: String) -> TranscriptionLabSpeakerProfile? {
         speakerProfiles.first { $0.speakerID == speakerID }
+    }
+
+    private func effectiveSpeakerProfile(for speakerID: String) -> TranscriptionLabSpeakerProfile? {
+        guard let localProfile = storedSpeakerProfile(for: speakerID) else {
+            return nil
+        }
+
+        return mergedSpeakerProfile(localProfile)
     }
 
     func hasPendingGlobalVoiceUpdate(for speakerID: String) -> Bool {
         guard
-            let localProfile = speakerProfile(for: speakerID),
+            let localProfile = storedSpeakerProfile(for: speakerID),
             let recognizedVoice = recognizedVoice(for: localProfile)
         else {
             return false
@@ -341,30 +341,32 @@ final class TranscriptionLabController: ObservableObject {
     }
 
     func updateSpeakerDisplayName(_ displayName: String, for speakerID: String) {
-        guard var profile = speakerProfile(for: speakerID) else {
+        guard var profile = storedSpeakerProfile(for: speakerID) else {
             return
         }
 
         profile.displayName = displayName
-        persistSpeakerProfile(profile)
+        persistSpeakerProfile(profile, syncGlobalVoice: true)
     }
 
     func setSpeakerIsMe(_ isMe: Bool, for speakerID: String) {
-        guard var profile = speakerProfile(for: speakerID) else {
+        guard var profile = storedSpeakerProfile(for: speakerID) else {
             return
         }
 
         profile.isMe = isMe
-        persistSpeakerProfile(profile)
+        persistSpeakerProfile(profile, syncGlobalVoice: true)
     }
 
     func pushSpeakerProfileToGlobalVoice(for speakerID: String) {
-        guard let profile = speakerProfile(for: speakerID) else {
+        guard let profile = storedSpeakerProfile(for: speakerID) else {
             return
         }
 
         do {
-            guard let updatedRecognizedVoice = try updateGlobalVoiceProfile(profile) else {
+            guard let updatedRecognizedVoice = try updateGlobalVoiceProfile(
+                globalVoiceUpdateProfile(for: profile)
+            ) else {
                 return
             }
 
@@ -593,6 +595,8 @@ final class TranscriptionLabController: ObservableObject {
             return
         }
 
+        reloadRecognizedVoices()
+
         do {
             speakerProfiles = try loadSpeakerProfiles(selectedEntryID)
         } catch {
@@ -611,12 +615,33 @@ final class TranscriptionLabController: ObservableObject {
         }
     }
 
-    private func persistSpeakerProfile(_ profile: TranscriptionLabSpeakerProfile) {
+    private func persistSpeakerProfile(
+        _ profile: TranscriptionLabSpeakerProfile,
+        syncGlobalVoice: Bool = false
+    ) {
         do {
             try saveSpeakerProfile(profile)
             speakerProfiles = replacingSpeakerProfile(profile)
         } catch {
             errorMessage = "Could not save the speaker identity."
+            return
+        }
+
+        guard syncGlobalVoice else {
+            return
+        }
+
+        do {
+            guard let updatedRecognizedVoice = try updateGlobalVoiceProfile(
+                globalVoiceUpdateProfile(for: profile)
+            ) else {
+                return
+            }
+
+            recognizedVoicesByID[updatedRecognizedVoice.id] = updatedRecognizedVoice
+            notifyRecognizedVoicesDidChange()
+        } catch {
+            errorMessage = "Could not update the global voice print."
         }
     }
 
@@ -647,6 +672,48 @@ final class TranscriptionLabController: ObservableObject {
         }
 
         return recognizedVoicesByID[recognizedVoiceID]
+    }
+
+    private func mergedSpeakerProfile(
+        _ localProfile: TranscriptionLabSpeakerProfile
+    ) -> TranscriptionLabSpeakerProfile {
+        guard let recognizedVoice = recognizedVoice(for: localProfile) else {
+            return localProfile
+        }
+
+        var mergedProfile = localProfile
+        let normalizedGlobalName = normalizedDisplayName(recognizedVoice.displayName)
+        if normalizedGlobalName.isEmpty == false {
+            mergedProfile.displayName = normalizedGlobalName
+        }
+
+        mergedProfile.isMe = recognizedVoice.isMe
+
+        let normalizedEvidenceTranscript = recognizedVoice.evidenceTranscript.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        if normalizedEvidenceTranscript.isEmpty == false {
+            mergedProfile.evidenceTranscript = normalizedEvidenceTranscript
+        }
+
+        return mergedProfile
+    }
+
+    private func globalVoiceUpdateProfile(
+        for localProfile: TranscriptionLabSpeakerProfile
+    ) -> TranscriptionLabSpeakerProfile {
+        var updateProfile = localProfile
+
+        if let recognizedVoice = recognizedVoice(for: localProfile) {
+            let normalizedEvidenceTranscript = recognizedVoice.evidenceTranscript.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            if normalizedEvidenceTranscript.isEmpty == false {
+                updateProfile.evidenceTranscript = normalizedEvidenceTranscript
+            }
+        }
+
+        return updateProfile
     }
 
     private func normalizedDisplayName(_ displayName: String) -> String {

--- a/GhostPepper/Lab/TranscriptionLabController.swift
+++ b/GhostPepper/Lab/TranscriptionLabController.swift
@@ -17,6 +17,11 @@ final class TranscriptionLabController: ObservableObject {
         _ prompt: String,
         _ includeWindowContext: Bool
     ) async throws -> TranscriptionLabCleanupResult
+    typealias SpeakerProfileLoader = (_ entryID: UUID) throws -> [TranscriptionLabSpeakerProfile]
+    typealias SpeakerProfileSaver = (_ profile: TranscriptionLabSpeakerProfile) throws -> Void
+    typealias RecognizedVoiceLoader = () throws -> [RecognizedVoiceProfile]
+    typealias GlobalVoiceProfileUpdater = (_ localProfile: TranscriptionLabSpeakerProfile) throws -> RecognizedVoiceProfile?
+    typealias RecognizedVoicesChangeObserver = () -> Void
     typealias SelectedSpeechModelSynchronizer = (_ speechModelID: String) -> Void
     typealias SpeakerTaggingSynchronizer = (_ speakerTaggingEnabled: Bool) -> Void
     typealias SelectedCleanupModelSynchronizer = (_ cleanupModelKind: LocalCleanupModelKind) -> Void
@@ -29,9 +34,24 @@ final class TranscriptionLabController: ObservableObject {
     struct DiarizationVisualization: Equatable {
         struct Span: Equatable {
             let speakerID: String
+            let displayName: String
             let startTime: TimeInterval
             let endTime: TimeInterval
             let isKept: Bool
+
+            init(
+                speakerID: String,
+                displayName: String? = nil,
+                startTime: TimeInterval,
+                endTime: TimeInterval,
+                isKept: Bool
+            ) {
+                self.speakerID = speakerID
+                self.displayName = displayName ?? speakerID
+                self.startTime = startTime
+                self.endTime = endTime
+                self.isKept = isKept
+            }
         }
 
         let audioDuration: TimeInterval
@@ -50,6 +70,18 @@ final class TranscriptionLabController: ObservableObject {
             }
 
             return speakerIDs
+        }
+
+        func displayName(for speakerID: String) -> String {
+            spans.first(where: { $0.speakerID == speakerID })?.displayName ?? speakerID
+        }
+
+        var targetDisplayName: String? {
+            guard let targetSpeakerID else {
+                return nil
+            }
+
+            return displayName(for: targetSpeakerID)
         }
     }
 
@@ -78,6 +110,7 @@ final class TranscriptionLabController: ObservableObject {
     @Published private(set) var experimentCleanupDuration: TimeInterval?
     @Published private(set) var experimentDiarizationSummary: DiarizationSummary?
     @Published private(set) var experimentSpeakerTaggedTranscript: SpeakerTaggedTranscript?
+    @Published private(set) var speakerProfiles: [TranscriptionLabSpeakerProfile] = []
     @Published private(set) var latestCleanupTranscript: TranscriptionLabCleanupTranscript?
     @Published private(set) var runningStage: RunningStage?
     @Published private(set) var errorMessage: String?
@@ -87,10 +120,16 @@ final class TranscriptionLabController: ObservableObject {
     private let audioURLForEntry: AudioURLProvider
     private let runTranscription: TranscriptionRunner
     private let runCleanup: CleanupRunner
+    private let loadSpeakerProfiles: SpeakerProfileLoader
+    private let saveSpeakerProfile: SpeakerProfileSaver
+    private let loadRecognizedVoices: RecognizedVoiceLoader
+    private let updateGlobalVoiceProfile: GlobalVoiceProfileUpdater
+    private let notifyRecognizedVoicesDidChange: RecognizedVoicesChangeObserver
     private let syncSelectedSpeechModelID: SelectedSpeechModelSynchronizer
     private let syncSpeakerTaggingEnabled: SpeakerTaggingSynchronizer
     private let syncSelectedCleanupModelKind: SelectedCleanupModelSynchronizer
     private var originalStageTimingsByEntryID: [UUID: TranscriptionLabStageTimings] = [:]
+    private var recognizedVoicesByID: [UUID: RecognizedVoiceProfile] = [:]
     private var suppressSelectionSynchronization = false
 
     init(
@@ -102,6 +141,11 @@ final class TranscriptionLabController: ObservableObject {
         audioURLForEntry: @escaping AudioURLProvider,
         runTranscription: @escaping TranscriptionRunner,
         runCleanup: @escaping CleanupRunner,
+        loadSpeakerProfiles: @escaping SpeakerProfileLoader = { _ in [] },
+        saveSpeakerProfile: @escaping SpeakerProfileSaver = { _ in },
+        loadRecognizedVoices: @escaping RecognizedVoiceLoader = { [] },
+        updateGlobalVoiceProfile: @escaping GlobalVoiceProfileUpdater = { _ in nil },
+        notifyRecognizedVoicesDidChange: @escaping RecognizedVoicesChangeObserver = {},
         syncSelectedSpeechModelID: @escaping SelectedSpeechModelSynchronizer = { _ in },
         syncSpeakerTaggingEnabled: @escaping SpeakerTaggingSynchronizer = { _ in },
         syncSelectedCleanupModelKind: @escaping SelectedCleanupModelSynchronizer = { _ in }
@@ -114,6 +158,11 @@ final class TranscriptionLabController: ObservableObject {
         self.audioURLForEntry = audioURLForEntry
         self.runTranscription = runTranscription
         self.runCleanup = runCleanup
+        self.loadSpeakerProfiles = loadSpeakerProfiles
+        self.saveSpeakerProfile = saveSpeakerProfile
+        self.loadRecognizedVoices = loadRecognizedVoices
+        self.updateGlobalVoiceProfile = updateGlobalVoiceProfile
+        self.notifyRecognizedVoicesDidChange = notifyRecognizedVoicesDidChange
         self.syncSelectedSpeechModelID = syncSelectedSpeechModelID
         self.syncSpeakerTaggingEnabled = syncSpeakerTaggingEnabled
         self.syncSelectedCleanupModelKind = syncSelectedCleanupModelKind
@@ -180,6 +229,18 @@ final class TranscriptionLabController: ObservableObject {
         return selectedEntry?.correctedTranscription ?? ""
     }
 
+    var speakerProfilesInDisplayOrder: [TranscriptionLabSpeakerProfile] {
+        let profilesBySpeakerID = Dictionary(uniqueKeysWithValues: speakerProfiles.map { ($0.speakerID, $0) })
+        let orderedSpeakerIDs = diarizationVisualization?.speakerIDsInDisplayOrder ?? speakerProfiles.map(\.speakerID)
+
+        var orderedProfiles = orderedSpeakerIDs.compactMap { profilesBySpeakerID[$0] }
+        let remainingProfiles = speakerProfiles.filter { profile in
+            orderedSpeakerIDs.contains(profile.speakerID) == false
+        }
+        orderedProfiles.append(contentsOf: remainingProfiles)
+        return orderedProfiles
+    }
+
     var displayedSpeakerTaggedTranscriptText: String? {
         guard let experimentSpeakerTaggedTranscript else {
             return nil
@@ -188,7 +249,7 @@ final class TranscriptionLabController: ObservableObject {
         return experimentSpeakerTaggedTranscript.segments
             .map { segment in
                 """
-                [\(segment.speakerID) | \(formattedDuration(segment.startTime))-\(formattedDuration(segment.endTime))]
+                [\(displayName(for: segment.speakerID) ?? segment.speakerID) | \(formattedDuration(segment.startTime))-\(formattedDuration(segment.endTime))]
                 \(segment.text)
                 """
             }
@@ -230,12 +291,88 @@ final class TranscriptionLabController: ObservableObject {
             spans: summary.spans.map {
                 DiarizationVisualization.Span(
                     speakerID: $0.speakerID,
+                    displayName: displayName(for: $0.speakerID) ?? $0.speakerID,
                     startTime: $0.startTime,
                     endTime: $0.endTime,
                     isKept: $0.isKept
                 )
             }
         )
+    }
+
+    func displayName(for speakerID: String) -> String? {
+        if let profile = speakerProfile(for: speakerID) {
+            let normalizedLocalName = normalizedDisplayName(profile.displayName)
+            if normalizedLocalName.isEmpty == false {
+                return normalizedLocalName
+            }
+
+            if let recognizedVoice = recognizedVoice(for: profile) {
+                let normalizedGlobalName = normalizedDisplayName(recognizedVoice.displayName)
+                if normalizedGlobalName.isEmpty == false {
+                    return normalizedGlobalName
+                }
+            }
+        }
+
+        return nil
+    }
+
+    func speakerProfile(for speakerID: String) -> TranscriptionLabSpeakerProfile? {
+        speakerProfiles.first { $0.speakerID == speakerID }
+    }
+
+    func hasPendingGlobalVoiceUpdate(for speakerID: String) -> Bool {
+        guard
+            let localProfile = speakerProfile(for: speakerID),
+            let recognizedVoice = recognizedVoice(for: localProfile)
+        else {
+            return false
+        }
+
+        let normalizedLocalName = normalizedDisplayName(localProfile.displayName)
+        let normalizedGlobalName = normalizedDisplayName(recognizedVoice.displayName)
+
+        if normalizedLocalName.isEmpty == false, normalizedLocalName != normalizedGlobalName {
+            return true
+        }
+
+        return localProfile.isMe != recognizedVoice.isMe
+    }
+
+    func updateSpeakerDisplayName(_ displayName: String, for speakerID: String) {
+        guard var profile = speakerProfile(for: speakerID) else {
+            return
+        }
+
+        profile.displayName = displayName
+        persistSpeakerProfile(profile)
+    }
+
+    func setSpeakerIsMe(_ isMe: Bool, for speakerID: String) {
+        guard var profile = speakerProfile(for: speakerID) else {
+            return
+        }
+
+        profile.isMe = isMe
+        persistSpeakerProfile(profile)
+    }
+
+    func pushSpeakerProfileToGlobalVoice(for speakerID: String) {
+        guard let profile = speakerProfile(for: speakerID) else {
+            return
+        }
+
+        do {
+            guard let updatedRecognizedVoice = try updateGlobalVoiceProfile(profile) else {
+                return
+            }
+
+            recognizedVoicesByID[updatedRecognizedVoice.id] = updatedRecognizedVoice
+            notifyRecognizedVoicesDidChange()
+        } catch {
+            errorMessage = "Could not update the global voice print."
+        }
     }
 
     func audioURL(for entry: TranscriptionLabEntry) -> URL {
@@ -246,10 +383,14 @@ final class TranscriptionLabController: ObservableObject {
         do {
             let loadedEntries = try loadEntries().sorted { $0.createdAt > $1.createdAt }
             originalStageTimingsByEntryID = try loadStageTimings()
+            recognizedVoicesByID = Dictionary(
+                uniqueKeysWithValues: try loadRecognizedVoices().map { ($0.id, $0) }
+            )
             entries = loadedEntries
 
             if let selectedEntryID,
                loadedEntries.contains(where: { $0.id == selectedEntryID }) {
+                loadSelectedEntrySpeakerProfiles()
                 return
             }
 
@@ -261,6 +402,7 @@ final class TranscriptionLabController: ObservableObject {
             experimentCleanupDuration = nil
             experimentDiarizationSummary = nil
             experimentSpeakerTaggedTranscript = nil
+            speakerProfiles = []
             latestCleanupTranscript = nil
             errorMessage = nil
         } catch {
@@ -273,8 +415,10 @@ final class TranscriptionLabController: ObservableObject {
             experimentCleanupDuration = nil
             experimentDiarizationSummary = nil
             experimentSpeakerTaggedTranscript = nil
+            speakerProfiles = []
             latestCleanupTranscript = nil
             originalStageTimingsByEntryID = [:]
+            recognizedVoicesByID = [:]
             errorMessage = "Could not load saved recordings."
         }
     }
@@ -292,6 +436,7 @@ final class TranscriptionLabController: ObservableObject {
         experimentCleanupDuration = nil
         experimentDiarizationSummary = nil
         experimentSpeakerTaggedTranscript = nil
+        loadSelectedEntrySpeakerProfiles()
         latestCleanupTranscript = nil
         errorMessage = nil
     }
@@ -305,6 +450,7 @@ final class TranscriptionLabController: ObservableObject {
         experimentCleanupDuration = nil
         experimentDiarizationSummary = nil
         experimentSpeakerTaggedTranscript = nil
+        speakerProfiles = []
         latestCleanupTranscript = nil
         errorMessage = nil
     }
@@ -334,6 +480,7 @@ final class TranscriptionLabController: ObservableObject {
         experimentTranscriptionDuration = nil
         experimentDiarizationSummary = nil
         experimentSpeakerTaggedTranscript = nil
+        speakerProfiles = []
         latestCleanupTranscript = nil
         let start = Date()
 
@@ -347,6 +494,8 @@ final class TranscriptionLabController: ObservableObject {
             experimentCorrectedTranscription = ""
             experimentDiarizationSummary = result.diarizationSummary
             experimentSpeakerTaggedTranscript = result.speakerTaggedTranscript
+            speakerProfiles = result.speakerProfiles
+            reloadRecognizedVoices()
             experimentTranscriptionDuration = Date().timeIntervalSince(start)
             experimentCleanupDuration = nil
         } catch let error as TranscriptionLabRunnerError {
@@ -436,6 +585,72 @@ final class TranscriptionLabController: ObservableObject {
         }
 
         syncSpeakerTaggingEnabled(usesSpeakerTagging)
+    }
+
+    private func loadSelectedEntrySpeakerProfiles() {
+        guard let selectedEntryID else {
+            speakerProfiles = []
+            return
+        }
+
+        do {
+            speakerProfiles = try loadSpeakerProfiles(selectedEntryID)
+        } catch {
+            speakerProfiles = []
+            errorMessage = "Could not load speaker identities for this recording."
+        }
+    }
+
+    private func reloadRecognizedVoices() {
+        do {
+            recognizedVoicesByID = Dictionary(
+                uniqueKeysWithValues: try loadRecognizedVoices().map { ($0.id, $0) }
+            )
+        } catch {
+            recognizedVoicesByID = [:]
+        }
+    }
+
+    private func persistSpeakerProfile(_ profile: TranscriptionLabSpeakerProfile) {
+        do {
+            try saveSpeakerProfile(profile)
+            speakerProfiles = replacingSpeakerProfile(profile)
+        } catch {
+            errorMessage = "Could not save the speaker identity."
+        }
+    }
+
+    private func replacingSpeakerProfile(
+        _ updatedProfile: TranscriptionLabSpeakerProfile
+    ) -> [TranscriptionLabSpeakerProfile] {
+        var updatedProfiles = speakerProfiles.filter { $0.speakerID != updatedProfile.speakerID }
+        updatedProfiles.append(updatedProfile)
+
+        let orderedSpeakerIDs = diarizationVisualization?.speakerIDsInDisplayOrder ?? speakerProfiles.map(\.speakerID)
+        return updatedProfiles.sorted { lhs, rhs in
+            let lhsIndex = orderedSpeakerIDs.firstIndex(of: lhs.speakerID) ?? Int.max
+            let rhsIndex = orderedSpeakerIDs.firstIndex(of: rhs.speakerID) ?? Int.max
+
+            if lhsIndex == rhsIndex {
+                return lhs.speakerID.localizedStandardCompare(rhs.speakerID) == .orderedAscending
+            }
+
+            return lhsIndex < rhsIndex
+        }
+    }
+
+    private func recognizedVoice(
+        for localProfile: TranscriptionLabSpeakerProfile
+    ) -> RecognizedVoiceProfile? {
+        guard let recognizedVoiceID = localProfile.recognizedVoiceID else {
+            return nil
+        }
+
+        return recognizedVoicesByID[recognizedVoiceID]
+    }
+
+    private func normalizedDisplayName(_ displayName: String) -> String {
+        displayName.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func formattedDuration(_ duration: TimeInterval) -> String {

--- a/GhostPepper/Lab/TranscriptionLabController.swift
+++ b/GhostPepper/Lab/TranscriptionLabController.swift
@@ -7,8 +7,9 @@ final class TranscriptionLabController: ObservableObject {
     typealias AudioURLProvider = (TranscriptionLabEntry) -> URL
     typealias TranscriptionRunner = (
         _ entry: TranscriptionLabEntry,
-        _ speechModelID: String
-    ) async throws -> String
+        _ speechModelID: String,
+        _ speakerTaggingEnabled: Bool
+    ) async throws -> TranscriptionLabTranscriptionResult
     typealias CleanupRunner = (
         _ entry: TranscriptionLabEntry,
         _ rawTranscription: String,
@@ -17,6 +18,7 @@ final class TranscriptionLabController: ObservableObject {
         _ includeWindowContext: Bool
     ) async throws -> TranscriptionLabCleanupResult
     typealias SelectedSpeechModelSynchronizer = (_ speechModelID: String) -> Void
+    typealias SpeakerTaggingSynchronizer = (_ speakerTaggingEnabled: Bool) -> Void
     typealias SelectedCleanupModelSynchronizer = (_ cleanupModelKind: LocalCleanupModelKind) -> Void
 
     enum RunningStage {
@@ -38,6 +40,17 @@ final class TranscriptionLabController: ObservableObject {
         let usedFallback: Bool
         let fallbackReason: DiarizationSummary.FallbackReason?
         let spans: [Span]
+
+        var speakerIDsInDisplayOrder: [String] {
+            var speakerIDs: [String] = []
+            var seenSpeakerIDs: Set<String> = []
+
+            for span in spans where seenSpeakerIDs.insert(span.speakerID).inserted {
+                speakerIDs.append(span.speakerID)
+            }
+
+            return speakerIDs
+        }
     }
 
     @Published private(set) var entries: [TranscriptionLabEntry] = []
@@ -46,6 +59,11 @@ final class TranscriptionLabController: ObservableObject {
     @Published var selectedSpeechModelID: String {
         didSet {
             synchronizeSelectedSpeechModelIDIfNeeded()
+        }
+    }
+    @Published var usesSpeakerTagging: Bool {
+        didSet {
+            synchronizeSpeakerTaggingIfNeeded()
         }
     }
     @Published var selectedCleanupModelKind: LocalCleanupModelKind {
@@ -58,6 +76,8 @@ final class TranscriptionLabController: ObservableObject {
     @Published private(set) var experimentCorrectedTranscription: String = ""
     @Published private(set) var experimentTranscriptionDuration: TimeInterval?
     @Published private(set) var experimentCleanupDuration: TimeInterval?
+    @Published private(set) var experimentDiarizationSummary: DiarizationSummary?
+    @Published private(set) var experimentSpeakerTaggedTranscript: SpeakerTaggedTranscript?
     @Published private(set) var latestCleanupTranscript: TranscriptionLabCleanupTranscript?
     @Published private(set) var runningStage: RunningStage?
     @Published private(set) var errorMessage: String?
@@ -68,12 +88,14 @@ final class TranscriptionLabController: ObservableObject {
     private let runTranscription: TranscriptionRunner
     private let runCleanup: CleanupRunner
     private let syncSelectedSpeechModelID: SelectedSpeechModelSynchronizer
+    private let syncSpeakerTaggingEnabled: SpeakerTaggingSynchronizer
     private let syncSelectedCleanupModelKind: SelectedCleanupModelSynchronizer
     private var originalStageTimingsByEntryID: [UUID: TranscriptionLabStageTimings] = [:]
     private var suppressSelectionSynchronization = false
 
     init(
         defaultSpeechModelID: String,
+        defaultSpeakerTaggingEnabled: Bool,
         defaultCleanupModelKind: LocalCleanupModelKind = .qwen35_4b_q4_k_m,
         loadStageTimings: @escaping StageTimingsLoader = { [:] },
         loadEntries: @escaping EntryLoader,
@@ -81,9 +103,11 @@ final class TranscriptionLabController: ObservableObject {
         runTranscription: @escaping TranscriptionRunner,
         runCleanup: @escaping CleanupRunner,
         syncSelectedSpeechModelID: @escaping SelectedSpeechModelSynchronizer = { _ in },
+        syncSpeakerTaggingEnabled: @escaping SpeakerTaggingSynchronizer = { _ in },
         syncSelectedCleanupModelKind: @escaping SelectedCleanupModelSynchronizer = { _ in }
     ) {
         self.selectedSpeechModelID = defaultSpeechModelID
+        self.usesSpeakerTagging = defaultSpeakerTaggingEnabled
         self.selectedCleanupModelKind = defaultCleanupModelKind
         self.loadStageTimings = loadStageTimings
         self.loadEntries = loadEntries
@@ -91,15 +115,18 @@ final class TranscriptionLabController: ObservableObject {
         self.runTranscription = runTranscription
         self.runCleanup = runCleanup
         self.syncSelectedSpeechModelID = syncSelectedSpeechModelID
+        self.syncSpeakerTaggingEnabled = syncSpeakerTaggingEnabled
         self.syncSelectedCleanupModelKind = syncSelectedCleanupModelKind
     }
 
     func applyCurrentRerunDefaults(
         speechModelID: String,
+        speakerTaggingEnabled: Bool,
         cleanupModelKind: LocalCleanupModelKind
     ) {
         suppressSelectionSynchronization = true
         selectedSpeechModelID = speechModelID
+        usesSpeakerTagging = speakerTaggingEnabled
         selectedCleanupModelKind = cleanupModelKind
         suppressSelectionSynchronization = false
     }
@@ -153,6 +180,21 @@ final class TranscriptionLabController: ObservableObject {
         return selectedEntry?.correctedTranscription ?? ""
     }
 
+    var displayedSpeakerTaggedTranscriptText: String? {
+        guard let experimentSpeakerTaggedTranscript else {
+            return nil
+        }
+
+        return experimentSpeakerTaggedTranscript.segments
+            .map { segment in
+                """
+                [\(segment.speakerID) | \(formattedDuration(segment.startTime))-\(formattedDuration(segment.endTime))]
+                \(segment.text)
+                """
+            }
+            .joined(separator: "\n\n")
+    }
+
     var originalTranscriptionDuration: TimeInterval? {
         guard let selectedEntryID else {
             return nil
@@ -170,8 +212,12 @@ final class TranscriptionLabController: ObservableObject {
     }
 
     var diarizationVisualization: DiarizationVisualization? {
-        guard let entry = selectedEntry,
-              let summary = entry.diarizationSummary else {
+        guard let entry = selectedEntry else {
+            return nil
+        }
+
+        let summary = experimentDiarizationSummary ?? entry.diarizationSummary
+        guard let summary else {
             return nil
         }
 
@@ -213,6 +259,8 @@ final class TranscriptionLabController: ObservableObject {
             experimentCorrectedTranscription = ""
             experimentTranscriptionDuration = nil
             experimentCleanupDuration = nil
+            experimentDiarizationSummary = nil
+            experimentSpeakerTaggedTranscript = nil
             latestCleanupTranscript = nil
             errorMessage = nil
         } catch {
@@ -223,6 +271,8 @@ final class TranscriptionLabController: ObservableObject {
             experimentCorrectedTranscription = ""
             experimentTranscriptionDuration = nil
             experimentCleanupDuration = nil
+            experimentDiarizationSummary = nil
+            experimentSpeakerTaggedTranscript = nil
             latestCleanupTranscript = nil
             originalStageTimingsByEntryID = [:]
             errorMessage = "Could not load saved recordings."
@@ -240,6 +290,8 @@ final class TranscriptionLabController: ObservableObject {
         experimentCorrectedTranscription = ""
         experimentTranscriptionDuration = nil
         experimentCleanupDuration = nil
+        experimentDiarizationSummary = nil
+        experimentSpeakerTaggedTranscript = nil
         latestCleanupTranscript = nil
         errorMessage = nil
     }
@@ -251,6 +303,8 @@ final class TranscriptionLabController: ObservableObject {
         experimentCorrectedTranscription = ""
         experimentTranscriptionDuration = nil
         experimentCleanupDuration = nil
+        experimentDiarizationSummary = nil
+        experimentSpeakerTaggedTranscript = nil
         latestCleanupTranscript = nil
         errorMessage = nil
     }
@@ -278,12 +332,21 @@ final class TranscriptionLabController: ObservableObject {
         runningStage = .transcription
         errorMessage = nil
         experimentTranscriptionDuration = nil
+        experimentDiarizationSummary = nil
+        experimentSpeakerTaggedTranscript = nil
         latestCleanupTranscript = nil
         let start = Date()
 
         do {
-            experimentRawTranscription = try await runTranscription(entry, selectedSpeechModelID)
+            let result = try await runTranscription(
+                entry,
+                selectedSpeechModelID,
+                usesSpeakerTagging && selectedSpeechModelSupportsSpeakerTagging
+            )
+            experimentRawTranscription = result.rawTranscription
             experimentCorrectedTranscription = ""
+            experimentDiarizationSummary = result.diarizationSummary
+            experimentSpeakerTaggedTranscript = result.speakerTaggedTranscript
             experimentTranscriptionDuration = Date().timeIntervalSince(start)
             experimentCleanupDuration = nil
         } catch let error as TranscriptionLabRunnerError {
@@ -347,6 +410,10 @@ final class TranscriptionLabController: ObservableObject {
         runningStage = nil
     }
 
+    private var selectedSpeechModelSupportsSpeakerTagging: Bool {
+        SpeechModelCatalog.model(named: selectedSpeechModelID)?.supportsSpeakerFiltering == true
+    }
+
     private func synchronizeSelectedSpeechModelIDIfNeeded() {
         guard !suppressSelectionSynchronization else {
             return
@@ -361,5 +428,17 @@ final class TranscriptionLabController: ObservableObject {
         }
 
         syncSelectedCleanupModelKind(selectedCleanupModelKind)
+    }
+
+    private func synchronizeSpeakerTaggingIfNeeded() {
+        guard !suppressSelectionSynchronization else {
+            return
+        }
+
+        syncSpeakerTaggingEnabled(usesSpeakerTagging)
+    }
+
+    private func formattedDuration(_ duration: TimeInterval) -> String {
+        String(format: "%.1fs", duration)
     }
 }

--- a/GhostPepper/Lab/TranscriptionLabRunner.swift
+++ b/GhostPepper/Lab/TranscriptionLabRunner.swift
@@ -183,7 +183,7 @@ final class TranscriptionLabRunner {
         from result: SpeakerTaggedTranscriptionResult,
         fallbackRawTranscription: String
     ) -> SpeakerTaggedTranscript? {
-        guard result.diarizationSummary.fallbackReason == .emptyFilteredTranscription else {
+        guard shouldRepairSingleSpeakerTranscript(for: result.diarizationSummary.fallbackReason) else {
             return result.speakerTaggedTranscript
         }
 
@@ -219,6 +219,22 @@ final class TranscriptionLabRunner {
                 )
             ]
         )
+    }
+
+    private func shouldRepairSingleSpeakerTranscript(
+        for fallbackReason: DiarizationSummary.FallbackReason?
+    ) -> Bool {
+        switch fallbackReason {
+        case .emptyFilteredTranscription, .singleDetectedSpeaker:
+            return true
+        case .none,
+             .noUsableSpeakerSpans,
+             .noSpeakerReachedThreshold,
+             .ambiguousDominantSpeaker,
+             .insufficientKeptAudio,
+             .filteredAudioExtractionFailed:
+            return false
+        }
     }
 
     func rerunCleanup(

--- a/GhostPepper/Lab/TranscriptionLabRunner.swift
+++ b/GhostPepper/Lab/TranscriptionLabRunner.swift
@@ -1,5 +1,38 @@
 import Foundation
 
+struct SpeakerTaggedTranscript: Equatable, Sendable {
+    struct Segment: Equatable, Sendable {
+        let speakerID: String
+        let startTime: TimeInterval
+        let endTime: TimeInterval
+        let text: String
+    }
+
+    let segments: [Segment]
+}
+
+struct SpeakerTaggedTranscriptionResult: Equatable, Sendable {
+    let filteredTranscript: String?
+    let diarizationSummary: DiarizationSummary
+    let speakerTaggedTranscript: SpeakerTaggedTranscript?
+}
+
+struct TranscriptionLabTranscriptionResult: Equatable, Sendable {
+    let rawTranscription: String
+    let diarizationSummary: DiarizationSummary?
+    let speakerTaggedTranscript: SpeakerTaggedTranscript?
+
+    init(
+        rawTranscription: String,
+        diarizationSummary: DiarizationSummary? = nil,
+        speakerTaggedTranscript: SpeakerTaggedTranscript? = nil
+    ) {
+        self.rawTranscription = rawTranscription
+        self.diarizationSummary = diarizationSummary
+        self.speakerTaggedTranscript = speakerTaggedTranscript
+    }
+}
+
 enum TranscriptionLabRunnerError: Error, Equatable {
     case pipelineBusy
     case missingAudio
@@ -33,11 +66,13 @@ final class TranscriptionLabRunner {
     typealias AudioLoader = (TranscriptionLabEntry) throws -> [Float]
     typealias SpeechModelLoader = (String) async -> Void
     typealias Transcriber = ([Float]) async -> String?
+    typealias SpeakerTaggingRunner = ([Float]) async -> SpeakerTaggedTranscriptionResult?
     typealias Cleaner = (String, String, LocalCleanupModelKind) async -> TextCleanerResult
 
     private let loadAudioBuffer: AudioLoader
     private let loadSpeechModel: SpeechModelLoader
     private let transcribe: Transcriber
+    private let runSpeakerTagging: SpeakerTaggingRunner
     private let clean: Cleaner
     private let correctionStore: CorrectionStore
     private let cleanupPromptBuilder: CleanupPromptBuilder
@@ -46,6 +81,7 @@ final class TranscriptionLabRunner {
         loadAudioBuffer: @escaping AudioLoader,
         loadSpeechModel: @escaping SpeechModelLoader,
         transcribe: @escaping Transcriber,
+        runSpeakerTagging: @escaping SpeakerTaggingRunner = { _ in nil },
         clean: @escaping Cleaner,
         correctionStore: CorrectionStore,
         cleanupPromptBuilder: CleanupPromptBuilder = CleanupPromptBuilder()
@@ -53,6 +89,7 @@ final class TranscriptionLabRunner {
         self.loadAudioBuffer = loadAudioBuffer
         self.loadSpeechModel = loadSpeechModel
         self.transcribe = transcribe
+        self.runSpeakerTagging = runSpeakerTagging
         self.clean = clean
         self.correctionStore = correctionStore
         self.cleanupPromptBuilder = cleanupPromptBuilder
@@ -61,9 +98,10 @@ final class TranscriptionLabRunner {
     func rerunTranscription(
         entry: TranscriptionLabEntry,
         speechModelID: String,
+        speakerTaggingEnabled: Bool,
         acquirePipeline: () -> Bool,
         releasePipeline: () -> Void
-    ) async throws -> String {
+    ) async throws -> TranscriptionLabTranscriptionResult {
         guard acquirePipeline() else {
             throw TranscriptionLabRunnerError.pipelineBusy
         }
@@ -76,11 +114,38 @@ final class TranscriptionLabRunner {
 
         await loadSpeechModel(speechModelID)
 
-        guard let rawTranscription = await transcribe(audioBuffer) else {
+        if speakerTaggingEnabled,
+           let speakerTaggedResult = await runSpeakerTagging(audioBuffer) {
+            if let filteredTranscript = speakerTaggedResult.filteredTranscript?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               filteredTranscript.isEmpty == false {
+                return TranscriptionLabTranscriptionResult(
+                    rawTranscription: filteredTranscript,
+                    diarizationSummary: speakerTaggedResult.diarizationSummary,
+                    speakerTaggedTranscript: speakerTaggedResult.speakerTaggedTranscript
+                )
+            }
+
+            guard let rawTranscription = await transcribe(audioBuffer)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                  rawTranscription.isEmpty == false else {
+                throw TranscriptionLabRunnerError.transcriptionFailed
+            }
+
+            return TranscriptionLabTranscriptionResult(
+                rawTranscription: rawTranscription,
+                diarizationSummary: speakerTaggedResult.diarizationSummary,
+                speakerTaggedTranscript: speakerTaggedResult.speakerTaggedTranscript
+            )
+        }
+
+        guard let rawTranscription = await transcribe(audioBuffer)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              rawTranscription.isEmpty == false else {
             throw TranscriptionLabRunnerError.transcriptionFailed
         }
 
-        return rawTranscription
+        return TranscriptionLabTranscriptionResult(rawTranscription: rawTranscription)
     }
 
     func rerunCleanup(

--- a/GhostPepper/Lab/TranscriptionLabRunner.swift
+++ b/GhostPepper/Lab/TranscriptionLabRunner.swift
@@ -21,15 +21,18 @@ struct TranscriptionLabTranscriptionResult: Equatable, Sendable {
     let rawTranscription: String
     let diarizationSummary: DiarizationSummary?
     let speakerTaggedTranscript: SpeakerTaggedTranscript?
+    let speakerProfiles: [TranscriptionLabSpeakerProfile]
 
     init(
         rawTranscription: String,
         diarizationSummary: DiarizationSummary? = nil,
-        speakerTaggedTranscript: SpeakerTaggedTranscript? = nil
+        speakerTaggedTranscript: SpeakerTaggedTranscript? = nil,
+        speakerProfiles: [TranscriptionLabSpeakerProfile] = []
     ) {
         self.rawTranscription = rawTranscription
         self.diarizationSummary = diarizationSummary
         self.speakerTaggedTranscript = speakerTaggedTranscript
+        self.speakerProfiles = speakerProfiles
     }
 }
 
@@ -67,12 +70,19 @@ final class TranscriptionLabRunner {
     typealias SpeechModelLoader = (String) async -> Void
     typealias Transcriber = ([Float]) async -> String?
     typealias SpeakerTaggingRunner = ([Float]) async -> SpeakerTaggedTranscriptionResult?
+    typealias SpeakerProfileResolver = (
+        _ entryID: UUID,
+        _ audioBuffer: [Float],
+        _ diarizationSummary: DiarizationSummary,
+        _ speakerTaggedTranscript: SpeakerTaggedTranscript?
+    ) async -> [TranscriptionLabSpeakerProfile]
     typealias Cleaner = (String, String, LocalCleanupModelKind) async -> TextCleanerResult
 
     private let loadAudioBuffer: AudioLoader
     private let loadSpeechModel: SpeechModelLoader
     private let transcribe: Transcriber
     private let runSpeakerTagging: SpeakerTaggingRunner
+    private let resolveSpeakerProfiles: SpeakerProfileResolver
     private let clean: Cleaner
     private let correctionStore: CorrectionStore
     private let cleanupPromptBuilder: CleanupPromptBuilder
@@ -82,6 +92,7 @@ final class TranscriptionLabRunner {
         loadSpeechModel: @escaping SpeechModelLoader,
         transcribe: @escaping Transcriber,
         runSpeakerTagging: @escaping SpeakerTaggingRunner = { _ in nil },
+        resolveSpeakerProfiles: @escaping SpeakerProfileResolver = { _, _, _, _ in [] },
         clean: @escaping Cleaner,
         correctionStore: CorrectionStore,
         cleanupPromptBuilder: CleanupPromptBuilder = CleanupPromptBuilder()
@@ -90,6 +101,7 @@ final class TranscriptionLabRunner {
         self.loadSpeechModel = loadSpeechModel
         self.transcribe = transcribe
         self.runSpeakerTagging = runSpeakerTagging
+        self.resolveSpeakerProfiles = resolveSpeakerProfiles
         self.clean = clean
         self.correctionStore = correctionStore
         self.cleanupPromptBuilder = cleanupPromptBuilder
@@ -116,13 +128,20 @@ final class TranscriptionLabRunner {
 
         if speakerTaggingEnabled,
            let speakerTaggedResult = await runSpeakerTagging(audioBuffer) {
+            let speakerProfiles = await resolveSpeakerProfiles(
+                entry.id,
+                audioBuffer,
+                speakerTaggedResult.diarizationSummary,
+                speakerTaggedResult.speakerTaggedTranscript
+            )
             if let filteredTranscript = speakerTaggedResult.filteredTranscript?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                filteredTranscript.isEmpty == false {
                 return TranscriptionLabTranscriptionResult(
                     rawTranscription: filteredTranscript,
                     diarizationSummary: speakerTaggedResult.diarizationSummary,
-                    speakerTaggedTranscript: speakerTaggedResult.speakerTaggedTranscript
+                    speakerTaggedTranscript: speakerTaggedResult.speakerTaggedTranscript,
+                    speakerProfiles: speakerProfiles
                 )
             }
 
@@ -135,7 +154,8 @@ final class TranscriptionLabRunner {
             return TranscriptionLabTranscriptionResult(
                 rawTranscription: rawTranscription,
                 diarizationSummary: speakerTaggedResult.diarizationSummary,
-                speakerTaggedTranscript: speakerTaggedResult.speakerTaggedTranscript
+                speakerTaggedTranscript: speakerTaggedResult.speakerTaggedTranscript,
+                speakerProfiles: speakerProfiles
             )
         }
 

--- a/GhostPepper/Lab/TranscriptionLabRunner.swift
+++ b/GhostPepper/Lab/TranscriptionLabRunner.swift
@@ -128,15 +128,15 @@ final class TranscriptionLabRunner {
 
         if speakerTaggingEnabled,
            let speakerTaggedResult = await runSpeakerTagging(audioBuffer) {
-            let speakerProfiles = await resolveSpeakerProfiles(
-                entry.id,
-                audioBuffer,
-                speakerTaggedResult.diarizationSummary,
-                speakerTaggedResult.speakerTaggedTranscript
-            )
             if let filteredTranscript = speakerTaggedResult.filteredTranscript?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                filteredTranscript.isEmpty == false {
+                let speakerProfiles = await resolveSpeakerProfiles(
+                    entry.id,
+                    audioBuffer,
+                    speakerTaggedResult.diarizationSummary,
+                    speakerTaggedResult.speakerTaggedTranscript
+                )
                 return TranscriptionLabTranscriptionResult(
                     rawTranscription: filteredTranscript,
                     diarizationSummary: speakerTaggedResult.diarizationSummary,
@@ -151,10 +151,21 @@ final class TranscriptionLabRunner {
                 throw TranscriptionLabRunnerError.transcriptionFailed
             }
 
+            let speakerTaggedTranscript = repairedSpeakerTaggedTranscript(
+                from: speakerTaggedResult,
+                fallbackRawTranscription: rawTranscription
+            )
+            let speakerProfiles = await resolveSpeakerProfiles(
+                entry.id,
+                audioBuffer,
+                speakerTaggedResult.diarizationSummary,
+                speakerTaggedTranscript
+            )
+
             return TranscriptionLabTranscriptionResult(
                 rawTranscription: rawTranscription,
                 diarizationSummary: speakerTaggedResult.diarizationSummary,
-                speakerTaggedTranscript: speakerTaggedResult.speakerTaggedTranscript,
+                speakerTaggedTranscript: speakerTaggedTranscript,
                 speakerProfiles: speakerProfiles
             )
         }
@@ -166,6 +177,48 @@ final class TranscriptionLabRunner {
         }
 
         return TranscriptionLabTranscriptionResult(rawTranscription: rawTranscription)
+    }
+
+    private func repairedSpeakerTaggedTranscript(
+        from result: SpeakerTaggedTranscriptionResult,
+        fallbackRawTranscription: String
+    ) -> SpeakerTaggedTranscript? {
+        guard result.diarizationSummary.fallbackReason == .emptyFilteredTranscription else {
+            return result.speakerTaggedTranscript
+        }
+
+        let normalizedFallbackTranscript = fallbackRawTranscription.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        guard normalizedFallbackTranscript.isEmpty == false else {
+            return nil
+        }
+
+        let speakerIDs = result.diarizationSummary.spans.reduce(into: [String]()) { orderedSpeakerIDs, span in
+            if orderedSpeakerIDs.contains(span.speakerID) == false {
+                orderedSpeakerIDs.append(span.speakerID)
+            }
+        }
+        guard speakerIDs.count == 1, let speakerID = speakerIDs.first else {
+            return nil
+        }
+
+        let startTime = result.diarizationSummary.spans.map(\.startTime).min() ?? 0
+        let endTime = result.diarizationSummary.spans.map(\.endTime).max() ?? startTime
+        guard endTime > startTime else {
+            return nil
+        }
+
+        return SpeakerTaggedTranscript(
+            segments: [
+                .init(
+                    speakerID: speakerID,
+                    startTime: startTime,
+                    endTime: endTime,
+                    text: normalizedFallbackTranscript
+                )
+            ]
+        )
     }
 
     func rerunCleanup(

--- a/GhostPepper/SpeakerIdentity/RecognizedVoiceStore.swift
+++ b/GhostPepper/SpeakerIdentity/RecognizedVoiceStore.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+struct RecognizedVoiceProfile: Codable, Equatable, Identifiable {
+    let id: UUID
+    var displayName: String
+    var isMe: Bool
+    var embedding: [Float]
+    var updateCount: Int
+    let createdAt: Date
+    var updatedAt: Date
+    var evidenceTranscript: String
+}
+
+final class RecognizedVoiceStore {
+    private let directoryURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(directoryURL: URL? = nil) {
+        self.directoryURL = directoryURL ?? Self.defaultDirectoryURL
+    }
+
+    func loadProfiles() throws -> [RecognizedVoiceProfile] {
+        guard FileManager.default.fileExists(atPath: indexURL.path) else {
+            return []
+        }
+
+        let data = try Data(contentsOf: indexURL)
+        let profiles = try decoder.decode([RecognizedVoiceProfile].self, from: data)
+        return profiles.sorted { lhs, rhs in
+            if lhs.updatedAt == rhs.updatedAt {
+                return lhs.createdAt > rhs.createdAt
+            }
+
+            return lhs.updatedAt > rhs.updatedAt
+        }
+    }
+
+    func upsert(_ profile: RecognizedVoiceProfile) throws {
+        var profiles = try loadProfiles()
+        profiles.removeAll { $0.id == profile.id }
+        profiles.append(profile)
+
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let data = try encoder.encode(profiles)
+        try data.write(to: indexURL, options: .atomic)
+    }
+
+    private var indexURL: URL {
+        directoryURL.appendingPathComponent("recognized-voices.json")
+    }
+
+    private static var defaultDirectoryURL: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport
+            .appendingPathComponent("GhostPepper", isDirectory: true)
+            .appendingPathComponent("recognized-voices", isDirectory: true)
+    }
+}
+
+struct TranscriptionLabSpeakerProfile: Codable, Equatable {
+    let entryID: UUID
+    let speakerID: String
+    var displayName: String
+    var isMe: Bool
+    var recognizedVoiceID: UUID?
+    var evidenceTranscript: String
+}
+
+final class TranscriptionLabSpeakerProfileStore {
+    private let directoryURL: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(directoryURL: URL? = nil) {
+        self.directoryURL = directoryURL ?? Self.defaultDirectoryURL
+    }
+
+    func loadProfiles(for entryID: UUID) throws -> [TranscriptionLabSpeakerProfile] {
+        let entryURL = profilesURL(for: entryID)
+        guard FileManager.default.fileExists(atPath: entryURL.path) else {
+            return []
+        }
+
+        let data = try Data(contentsOf: entryURL)
+        let profiles = try decoder.decode([TranscriptionLabSpeakerProfile].self, from: data)
+        return profiles.sorted { lhs, rhs in
+            lhs.speakerID.localizedStandardCompare(rhs.speakerID) == .orderedAscending
+        }
+    }
+
+    func upsert(_ profile: TranscriptionLabSpeakerProfile) throws {
+        var profiles = try loadProfiles(for: profile.entryID)
+        profiles.removeAll { $0.speakerID == profile.speakerID }
+        profiles.append(profile)
+
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let data = try encoder.encode(profiles)
+        try data.write(to: profilesURL(for: profile.entryID), options: .atomic)
+    }
+
+    private func profilesURL(for entryID: UUID) -> URL {
+        directoryURL.appendingPathComponent("\(entryID.uuidString).json")
+    }
+
+    private static var defaultDirectoryURL: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport
+            .appendingPathComponent("GhostPepper", isDirectory: true)
+            .appendingPathComponent("transcription-lab-speaker-profiles", isDirectory: true)
+    }
+}

--- a/GhostPepper/SpeakerIdentity/SpeakerIdentityResolver.swift
+++ b/GhostPepper/SpeakerIdentity/SpeakerIdentityResolver.swift
@@ -1,0 +1,227 @@
+import Foundation
+import FluidAudio
+
+struct SpeakerIdentityInput: Equatable {
+    let speakerID: String
+    let audioDuration: TimeInterval
+    let evidenceTranscript: String
+    let embedding: [Float]?
+}
+
+struct SpeakerIdentityResolution: Equatable {
+    let recognizedVoices: [RecognizedVoiceProfile]
+    let localProfiles: [TranscriptionLabSpeakerProfile]
+}
+
+struct SpeakerIdentityResolver {
+    let matchDistanceThreshold: Float
+    let minimumEmbeddingDuration: TimeInterval
+
+    init(
+        matchDistanceThreshold: Float = 0.45,
+        minimumEmbeddingDuration: TimeInterval = 1.0
+    ) {
+        self.matchDistanceThreshold = matchDistanceThreshold
+        self.minimumEmbeddingDuration = minimumEmbeddingDuration
+    }
+
+    func resolve(
+        entryID: UUID,
+        speakers: [SpeakerIdentityInput],
+        existingLocalProfiles: [TranscriptionLabSpeakerProfile],
+        recognizedVoices: [RecognizedVoiceProfile],
+        now: Date = Date()
+    ) -> SpeakerIdentityResolution {
+        var resolvedVoices = recognizedVoices
+        var recognizedVoiceIndicesByID = Dictionary(
+            uniqueKeysWithValues: resolvedVoices.enumerated().map { ($0.element.id, $0.offset) }
+        )
+        let localProfilesBySpeakerID = Dictionary(
+            uniqueKeysWithValues: existingLocalProfiles.map { ($0.speakerID, $0) }
+        )
+
+        let resolvedLocalProfiles = speakers.map { speaker in
+            let normalizedEvidence = speaker.evidenceTranscript.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            )
+            let existingLocalProfile = localProfilesBySpeakerID[speaker.speakerID]
+            var localProfile = existingLocalProfile ?? TranscriptionLabSpeakerProfile(
+                entryID: entryID,
+                speakerID: speaker.speakerID,
+                displayName: speaker.speakerID,
+                isMe: false,
+                recognizedVoiceID: nil,
+                evidenceTranscript: normalizedEvidence
+            )
+
+            if normalizedEvidence.isEmpty == false {
+                localProfile.evidenceTranscript = normalizedEvidence
+            }
+
+            guard
+                let embedding = speaker.embedding,
+                speaker.audioDuration >= minimumEmbeddingDuration,
+                SpeakerUtilities.validateEmbedding(embedding)
+            else {
+                return localProfile
+            }
+
+            if let recognizedVoiceID = localProfile.recognizedVoiceID,
+               let recognizedVoiceIndex = recognizedVoiceIndicesByID[recognizedVoiceID] {
+                let updatedVoice = updatedRecognizedVoice(
+                    recognizedVoice: resolvedVoices[recognizedVoiceIndex],
+                    embedding: embedding,
+                    evidenceTranscript: normalizedEvidence,
+                    now: now
+                )
+                resolvedVoices[recognizedVoiceIndex] = updatedVoice
+                if existingLocalProfile == nil {
+                    localProfile.displayName = updatedVoice.displayName
+                    localProfile.isMe = updatedVoice.isMe
+                }
+                return localProfile
+            }
+
+            if let matchedVoiceIndex = bestMatchingRecognizedVoiceIndex(
+                for: embedding,
+                in: resolvedVoices
+            ) {
+                let matchedVoice = updatedRecognizedVoice(
+                    recognizedVoice: resolvedVoices[matchedVoiceIndex],
+                    embedding: embedding,
+                    evidenceTranscript: normalizedEvidence,
+                    now: now
+                )
+                resolvedVoices[matchedVoiceIndex] = matchedVoice
+                localProfile.recognizedVoiceID = matchedVoice.id
+                if existingLocalProfile == nil {
+                    localProfile.displayName = matchedVoice.displayName
+                    localProfile.isMe = matchedVoice.isMe
+                }
+                return localProfile
+            }
+
+            let createdVoice = RecognizedVoiceProfile(
+                id: UUID(),
+                displayName: nextRecognizedVoiceName(existingVoices: resolvedVoices),
+                isMe: false,
+                embedding: normalizedEmbedding(embedding),
+                updateCount: 1,
+                createdAt: now,
+                updatedAt: now,
+                evidenceTranscript: normalizedEvidence
+            )
+            recognizedVoiceIndicesByID[createdVoice.id] = resolvedVoices.count
+            resolvedVoices.append(createdVoice)
+
+            localProfile.recognizedVoiceID = createdVoice.id
+            if existingLocalProfile == nil {
+                localProfile.displayName = createdVoice.displayName
+                localProfile.isMe = createdVoice.isMe
+            }
+
+            return localProfile
+        }
+
+        return SpeakerIdentityResolution(
+            recognizedVoices: resolvedVoices.sorted(by: Self.sortRecognizedVoices),
+            localProfiles: resolvedLocalProfiles.sorted {
+                $0.speakerID.localizedStandardCompare($1.speakerID) == .orderedAscending
+            }
+        )
+    }
+
+    private func bestMatchingRecognizedVoiceIndex(
+        for embedding: [Float],
+        in recognizedVoices: [RecognizedVoiceProfile]
+    ) -> Int? {
+        let normalized = normalizedEmbedding(embedding)
+        let bestMatch = recognizedVoices.enumerated().min { lhs, rhs in
+            SpeakerUtilities.cosineDistance(normalized, lhs.element.embedding)
+                < SpeakerUtilities.cosineDistance(normalized, rhs.element.embedding)
+        }
+
+        guard let bestMatch else {
+            return nil
+        }
+
+        let distance = SpeakerUtilities.cosineDistance(normalized, bestMatch.element.embedding)
+        guard distance <= matchDistanceThreshold else {
+            return nil
+        }
+
+        return bestMatch.offset
+    }
+
+    private func updatedRecognizedVoice(
+        recognizedVoice: RecognizedVoiceProfile,
+        embedding: [Float],
+        evidenceTranscript: String,
+        now: Date
+    ) -> RecognizedVoiceProfile {
+        var updatedVoice = recognizedVoice
+        updatedVoice.embedding = mergedEmbedding(
+            current: recognizedVoice.embedding,
+            currentUpdateCount: recognizedVoice.updateCount,
+            new: embedding
+        )
+        updatedVoice.updateCount += 1
+        updatedVoice.updatedAt = now
+        if evidenceTranscript.isEmpty == false {
+            updatedVoice.evidenceTranscript = evidenceTranscript
+        }
+        return updatedVoice
+    }
+
+    private func mergedEmbedding(
+        current: [Float],
+        currentUpdateCount: Int,
+        new: [Float]
+    ) -> [Float] {
+        let normalizedCurrent = normalizedEmbedding(current)
+        let normalizedNew = normalizedEmbedding(new)
+        let currentWeight = Float(max(currentUpdateCount, 1))
+        let newWeight: Float = 1
+        let totalWeight = currentWeight + newWeight
+
+        var merged = [Float](repeating: 0, count: normalizedCurrent.count)
+        for index in merged.indices {
+            merged[index] = (
+                normalizedCurrent[index] * currentWeight
+                + normalizedNew[index] * newWeight
+            ) / totalWeight
+        }
+        return normalizedEmbedding(merged)
+    }
+
+    private func normalizedEmbedding(_ embedding: [Float]) -> [Float] {
+        guard embedding.isEmpty == false else {
+            return embedding
+        }
+
+        let magnitudeSquared = embedding.reduce(into: Float.zero) { partialResult, value in
+            partialResult += value * value
+        }
+        guard magnitudeSquared > 0 else {
+            return embedding
+        }
+
+        let magnitude = magnitudeSquared.squareRoot()
+        return embedding.map { $0 / magnitude }
+    }
+
+    private func nextRecognizedVoiceName(existingVoices: [RecognizedVoiceProfile]) -> String {
+        "Recognized Voice \(existingVoices.count + 1)"
+    }
+
+    private static func sortRecognizedVoices(
+        lhs: RecognizedVoiceProfile,
+        rhs: RecognizedVoiceProfile
+    ) -> Bool {
+        if lhs.updatedAt == rhs.updatedAt {
+            return lhs.createdAt > rhs.createdAt
+        }
+
+        return lhs.updatedAt > rhs.updatedAt
+    }
+}

--- a/GhostPepper/Transcription/DiarizationSummary.swift
+++ b/GhostPepper/Transcription/DiarizationSummary.swift
@@ -42,6 +42,7 @@ struct DiarizationSummary: Equatable, Codable, Sendable {
         case noUsableSpeakerSpans
         case noSpeakerReachedThreshold
         case ambiguousDominantSpeaker
+        case singleDetectedSpeaker
         case insufficientKeptAudio
         case filteredAudioExtractionFailed
         case emptyFilteredTranscription

--- a/GhostPepper/Transcription/DiarizationSummary.swift
+++ b/GhostPepper/Transcription/DiarizationSummary.swift
@@ -41,6 +41,7 @@ struct DiarizationSummary: Equatable, Codable, Sendable {
     enum FallbackReason: String, Equatable, Codable, Sendable {
         case noUsableSpeakerSpans
         case noSpeakerReachedThreshold
+        case ambiguousDominantSpeaker
         case insufficientKeptAudio
         case filteredAudioExtractionFailed
         case emptyFilteredTranscription

--- a/GhostPepper/Transcription/FluidAudioSpeechSession.swift
+++ b/GhostPepper/Transcription/FluidAudioSpeechSession.swift
@@ -76,6 +76,42 @@ final class FluidAudioSpeechSession {
             )
         }
 
+        let detectedSpeakerIDs = sortedSpans.reduce(into: [String]()) { speakerIDs, span in
+            if speakerIDs.contains(span.speakerID) == false {
+                speakerIDs.append(span.speakerID)
+            }
+        }
+        if detectedSpeakerIDs.count == 1, let speakerID = detectedSpeakerIDs.first {
+            let keptSpans = sortedSpans.map { span in
+                DiarizationSummary.Span(
+                    speakerID: span.speakerID,
+                    startTime: span.startTime,
+                    endTime: span.endTime,
+                    isKept: true
+                )
+            }
+            let targetSpeakerDuration = keptSpans.reduce(into: 0.0) { total, span in
+                total += span.duration
+            }
+            let mergedKeptSpans = mergeKeptSpans(in: keptSpans)
+            let keptAudioDuration = mergedKeptSpans.reduce(into: 0.0) { total, span in
+                total += span.duration
+            }
+
+            return FinalizationResult(
+                filteredTranscript: nil,
+                summary: DiarizationSummary(
+                    spans: keptSpans,
+                    mergedKeptSpans: mergedKeptSpans,
+                    targetSpeakerID: speakerID,
+                    targetSpeakerDuration: targetSpeakerDuration,
+                    keptAudioDuration: keptAudioDuration,
+                    usedFallback: true,
+                    fallbackReason: .singleDetectedSpeaker
+                )
+            )
+        }
+
         switch selectTargetSpeaker(in: sortedSpans) {
         case .selected(let targetSpeakerID):
             let keptSpans = sortedSpans.map { span in

--- a/GhostPepper/Transcription/FluidAudioSpeechSession.swift
+++ b/GhostPepper/Transcription/FluidAudioSpeechSession.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 final class FluidAudioSpeechSession {
+    private struct TaggedSpanGroup {
+        let speakerID: String
+        let span: DiarizationSummary.MergedSpan
+    }
+
     struct FinalizationResult {
         let filteredTranscript: String?
         let summary: DiarizationSummary
@@ -180,6 +185,40 @@ final class FluidAudioSpeechSession {
         }
     }
 
+    func speakerTaggedTranscript(spans: [DiarizationSummary.Span]) async -> SpeakerTaggedTranscript? {
+        let taggedSpanGroups = mergeSpeakerSpans(in: spans)
+        guard taggedSpanGroups.isEmpty == false else {
+            return nil
+        }
+
+        var transcriptSegments: [SpeakerTaggedTranscript.Segment] = []
+        transcriptSegments.reserveCapacity(taggedSpanGroups.count)
+
+        for taggedSpanGroup in taggedSpanGroups {
+            guard let audio = extractAudio(from: [taggedSpanGroup.span]),
+                  let transcript = await transcribeFilteredAudio(audio)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                  transcript.isEmpty == false else {
+                continue
+            }
+
+            transcriptSegments.append(
+                SpeakerTaggedTranscript.Segment(
+                    speakerID: taggedSpanGroup.speakerID,
+                    startTime: taggedSpanGroup.span.startTime,
+                    endTime: taggedSpanGroup.span.endTime,
+                    text: transcript
+                )
+            )
+        }
+
+        guard transcriptSegments.isEmpty == false else {
+            return nil
+        }
+
+        return SpeakerTaggedTranscript(segments: transcriptSegments)
+    }
+
     private func selectTargetSpeaker(in spans: [DiarizationSummary.Span]) -> TargetSpeakerSelection {
         var durationsBySpeaker: [String: TimeInterval] = [:]
         var firstStartBySpeaker: [String: TimeInterval] = [:]
@@ -218,6 +257,44 @@ final class FluidAudioSpeechSession {
         }
 
         return .selected(targetSpeaker.speakerID)
+    }
+
+    private func mergeSpeakerSpans(in spans: [DiarizationSummary.Span]) -> [TaggedSpanGroup] {
+        guard spans.isEmpty == false else {
+            return []
+        }
+
+        var mergedSpanGroups: [TaggedSpanGroup] = []
+
+        for span in spans {
+            guard span.duration > 0 else {
+                continue
+            }
+
+            if let lastSpanGroup = mergedSpanGroups.last,
+               lastSpanGroup.speakerID == span.speakerID,
+               span.startTime - lastSpanGroup.span.endTime <= mergeGapTolerance {
+                mergedSpanGroups[mergedSpanGroups.count - 1] = TaggedSpanGroup(
+                    speakerID: lastSpanGroup.speakerID,
+                    span: DiarizationSummary.MergedSpan(
+                        startTime: lastSpanGroup.span.startTime,
+                        endTime: max(lastSpanGroup.span.endTime, span.endTime)
+                    )
+                )
+            } else {
+                mergedSpanGroups.append(
+                    TaggedSpanGroup(
+                        speakerID: span.speakerID,
+                        span: DiarizationSummary.MergedSpan(
+                            startTime: span.startTime,
+                            endTime: span.endTime
+                        )
+                    )
+                )
+            }
+        }
+
+        return mergedSpanGroups
     }
 
     private func mergeKeptSpans(in spans: [DiarizationSummary.Span]) -> [DiarizationSummary.MergedSpan] {

--- a/GhostPepper/Transcription/FluidAudioSpeechSession.swift
+++ b/GhostPepper/Transcription/FluidAudioSpeechSession.swift
@@ -6,8 +6,15 @@ final class FluidAudioSpeechSession {
         let summary: DiarizationSummary
     }
 
+    private enum TargetSpeakerSelection {
+        case selected(String)
+        case noSpeakerReachedThreshold
+        case ambiguousDominantSpeaker
+    }
+
     private let sampleRate: Int
     private let substantialSpeakerThreshold: TimeInterval
+    private let dominantSpeakerRatioThreshold: Double
     private let minimumKeptAudioDuration: TimeInterval
     private let mergeGapTolerance: TimeInterval
     private let transcribeFilteredAudio: @Sendable ([Float]) async -> String?
@@ -18,12 +25,14 @@ final class FluidAudioSpeechSession {
     init(
         sampleRate: Int = 16_000,
         substantialSpeakerThreshold: TimeInterval = 0.5,
+        dominantSpeakerRatioThreshold: Double = 1.25,
         minimumKeptAudioDuration: TimeInterval = 0.75,
         mergeGapTolerance: TimeInterval = 0.05,
         transcribeFilteredAudio: @escaping @Sendable ([Float]) async -> String?
     ) {
         self.sampleRate = sampleRate
         self.substantialSpeakerThreshold = substantialSpeakerThreshold
+        self.dominantSpeakerRatioThreshold = dominantSpeakerRatioThreshold
         self.minimumKeptAudioDuration = minimumKeptAudioDuration
         self.mergeGapTolerance = mergeGapTolerance
         self.transcribeFilteredAudio = transcribeFilteredAudio
@@ -62,7 +71,87 @@ final class FluidAudioSpeechSession {
             )
         }
 
-        guard let targetSpeakerID = selectTargetSpeakerID(from: sortedSpans) else {
+        switch selectTargetSpeaker(in: sortedSpans) {
+        case .selected(let targetSpeakerID):
+            let keptSpans = sortedSpans.map { span in
+                DiarizationSummary.Span(
+                    speakerID: span.speakerID,
+                    startTime: span.startTime,
+                    endTime: span.endTime,
+                    isKept: span.speakerID == targetSpeakerID
+                )
+            }
+            let targetSpeakerDuration = keptSpans
+                .filter(\.isKept)
+                .reduce(into: 0.0) { total, span in
+                    total += span.duration
+                }
+            let mergedKeptSpans = mergeKeptSpans(in: keptSpans)
+            let keptAudioDuration = mergedKeptSpans.reduce(into: 0.0) { total, span in
+                total += span.duration
+            }
+
+            guard keptAudioDuration >= minimumKeptAudioDuration else {
+                return FinalizationResult(
+                    filteredTranscript: nil,
+                    summary: DiarizationSummary(
+                        spans: keptSpans,
+                        mergedKeptSpans: mergedKeptSpans,
+                        targetSpeakerID: targetSpeakerID,
+                        targetSpeakerDuration: targetSpeakerDuration,
+                        keptAudioDuration: keptAudioDuration,
+                        usedFallback: true,
+                        fallbackReason: .insufficientKeptAudio
+                    )
+                )
+            }
+
+            guard let filteredAudio = extractAudio(from: mergedKeptSpans) else {
+                return FinalizationResult(
+                    filteredTranscript: nil,
+                    summary: DiarizationSummary(
+                        spans: keptSpans,
+                        mergedKeptSpans: mergedKeptSpans,
+                        targetSpeakerID: targetSpeakerID,
+                        targetSpeakerDuration: targetSpeakerDuration,
+                        keptAudioDuration: keptAudioDuration,
+                        usedFallback: true,
+                        fallbackReason: .filteredAudioExtractionFailed
+                    )
+                )
+            }
+
+            let filteredTranscript = await transcribeFilteredAudio(filteredAudio)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard let filteredTranscript, filteredTranscript.isEmpty == false else {
+                return FinalizationResult(
+                    filteredTranscript: nil,
+                    summary: DiarizationSummary(
+                        spans: keptSpans,
+                        mergedKeptSpans: mergedKeptSpans,
+                        targetSpeakerID: targetSpeakerID,
+                        targetSpeakerDuration: targetSpeakerDuration,
+                        keptAudioDuration: keptAudioDuration,
+                        usedFallback: true,
+                        fallbackReason: .emptyFilteredTranscription
+                    )
+                )
+            }
+
+            return FinalizationResult(
+                filteredTranscript: filteredTranscript,
+                summary: DiarizationSummary(
+                    spans: keptSpans,
+                    mergedKeptSpans: mergedKeptSpans,
+                    targetSpeakerID: targetSpeakerID,
+                    targetSpeakerDuration: targetSpeakerDuration,
+                    keptAudioDuration: keptAudioDuration,
+                    usedFallback: false,
+                    fallbackReason: nil
+                )
+            )
+        case .noSpeakerReachedThreshold:
             return FinalizationResult(
                 filteredTranscript: nil,
                 summary: DiarizationSummary(
@@ -75,102 +164,60 @@ final class FluidAudioSpeechSession {
                     fallbackReason: .noSpeakerReachedThreshold
                 )
             )
-        }
-
-        let keptSpans = sortedSpans.map { span in
-            DiarizationSummary.Span(
-                speakerID: span.speakerID,
-                startTime: span.startTime,
-                endTime: span.endTime,
-                isKept: span.speakerID == targetSpeakerID
-            )
-        }
-        let targetSpeakerDuration = keptSpans
-            .filter(\.isKept)
-            .reduce(into: 0.0) { total, span in
-                total += span.duration
-            }
-        let mergedKeptSpans = mergeKeptSpans(in: keptSpans)
-        let keptAudioDuration = mergedKeptSpans.reduce(into: 0.0) { total, span in
-            total += span.duration
-        }
-
-        guard keptAudioDuration >= minimumKeptAudioDuration else {
+        case .ambiguousDominantSpeaker:
             return FinalizationResult(
                 filteredTranscript: nil,
                 summary: DiarizationSummary(
-                    spans: keptSpans,
-                    mergedKeptSpans: mergedKeptSpans,
-                    targetSpeakerID: targetSpeakerID,
-                    targetSpeakerDuration: targetSpeakerDuration,
-                    keptAudioDuration: keptAudioDuration,
+                    spans: sortedSpans,
+                    mergedKeptSpans: [],
+                    targetSpeakerID: nil,
+                    targetSpeakerDuration: 0,
+                    keptAudioDuration: 0,
                     usedFallback: true,
-                    fallbackReason: .insufficientKeptAudio
+                    fallbackReason: .ambiguousDominantSpeaker
                 )
             )
         }
-
-        guard let filteredAudio = extractAudio(from: mergedKeptSpans) else {
-            return FinalizationResult(
-                filteredTranscript: nil,
-                summary: DiarizationSummary(
-                    spans: keptSpans,
-                    mergedKeptSpans: mergedKeptSpans,
-                    targetSpeakerID: targetSpeakerID,
-                    targetSpeakerDuration: targetSpeakerDuration,
-                    keptAudioDuration: keptAudioDuration,
-                    usedFallback: true,
-                    fallbackReason: .filteredAudioExtractionFailed
-                )
-            )
-        }
-
-        let filteredTranscript = await transcribeFilteredAudio(filteredAudio)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard let filteredTranscript, filteredTranscript.isEmpty == false else {
-            return FinalizationResult(
-                filteredTranscript: nil,
-                summary: DiarizationSummary(
-                    spans: keptSpans,
-                    mergedKeptSpans: mergedKeptSpans,
-                    targetSpeakerID: targetSpeakerID,
-                    targetSpeakerDuration: targetSpeakerDuration,
-                    keptAudioDuration: keptAudioDuration,
-                    usedFallback: true,
-                    fallbackReason: .emptyFilteredTranscription
-                )
-            )
-        }
-
-        return FinalizationResult(
-            filteredTranscript: filteredTranscript,
-            summary: DiarizationSummary(
-                spans: keptSpans,
-                mergedKeptSpans: mergedKeptSpans,
-                targetSpeakerID: targetSpeakerID,
-                targetSpeakerDuration: targetSpeakerDuration,
-                keptAudioDuration: keptAudioDuration,
-                usedFallback: false,
-                fallbackReason: nil
-            )
-        )
     }
 
-    private func selectTargetSpeakerID(from spans: [DiarizationSummary.Span]) -> String? {
+    private func selectTargetSpeaker(in spans: [DiarizationSummary.Span]) -> TargetSpeakerSelection {
         var durationsBySpeaker: [String: TimeInterval] = [:]
+        var firstStartBySpeaker: [String: TimeInterval] = [:]
 
         for span in spans {
             durationsBySpeaker[span.speakerID, default: 0] += span.duration
+            firstStartBySpeaker[span.speakerID] = min(
+                firstStartBySpeaker[span.speakerID] ?? span.startTime,
+                span.startTime
+            )
         }
 
-        for span in spans {
-            if let duration = durationsBySpeaker[span.speakerID], duration >= substantialSpeakerThreshold {
-                return span.speakerID
+        let rankedSpeakers = durationsBySpeaker.map { speakerID, duration in
+            (
+                speakerID: speakerID,
+                duration: duration,
+                firstStartTime: firstStartBySpeaker[speakerID] ?? .greatestFiniteMagnitude
+            )
+        }
+        .sorted { lhs, rhs in
+            if lhs.duration == rhs.duration {
+                return lhs.firstStartTime < rhs.firstStartTime
             }
+
+            return lhs.duration > rhs.duration
         }
 
-        return nil
+        guard let targetSpeaker = rankedSpeakers.first,
+              targetSpeaker.duration >= substantialSpeakerThreshold else {
+            return .noSpeakerReachedThreshold
+        }
+
+        if let runnerUpSpeaker = rankedSpeakers.dropFirst().first,
+           targetSpeaker.duration < runnerUpSpeaker.duration * dominantSpeakerRatioThreshold {
+            return .ambiguousDominantSpeaker
+        }
+
+        return .selected(targetSpeaker.speakerID)
     }
 
     private func mergeKeptSpans(in spans: [DiarizationSummary.Span]) -> [DiarizationSummary.MergedSpan] {

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -186,10 +186,22 @@ final class ModelManager: ObservableObject {
             }
             return nil
         case .parakeetV3, .none:
-            guard let fluidAudioModels else {
+            guard let fluidAudioModels,
+                  let fluidAudioManager else {
                 return nil
             }
-            return SlidingWindowRecordingTranscriptionSession(models: fluidAudioModels)
+            return SlidingWindowRecordingTranscriptionSession(
+                models: fluidAudioModels,
+                fullBufferTranscription: { audioBuffer in
+                    do {
+                        let result = try await fluidAudioManager.transcribe(audioBuffer, source: .microphone)
+                        let cleaned = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        return cleaned.isEmpty ? nil : cleaned
+                    } catch {
+                        return nil
+                    }
+                }
+            )
         }
     }
 

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -10,6 +10,7 @@ final class ModelManager: ObservableObject {
 
     private(set) var whisperKit: WhisperKit?
     private var fluidAudioManager: AsrManager?
+    private var fluidAudioModels: AsrModels?
     private var sortformerModels: SortformerModels?
     /// Stored as `Any?` because `Qwen3AsrManager` is `@available(macOS 15, *)`
     /// and the app deploys to macOS 14. Cast at use sites under `#available`.
@@ -171,10 +172,30 @@ final class ModelManager: ObservableObject {
         }
     }
 
+    func makeRecordingTranscriptionSession() -> RecordingTranscriptionSession? {
+        guard let model = SpeechModelCatalog.model(named: modelName),
+              model.backend == .fluidAudio else {
+            return nil
+        }
+
+        switch model.fluidAudioVariant {
+        case .qwen3AsrInt8:
+            if #available(macOS 15, iOS 18, *),
+               let manager = qwen3AsrManagerStorage as? Qwen3AsrManager {
+                return QwenRecordingTranscriptionSession(asrManager: manager)
+            }
+            return nil
+        case .parakeetV3, .none:
+            guard let fluidAudioModels else {
+                return nil
+            }
+            return SlidingWindowRecordingTranscriptionSession(models: fluidAudioModels)
+        }
+    }
+
     func makeRecordingSessionCoordinator() async -> RecordingSessionCoordinator? {
         guard let model = SpeechModelCatalog.model(named: modelName),
-              model.supportsSpeakerFiltering,
-              fluidAudioManager != nil else {
+              model.backend == .fluidAudio else {
             return nil
         }
 
@@ -273,6 +294,7 @@ final class ModelManager: ObservableObject {
         downloadProgress = nil
         let manager = AsrManager(config: .default)
         try await manager.loadModels(models)
+        fluidAudioModels = models
         fluidAudioManager = manager
     }
 
@@ -316,6 +338,7 @@ final class ModelManager: ObservableObject {
     private func clearLoadedModelInstances() {
         whisperKit = nil
         fluidAudioManager = nil
+        fluidAudioModels = nil
         sortformerModels = nil
         qwen3AsrManagerStorage = nil
         downloadProgress = nil

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -283,7 +283,10 @@ final class ModelManager: ObservableObject {
             diarizer.timeline.finalize()
             let segments = diarizer.timeline.speakers.values
                 .flatMap { $0.finalizedSegments }
-            let spans = Self.diarizationSpans(from: segments)
+            let spans = await speakerTaggingSpans(
+                from: Self.diarizationSpans(from: segments),
+                audioBuffer: audioBuffer
+            )
             let finalizationResult = await session.finalize(spans: spans)
             let speakerTaggedTranscript = await session.speakerTaggedTranscript(spans: spans)
 
@@ -294,6 +297,49 @@ final class ModelManager: ObservableObject {
             )
         } catch {
             debugLogger?(.model, "Speaker tagging diarizer failed to load: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func speakerTaggingSpans(
+        from spans: [DiarizationSummary.Span],
+        audioBuffer: [Float]
+    ) async -> [DiarizationSummary.Span] {
+        guard Self.singleDetectedSpeakerID(in: spans) != nil,
+              let speechSegments = await singleSpeakerSpeechSegments(from: audioBuffer) else {
+            return spans
+        }
+
+        let rescuedSpans = Self.rescuedSingleSpeakerSpans(
+            from: spans,
+            usingSpeechSegments: speechSegments
+        )
+        if rescuedSpans != spans {
+            debugLogger?(.model, "Speaker tagging rescued single-speaker spans with VAD speech segments.")
+        }
+        return rescuedSpans
+    }
+
+    private func singleSpeakerSpeechSegments(
+        from audioBuffer: [Float]
+    ) async -> [DiarizationSummary.MergedSpan]? {
+        guard audioBuffer.isEmpty == false else {
+            return nil
+        }
+
+        do {
+            let vadManager = try await VadManager()
+            let speechSegments = try await vadManager.segmentSpeech(audioBuffer)
+                .map { segment in
+                    DiarizationSummary.MergedSpan(
+                        startTime: segment.startTime,
+                        endTime: segment.endTime
+                    )
+                }
+                .filter { $0.duration > 0 }
+            return speechSegments.isEmpty ? nil : speechSegments
+        } catch {
+            debugLogger?(.model, "Single-speaker VAD rescue failed: \(error.localizedDescription)")
             return nil
         }
     }
@@ -443,6 +489,33 @@ final class ModelManager: ObservableObject {
         return diarizerManager
     }
 
+    static func rescuedSingleSpeakerSpans(
+        from spans: [DiarizationSummary.Span],
+        usingSpeechSegments speechSegments: [DiarizationSummary.MergedSpan]
+    ) -> [DiarizationSummary.Span] {
+        guard let speakerID = singleDetectedSpeakerID(in: spans) else {
+            return spans
+        }
+
+        let rescuedSpans = speechSegments
+            .sorted { lhs, rhs in
+                if lhs.startTime == rhs.startTime {
+                    return lhs.endTime < rhs.endTime
+                }
+                return lhs.startTime < rhs.startTime
+            }
+            .map { segment in
+                DiarizationSummary.Span(
+                    speakerID: speakerID,
+                    startTime: segment.startTime,
+                    endTime: segment.endTime
+                )
+            }
+            .filter { $0.duration > 0 }
+
+        return rescuedSpans.isEmpty ? spans : rescuedSpans
+    }
+
     private static func diarizationSpans(from segments: [DiarizerSegment]) -> [DiarizationSummary.Span] {
         segments
             .map { segment in
@@ -458,6 +531,20 @@ final class ModelManager: ObservableObject {
                 }
                 return lhs.startTime < rhs.startTime
             }
+    }
+
+    private static func singleDetectedSpeakerID(
+        in spans: [DiarizationSummary.Span]
+    ) -> String? {
+        let speakerIDs = spans.reduce(into: [String]()) { orderedSpeakerIDs, span in
+            if orderedSpeakerIDs.contains(span.speakerID) == false {
+                orderedSpeakerIDs.append(span.speakerID)
+            }
+        }
+        guard speakerIDs.count == 1 else {
+            return nil
+        }
+        return speakerIDs.first
     }
 
     private static let speakerTaggingChunkSizeSamples = 16_000

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -12,6 +12,7 @@ final class ModelManager: ObservableObject {
     private var fluidAudioManager: AsrManager?
     private var fluidAudioModels: AsrModels?
     private var sortformerModels: SortformerModels?
+    private var diarizerManager: DiarizerManager?
     /// Stored as `Any?` because `Qwen3AsrManager` is `@available(macOS 15, *)`
     /// and the app deploys to macOS 14. Cast at use sites under `#available`.
     private var qwen3AsrManagerStorage: Any?
@@ -297,6 +298,11 @@ final class ModelManager: ObservableObject {
         }
     }
 
+    func extractSpeakerEmbedding(from audioBuffer: [Float]) async throws -> [Float] {
+        let diarizerManager = try await loadDiarizerManager()
+        return try diarizerManager.extractSpeakerEmbedding(from: audioBuffer)
+    }
+
     private func loadWhisperModel(named modelName: String) async throws {
         let modelsDir = Self.whisperModelsDirectory
         try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
@@ -423,6 +429,18 @@ final class ModelManager: ObservableObject {
         let models = try await SortformerModels.loadFromHuggingFace(config: .default)
         sortformerModels = models
         return models
+    }
+
+    private func loadDiarizerManager() async throws -> DiarizerManager {
+        if let diarizerManager {
+            return diarizerManager
+        }
+
+        let models = try await DiarizerModels.downloadIfNeeded()
+        let diarizerManager = DiarizerManager()
+        diarizerManager.initialize(models: models)
+        self.diarizerManager = diarizerManager
+        return diarizerManager
     }
 
     private static func diarizationSpans(from segments: [DiarizerSegment]) -> [DiarizationSummary.Span] {

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -187,7 +187,22 @@ final class ModelManager: ObservableObject {
             }
             return nil
         case .parakeetV3, .none:
-            return nil
+            guard let fluidAudioModels,
+                  let fluidAudioManager else {
+                return nil
+            }
+            return SlidingWindowRecordingTranscriptionSession(
+                models: fluidAudioModels,
+                fullBufferTranscription: { audioBuffer in
+                    do {
+                        let result = try await fluidAudioManager.transcribe(audioBuffer, source: .microphone)
+                        let cleaned = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        return cleaned.isEmpty ? nil : cleaned
+                    } catch {
+                        return nil
+                    }
+                }
+            )
         }
     }
 

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -187,22 +187,7 @@ final class ModelManager: ObservableObject {
             }
             return nil
         case .parakeetV3, .none:
-            guard let fluidAudioModels,
-                  let fluidAudioManager else {
-                return nil
-            }
-            return SlidingWindowRecordingTranscriptionSession(
-                models: fluidAudioModels,
-                fullBufferTranscription: { audioBuffer in
-                    do {
-                        let result = try await fluidAudioManager.transcribe(audioBuffer, source: .microphone)
-                        let cleaned = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        return cleaned.isEmpty ? nil : cleaned
-                    } catch {
-                        return nil
-                    }
-                }
-            )
+            return nil
         }
     }
 

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -247,6 +247,56 @@ final class ModelManager: ObservableObject {
         }
     }
 
+    func transcribeWithSpeakerTagging(audioBuffer: [Float]) async -> SpeakerTaggedTranscriptionResult? {
+        guard let model = SpeechModelCatalog.model(named: modelName),
+              model.supportsSpeakerFiltering,
+              audioBuffer.isEmpty == false else {
+            return nil
+        }
+
+        do {
+            let diarizerModels = try await loadSortformerModels()
+            let diarizer = SortformerDiarizer()
+            diarizer.initialize(models: diarizerModels)
+            defer { diarizer.cleanup() }
+
+            let session = FluidAudioSpeechSession { [weak self] filteredAudio in
+                await self?.transcribe(audioBuffer: filteredAudio)
+            }
+            session.appendAudioChunk(audioBuffer)
+
+            for audioChunk in Self.audioChunks(
+                from: audioBuffer,
+                maxCount: Self.speakerTaggingChunkSizeSamples
+            ) {
+                do {
+                    _ = try diarizer.process(samples: audioChunk)
+                } catch {
+                    debugLogger?(
+                        .model,
+                        "Speaker tagging diarization chunk failed: \(error.localizedDescription)"
+                    )
+                }
+            }
+
+            diarizer.timeline.finalize()
+            let segments = diarizer.timeline.speakers.values
+                .flatMap { $0.finalizedSegments }
+            let spans = Self.diarizationSpans(from: segments)
+            let finalizationResult = await session.finalize(spans: spans)
+            let speakerTaggedTranscript = await session.speakerTaggedTranscript(spans: spans)
+
+            return SpeakerTaggedTranscriptionResult(
+                filteredTranscript: finalizationResult.filteredTranscript,
+                diarizationSummary: finalizationResult.summary,
+                speakerTaggedTranscript: speakerTaggedTranscript
+            )
+        } catch {
+            debugLogger?(.model, "Speaker tagging diarizer failed to load: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
     private func loadWhisperModel(named modelName: String) async throws {
         let modelsDir = Self.whisperModelsDirectory
         try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
@@ -390,6 +440,26 @@ final class ModelManager: ObservableObject {
                 }
                 return lhs.startTime < rhs.startTime
             }
+    }
+
+    private static let speakerTaggingChunkSizeSamples = 16_000
+
+    private static func audioChunks(from audioBuffer: [Float], maxCount: Int) -> [[Float]] {
+        guard maxCount > 0, audioBuffer.isEmpty == false else {
+            return []
+        }
+
+        var audioChunks: [[Float]] = []
+        audioChunks.reserveCapacity((audioBuffer.count + maxCount - 1) / maxCount)
+
+        var startIndex = 0
+        while startIndex < audioBuffer.count {
+            let endIndex = min(startIndex + maxCount, audioBuffer.count)
+            audioChunks.append(Array(audioBuffer[startIndex..<endIndex]))
+            startIndex = endIndex
+        }
+
+        return audioChunks
     }
 
     private static func isRetryableLoadError(_ error: Error) -> Bool {

--- a/GhostPepper/Transcription/RecordingSessionCoordinator.swift
+++ b/GhostPepper/Transcription/RecordingSessionCoordinator.swift
@@ -1,9 +1,318 @@
+@preconcurrency import AVFoundation
 import Foundation
+import FluidAudio
 
 protocol RecordingTranscriptionSession: AnyObject {
+    var supportsConcurrentFinalization: Bool { get }
     func appendAudioChunk(_ samples: [Float])
     func finishTranscription() async -> String?
     func cancel()
+}
+
+struct StreamingRecordingHandle: Sendable {
+    let appendAudioChunk: @Sendable ([Float]) async -> Void
+    let finishTranscription: @Sendable () async throws -> String
+    let cancel: @Sendable () async -> Void
+    let cleanup: @Sendable () async -> Void
+}
+
+final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSession, @unchecked Sendable {
+    private static let inputFormat = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: 16_000,
+        channels: 1,
+        interleaved: false
+    )!
+
+    private let handleTask: Task<StreamingRecordingHandle, Error>
+    private let stateQueue = DispatchQueue(
+        label: "GhostPepper.SlidingWindowRecordingTranscriptionSession.state"
+    )
+
+    private var isCancelled = false
+    private var isFinishing = false
+    private var didCleanup = false
+    private var appendTask: Task<Void, Never>?
+
+    let supportsConcurrentFinalization = true
+
+    init(handleFactory: @escaping @Sendable () async throws -> StreamingRecordingHandle) {
+        handleTask = Task {
+            try await handleFactory()
+        }
+    }
+
+    convenience init(
+        models: AsrModels,
+        config: SlidingWindowAsrConfig = .streaming
+    ) {
+        self.init {
+            let manager = SlidingWindowAsrManager(config: config)
+            try await manager.start(models: models, source: .microphone)
+
+            return StreamingRecordingHandle(
+                appendAudioChunk: { samples in
+                    guard let buffer = Self.makePCMBuffer(from: samples) else {
+                        return
+                    }
+                    await manager.streamAudio(buffer)
+                },
+                finishTranscription: {
+                    try await manager.finish()
+                },
+                cancel: {
+                    await manager.cancel()
+                },
+                cleanup: {
+                    await manager.cleanup()
+                }
+            )
+        }
+    }
+
+    func appendAudioChunk(_ samples: [Float]) {
+        guard samples.isEmpty == false else {
+            return
+        }
+
+        let shouldProcess = stateQueue.sync { () -> Bool in
+            guard isCancelled == false, isFinishing == false else {
+                return false
+            }
+            let previousTask = appendTask
+            appendTask = Task {
+                _ = await previousTask?.value
+                guard let handle = try? await handleTask.value else {
+                    return
+                }
+                await handle.appendAudioChunk(samples)
+            }
+            return true
+        }
+
+        guard shouldProcess else {
+            return
+        }
+    }
+
+    func finishTranscription() async -> String? {
+        let shouldFinish = stateQueue.sync { () -> Bool in
+            guard isCancelled == false else {
+                return false
+            }
+
+            isFinishing = true
+            return true
+        }
+
+        guard shouldFinish else {
+            return nil
+        }
+
+        await waitForPendingAppends()
+
+        guard let handle = try? await handleTask.value else {
+            return nil
+        }
+
+        let transcript = try? await handle.finishTranscription()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        await cleanupIfNeeded(using: handle)
+        guard let transcript, transcript.isEmpty == false else {
+            return nil
+        }
+
+        return transcript
+    }
+
+    func cancel() {
+        let shouldCancel = stateQueue.sync { () -> Bool in
+            let shouldCancel = isCancelled == false
+            isCancelled = true
+            isFinishing = true
+            return shouldCancel
+        }
+
+        guard shouldCancel else {
+            return
+        }
+
+        Task {
+            let pendingTask = stateQueue.sync { appendTask }
+            _ = await pendingTask?.value
+            guard let handle = try? await handleTask.value else {
+                return
+            }
+
+            await handle.cancel()
+            await self.cleanupIfNeeded(using: handle)
+        }
+    }
+
+    private func waitForPendingAppends() async {
+        let pendingTask = stateQueue.sync { appendTask }
+        _ = await pendingTask?.value
+    }
+
+    private func cleanupIfNeeded(using handle: StreamingRecordingHandle) async {
+        let shouldCleanup = stateQueue.sync { () -> Bool in
+            guard didCleanup == false else {
+                return false
+            }
+
+            didCleanup = true
+            return true
+        }
+
+        guard shouldCleanup else {
+            return
+        }
+
+        await handle.cleanup()
+    }
+
+    private static func makePCMBuffer(from samples: [Float]) -> AVAudioPCMBuffer? {
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: inputFormat,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ) else {
+            return nil
+        }
+
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        if let channelData = buffer.floatChannelData?.pointee {
+            for (index, sample) in samples.enumerated() {
+                channelData[index] = sample
+            }
+        }
+
+        return buffer
+    }
+}
+
+@available(macOS 15, iOS 18, *)
+final class QwenRecordingTranscriptionSession: RecordingTranscriptionSession, @unchecked Sendable {
+    private static let streamingConfig = Qwen3StreamingConfig(
+        minAudioSeconds: 0.5,
+        chunkSeconds: 0.5,
+        maxAudioSeconds: 30.0,
+        language: nil
+    )
+
+    private let streamingManager: Qwen3StreamingManager
+    private let stateQueue = DispatchQueue(
+        label: "GhostPepper.QwenRecordingTranscriptionSession.state"
+    )
+
+    private var latestTranscript: String?
+    private var isCancelled = false
+    private var isFinishing = false
+    private var appendTask: Task<Void, Never>?
+
+    let supportsConcurrentFinalization = false
+
+    init(asrManager: Qwen3AsrManager) {
+        streamingManager = Qwen3StreamingManager(
+            asrManager: asrManager,
+            config: Self.streamingConfig
+        )
+    }
+
+    func appendAudioChunk(_ samples: [Float]) {
+        guard samples.isEmpty == false else {
+            return
+        }
+
+        let shouldProcess = stateQueue.sync { () -> Bool in
+            guard isCancelled == false, isFinishing == false else {
+                return false
+            }
+
+            let previousTask = appendTask
+            appendTask = Task {
+                _ = await previousTask?.value
+
+                let canProcess = stateQueue.sync { () -> Bool in
+                    isCancelled == false
+                }
+                guard canProcess else {
+                    return
+                }
+
+                let transcript = try? await streamingManager.addAudio(samples)?
+                    .transcript
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+
+                stateQueue.sync {
+                    guard self.isCancelled == false else {
+                        return
+                    }
+
+                    if let transcript, transcript.isEmpty == false {
+                        self.latestTranscript = transcript
+                    }
+                }
+            }
+            return true
+        }
+
+        guard shouldProcess else {
+            return
+        }
+    }
+
+    func finishTranscription() async -> String? {
+        let shouldFinish = stateQueue.sync { () -> Bool in
+            guard isCancelled == false else {
+                return false
+            }
+
+            isFinishing = true
+            return true
+        }
+
+        guard shouldFinish else {
+            return nil
+        }
+
+        let pendingTask = stateQueue.sync { appendTask }
+        _ = await pendingTask?.value
+
+        let finalTranscript = try? await streamingManager.finish()
+            .transcript
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return stateQueue.sync {
+            if let finalTranscript, finalTranscript.isEmpty == false {
+                latestTranscript = finalTranscript
+            }
+
+            guard let latestTranscript, latestTranscript.isEmpty == false else {
+                return nil
+            }
+
+            return latestTranscript
+        }
+    }
+
+    func cancel() {
+        let pendingTask = stateQueue.sync { () -> Task<Void, Never>? in
+            let shouldReset = isCancelled == false
+            isCancelled = true
+            isFinishing = true
+            latestTranscript = nil
+            return shouldReset ? appendTask : nil
+        }
+
+        guard let pendingTask else {
+            return
+        }
+
+        Task {
+            _ = await pendingTask.value
+            await streamingManager.reset()
+        }
+    }
 }
 
 final class ChunkedRecordingTranscriptionSession: RecordingTranscriptionSession, @unchecked Sendable {
@@ -24,6 +333,8 @@ final class ChunkedRecordingTranscriptionSession: RecordingTranscriptionSession,
     private var nextTranscriptChunkIndex = 0
     private var isCancelled = false
     private var isFinishing = false
+
+    let supportsConcurrentFinalization = false
 
     init(
         chunkSizeSamples: Int = 17_920,
@@ -236,30 +547,43 @@ final class RecordingSessionCoordinator {
     }
 
     func finish() async -> DiarizationSummary {
+        let result = await finishResult()
+        return result.summary
+    }
+
+    func finishResult() async -> FinalizationResult {
         guard let finishHandler else {
-            return DiarizationSummary(
-                spans: [],
-                mergedKeptSpans: [],
-                targetSpeakerID: nil,
-                targetSpeakerDuration: 0,
-                keptAudioDuration: 0,
-                usedFallback: true,
-                fallbackReason: .noUsableSpeakerSpans
+            return (
+                filteredTranscript: nil,
+                summary: DiarizationSummary(
+                    spans: [],
+                    mergedKeptSpans: [],
+                    targetSpeakerID: nil,
+                    targetSpeakerDuration: 0,
+                    keptAudioDuration: 0,
+                    usedFallback: true,
+                    fallbackReason: .noUsableSpeakerSpans
+                )
             )
         }
 
         let result = await finishHandler()
         filteredTranscript = result.filteredTranscript
-        return result.summary
+        return result
     }
 
     func finish(spans: [DiarizationSummary.Span]) async -> DiarizationSummary {
+        let result = await finishResult(spans: spans)
+        return result.summary
+    }
+
+    func finishResult(spans: [DiarizationSummary.Span]) async -> FinalizationResult {
         guard let finishWithSpansHandler else {
-            return await finish()
+            return await finishResult()
         }
 
         let result = await finishWithSpansHandler(spans)
         filteredTranscript = result.filteredTranscript
-        return result.summary
+        return result
     }
 }

--- a/GhostPepper/Transcription/RecordingSessionCoordinator.swift
+++ b/GhostPepper/Transcription/RecordingSessionCoordinator.swift
@@ -62,7 +62,9 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
     private var appendTask: Task<Void, Never>?
     private var bufferedSamples: [Float] = []
 
-    let allowsBatchFallback = true
+    var allowsBatchFallback: Bool {
+        fullBufferTranscription == nil
+    }
     let supportsConcurrentFinalization = true
 
     init(
@@ -155,26 +157,33 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
             bufferedSamples = []
             return fullBuffer
         }
-        async let streamedTranscriptTask = try? await handle.finishTranscription()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        async let batchTranscriptTask = fullBufferTranscription?(fullBuffer)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let streamedTranscript = await streamedTranscriptTask
-        let batchTranscript = await batchTranscriptTask
-        await cleanupIfNeeded(using: handle)
-        let transcript = [batchTranscript, streamedTranscript]
-            .compactMap { transcript -> String? in
-                guard let transcript, transcript.isEmpty == false else {
-                    return nil
-                }
-                return transcript
+        let streamedTranscriptTask = Task<String?, Never> {
+            let transcript = try? await handle.finishTranscription()
+            return transcript?.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let batchTranscriptTask = fullBufferTranscription.map { fullBufferTranscription in
+            Task<String?, Never> {
+                await fullBufferTranscription(fullBuffer)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
             }
-            .first
-        guard let transcript else {
+        }
+        let batchTranscript = await batchTranscriptTask?.value
+        let streamedTranscript = await streamedTranscriptTask.value
+        await cleanupIfNeeded(using: handle)
+
+        if batchTranscriptTask != nil {
+            guard let batchTranscript, batchTranscript.isEmpty == false else {
+                return nil
+            }
+
+            return batchTranscript
+        }
+
+        guard let streamedTranscript, streamedTranscript.isEmpty == false else {
             return nil
         }
 
-        return transcript
+        return streamedTranscript
     }
 
     func cancel() {

--- a/GhostPepper/Transcription/RecordingSessionCoordinator.swift
+++ b/GhostPepper/Transcription/RecordingSessionCoordinator.swift
@@ -51,6 +51,7 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
     )!
 
     private let handleTask: Task<StreamingRecordingHandle, Error>
+    private let fullBufferTranscription: (@Sendable ([Float]) async -> String?)?
     private let stateQueue = DispatchQueue(
         label: "GhostPepper.SlidingWindowRecordingTranscriptionSession.state"
     )
@@ -59,11 +60,16 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
     private var isFinishing = false
     private var didCleanup = false
     private var appendTask: Task<Void, Never>?
+    private var bufferedSamples: [Float] = []
 
     let allowsBatchFallback = true
     let supportsConcurrentFinalization = true
 
-    init(handleFactory: @escaping @Sendable () async throws -> StreamingRecordingHandle) {
+    init(
+        fullBufferTranscription: (@Sendable ([Float]) async -> String?)? = nil,
+        handleFactory: @escaping @Sendable () async throws -> StreamingRecordingHandle
+    ) {
+        self.fullBufferTranscription = fullBufferTranscription
         handleTask = Task {
             try await handleFactory()
         }
@@ -71,9 +77,10 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
 
     convenience init(
         models: AsrModels,
-        config: SlidingWindowAsrConfig = .streaming
+        config: SlidingWindowAsrConfig = .streaming,
+        fullBufferTranscription: (@Sendable ([Float]) async -> String?)? = nil
     ) {
-        self.init {
+        self.init(fullBufferTranscription: fullBufferTranscription) {
             let manager = SlidingWindowAsrManager(config: config)
             try await manager.start(models: models, source: .microphone)
 
@@ -106,6 +113,7 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
             guard isCancelled == false, isFinishing == false else {
                 return false
             }
+            bufferedSamples.append(contentsOf: samples)
             let previousTask = appendTask
             appendTask = Task {
                 _ = await previousTask?.value
@@ -142,10 +150,27 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
             return nil
         }
 
-        let transcript = try? await handle.finishTranscription()
+        let fullBuffer = stateQueue.sync { () -> [Float] in
+            let fullBuffer = bufferedSamples
+            bufferedSamples = []
+            return fullBuffer
+        }
+        async let streamedTranscriptTask = try? await handle.finishTranscription()
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        async let batchTranscriptTask = fullBufferTranscription?(fullBuffer)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let streamedTranscript = await streamedTranscriptTask
+        let batchTranscript = await batchTranscriptTask
         await cleanupIfNeeded(using: handle)
-        guard let transcript, transcript.isEmpty == false else {
+        let transcript = [batchTranscript, streamedTranscript]
+            .compactMap { transcript -> String? in
+                guard let transcript, transcript.isEmpty == false else {
+                    return nil
+                }
+                return transcript
+            }
+            .first
+        guard let transcript else {
             return nil
         }
 
@@ -157,6 +182,7 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
             let shouldCancel = isCancelled == false
             isCancelled = true
             isFinishing = true
+            bufferedSamples = []
             return shouldCancel
         }
 

--- a/GhostPepper/Transcription/RecordingSessionCoordinator.swift
+++ b/GhostPepper/Transcription/RecordingSessionCoordinator.swift
@@ -3,10 +3,36 @@ import Foundation
 import FluidAudio
 
 protocol RecordingTranscriptionSession: AnyObject {
+    var allowsBatchFallback: Bool { get }
     var supportsConcurrentFinalization: Bool { get }
     func appendAudioChunk(_ samples: [Float])
     func finishTranscription() async -> String?
     func cancel()
+}
+
+private final class OrderedChunkProcessor {
+    private let queue = DispatchQueue(
+        label: "GhostPepper.OrderedChunkProcessor.queue",
+        qos: .userInitiated
+    )
+    private let group = DispatchGroup()
+
+    func enqueue(_ operation: @escaping () -> Void) {
+        group.enter()
+        queue.async { [group] in
+            defer { group.leave() }
+            operation()
+        }
+    }
+
+    func waitForDrain() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async { [group] in
+                group.wait()
+                continuation.resume()
+            }
+        }
+    }
 }
 
 struct StreamingRecordingHandle: Sendable {
@@ -34,6 +60,7 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
     private var didCleanup = false
     private var appendTask: Task<Void, Never>?
 
+    let allowsBatchFallback = false
     let supportsConcurrentFinalization = true
 
     init(handleFactory: @escaping @Sendable () async throws -> StreamingRecordingHandle) {
@@ -181,8 +208,10 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
 
         buffer.frameLength = AVAudioFrameCount(samples.count)
         if let channelData = buffer.floatChannelData?.pointee {
-            for (index, sample) in samples.enumerated() {
-                channelData[index] = sample
+            samples.withUnsafeBufferPointer { source in
+                if let baseAddress = source.baseAddress {
+                    channelData.update(from: baseAddress, count: samples.count)
+                }
             }
         }
 
@@ -209,6 +238,7 @@ final class QwenRecordingTranscriptionSession: RecordingTranscriptionSession, @u
     private var isFinishing = false
     private var appendTask: Task<Void, Never>?
 
+    let allowsBatchFallback = false
     let supportsConcurrentFinalization = false
 
     init(asrManager: Qwen3AsrManager) {
@@ -334,6 +364,7 @@ final class ChunkedRecordingTranscriptionSession: RecordingTranscriptionSession,
     private var isCancelled = false
     private var isFinishing = false
 
+    let allowsBatchFallback = true
     let supportsConcurrentFinalization = false
 
     init(
@@ -521,11 +552,15 @@ final class RecordingSessionCoordinator {
         finish: @escaping () -> [DiarizationSummary.Span],
         cleanup: @escaping () -> Void = {}
     ) {
+        let processor = OrderedChunkProcessor()
         appendAudioChunkHandler = { samples in
             session.appendAudioChunk(samples)
-            processAudioChunk(samples)
+            processor.enqueue {
+                processAudioChunk(samples)
+            }
         }
         finishHandler = {
+            await processor.waitForDrain()
             let result = await session.finalize(spans: finish())
             cleanup()
             return (filteredTranscript: result.filteredTranscript, summary: result.summary)

--- a/GhostPepper/Transcription/RecordingSessionCoordinator.swift
+++ b/GhostPepper/Transcription/RecordingSessionCoordinator.swift
@@ -60,7 +60,7 @@ final class SlidingWindowRecordingTranscriptionSession: RecordingTranscriptionSe
     private var didCleanup = false
     private var appendTask: Task<Void, Never>?
 
-    let allowsBatchFallback = false
+    let allowsBatchFallback = true
     let supportsConcurrentFinalization = true
 
     init(handleFactory: @escaping @Sendable () async throws -> StreamingRecordingHandle) {

--- a/GhostPepper/Transcription/SpeechModelCatalog.swift
+++ b/GhostPepper/Transcription/SpeechModelCatalog.swift
@@ -35,9 +35,9 @@ struct SpeechModelDescriptor: Identifiable, Equatable {
     }
 
     var supportsSpeakerFiltering: Bool {
-        // Only Parakeet exposes diarization output via the Sortformer pipeline.
-        // Qwen3-ASR is an encoder-decoder and has no per-speaker segmentation.
-        fluidAudioVariant == .parakeetV3
+        // Speaker filtering uses a separate diarization pipeline, so any
+        // FluidAudio-backed ASR model can participate in filtering.
+        backend == .fluidAudio
     }
 }
 

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -2556,6 +2556,8 @@ private struct TranscriptionLabDiarizationSummaryView: View {
             return "no speaker reached the selection threshold"
         case .ambiguousDominantSpeaker:
             return "speaker split was too close to call"
+        case .singleDetectedSpeaker:
+            return "only one speaker was detected"
         case .insufficientKeptAudio:
             return "kept audio was too short"
         case .filteredAudioExtractionFailed:

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -171,6 +171,7 @@ struct SettingsView: View {
         _transcriptionLabController = StateObject(
             wrappedValue: TranscriptionLabController(
                 defaultSpeechModelID: appState.speechModel,
+                defaultSpeakerTaggingEnabled: appState.ignoreOtherSpeakers,
                 defaultCleanupModelKind: appState.textCleanupManager.selectedCleanupModelKind,
                 loadStageTimings: {
                     try appState.loadTranscriptionLabStageTimings()
@@ -181,10 +182,11 @@ struct SettingsView: View {
                 audioURLForEntry: { entry in
                     appState.transcriptionLabAudioURL(for: entry)
                 },
-                runTranscription: { entry, speechModelID in
+                runTranscription: { entry, speechModelID, speakerTaggingEnabled in
                     try await appState.rerunTranscriptionLabTranscription(
                         entry,
-                        speechModelID: speechModelID
+                        speechModelID: speechModelID,
+                        speakerTaggingEnabled: speakerTaggingEnabled
                     )
                 },
                 runCleanup: { entry, rawTranscription, cleanupModelKind, prompt, includeWindowContext in
@@ -201,6 +203,9 @@ struct SettingsView: View {
                     Task {
                         await appState.loadSpeechModel(name: speechModelID)
                     }
+                },
+                syncSpeakerTaggingEnabled: { speakerTaggingEnabled in
+                    appState.ignoreOtherSpeakers = speakerTaggingEnabled
                 },
                 syncSelectedCleanupModelKind: { cleanupModelKind in
                     appState.textCleanupManager.selectedCleanupModelKind = cleanupModelKind
@@ -380,6 +385,7 @@ struct SettingsView: View {
     private func syncTranscriptionLabRerunDefaults() {
         transcriptionLabController.applyCurrentRerunDefaults(
             speechModelID: appState.speechModel,
+            speakerTaggingEnabled: appState.ignoreOtherSpeakers,
             cleanupModelKind: appState.textCleanupManager.selectedCleanupModelKind
         )
     }
@@ -1042,6 +1048,27 @@ struct SettingsView: View {
                     }
                 }
 
+                HStack(alignment: .center, spacing: 12) {
+                    Toggle(
+                        "Run speaker tagging",
+                        isOn: $transcriptionLabController.usesSpeakerTagging
+                    )
+                    .toggleStyle(.checkbox)
+                    .disabled(
+                        SpeechModelCatalog.model(named: transcriptionLabController.selectedSpeechModelID)?
+                            .supportsSpeakerFiltering != true || transcriptionLabController.runningStage != nil
+                    )
+
+                    if SpeechModelCatalog.model(named: transcriptionLabController.selectedSpeechModelID)?
+                        .supportsSpeakerFiltering != true {
+                        Text("Speaker tagging is available only for FluidAudio models.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer()
+                }
+
                 DiffReadOnlyTextPane(
                     originalText: entry.rawTranscription ?? "",
                     text: transcriptionLabController.displayedExperimentRawTranscription,
@@ -1049,6 +1076,20 @@ struct SettingsView: View {
                     maximumHeight: 140,
                     monospaced: false
                 )
+
+                if let displayedSpeakerTaggedTranscriptText = transcriptionLabController.displayedSpeakerTaggedTranscriptText {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Speaker-tagged transcript")
+                            .font(.subheadline.weight(.medium))
+
+                        ReadOnlyTextPane(
+                            text: displayedSpeakerTaggedTranscriptText,
+                            minimumHeight: 84,
+                            maximumHeight: 220,
+                            monospaced: false
+                        )
+                    }
+                }
 
                 addCorrectionSection
             }
@@ -1985,6 +2026,17 @@ private struct TranscriptionLabMetadataSummary: View {
 }
 
 private struct TranscriptionLabDiarizationSummaryView: View {
+    private static let speakerPalette: [NSColor] = [
+        .systemBlue,
+        .systemGreen,
+        .systemOrange,
+        .systemPink,
+        .systemTeal,
+        .systemRed,
+        .systemIndigo,
+        .systemBrown,
+    ]
+
     let visualization: TranscriptionLabController.DiarizationVisualization
 
     private var totalDuration: TimeInterval {
@@ -1995,25 +2047,29 @@ private struct TranscriptionLabDiarizationSummaryView: View {
     }
 
     private var summaryText: String {
+        let speakerText = visualization.speakerIDsInDisplayOrder.isEmpty
+            ? "Speaker tagging ran"
+            : "Tagged \(formattedSpeakerCount(visualization.speakerIDsInDisplayOrder.count))"
+
         if visualization.usedFallback {
             if let fallbackReason = visualization.fallbackReason {
-                return "Speaker filtering fell back to the full recording (\(fallbackReasonText(for: fallbackReason)))."
+                return "\(speakerText), but transcription fell back to the full recording (\(fallbackReasonText(for: fallbackReason)))."
             }
 
-            return "Speaker filtering fell back to the full recording."
+            return "\(speakerText), but transcription fell back to the full recording."
         }
 
         if let targetSpeakerID = visualization.targetSpeakerID {
-            return "Kept \(formattedDuration(visualization.keptAudioDuration)) from \(targetSpeakerID)."
+            return "\(speakerText) and kept \(formattedDuration(visualization.keptAudioDuration)) from \(targetSpeakerID)."
         }
 
-        return "Speaker filtering ran without a target speaker."
+        return "\(speakerText)."
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 12) {
-                Text("Speaker filtering")
+                Text("Speaker tagging")
                     .font(.subheadline.weight(.medium))
 
                 Spacer()
@@ -2027,11 +2083,7 @@ private struct TranscriptionLabDiarizationSummaryView: View {
                 HStack(spacing: 2) {
                     ForEach(Array(visualization.spans.enumerated()), id: \.offset) { _, span in
                         Rectangle()
-                            .fill(
-                                span.isKept
-                                ? Color.accentColor
-                                : Color(nsColor: .quaternaryLabelColor)
-                            )
+                            .fill(speakerColor(for: span.speakerID))
                             .frame(width: segmentWidth(for: span, totalWidth: geometry.size.width))
                     }
                 }
@@ -2044,15 +2096,48 @@ private struct TranscriptionLabDiarizationSummaryView: View {
                     .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
             )
 
+            if visualization.speakerIDsInDisplayOrder.isEmpty == false {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .center, spacing: 8) {
+                        ForEach(visualization.speakerIDsInDisplayOrder, id: \.self) { speakerID in
+                            HStack(alignment: .center, spacing: 6) {
+                                Circle()
+                                    .fill(speakerColor(for: speakerID))
+                                    .frame(width: 8, height: 8)
+
+                                Text(speakerID)
+
+                                if speakerID == visualization.targetSpeakerID {
+                                    Text(visualization.usedFallback ? "Target" : "Kept")
+                                        .font(.caption2.weight(.semibold))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .font(.caption)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(
+                                RoundedRectangle(cornerRadius: 999, style: .continuous)
+                                    .fill(Color(nsColor: .textBackgroundColor))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 999, style: .continuous)
+                                    .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+                            )
+                        }
+                    }
+                }
+            }
+
             HStack(alignment: .center, spacing: 12) {
                 if let targetSpeakerID = visualization.targetSpeakerID {
-                    Text("Target: \(targetSpeakerID)")
+                    Text(visualization.usedFallback ? "Target: \(targetSpeakerID)" : "Kept: \(targetSpeakerID)")
                 }
 
                 Text("Kept \(formattedDuration(visualization.keptAudioDuration))")
 
                 if visualization.usedFallback {
-                    Text("Used fallback")
+                    Text("Used full recording")
                 }
 
                 Spacer()
@@ -2077,6 +2162,20 @@ private struct TranscriptionLabDiarizationSummaryView: View {
         for span: TranscriptionLabController.DiarizationVisualization.Span
     ) -> CGFloat {
         CGFloat(max(0, span.endTime - span.startTime) / totalDuration)
+    }
+
+    private func speakerColor(for speakerID: String) -> Color {
+        let speakerIDs = visualization.speakerIDsInDisplayOrder
+        guard let speakerIndex = speakerIDs.firstIndex(of: speakerID) else {
+            return Color.accentColor
+        }
+
+        let paletteIndex = speakerIndex % Self.speakerPalette.count
+        return Color(nsColor: Self.speakerPalette[paletteIndex])
+    }
+
+    private func formattedSpeakerCount(_ count: Int) -> String {
+        count == 1 ? "1 speaker" : "\(count) speakers"
     }
 
     private func formattedDuration(_ duration: TimeInterval) -> String {

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -2089,6 +2089,8 @@ private struct TranscriptionLabDiarizationSummaryView: View {
             return "no usable speaker spans"
         case .noSpeakerReachedThreshold:
             return "no speaker reached the selection threshold"
+        case .ambiguousDominantSpeaker:
+            return "speaker split was too close to call"
         case .insufficientKeptAudio:
             return "kept audio was too short"
         case .filteredAudioExtractionFailed:

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -93,6 +93,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
     case corrections
     case models
     case transcriptionLab
+    case recognizedVoices
     case pepperChat
     case meetingTranscript
     case general
@@ -106,6 +107,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .corrections: "Corrections"
         case .models: "Models"
         case .transcriptionLab: "History"
+        case .recognizedVoices: "Recognized Voices"
         case .pepperChat: "Context Bundler"
         case .meetingTranscript: "Meeting Transcript"
         case .general: "General"
@@ -119,6 +121,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .corrections: "Words and replacements Ghost Pepper should preserve."
         case .models: "Speech and cleanup model downloads and runtime status."
         case .transcriptionLab: "Saved recordings, reruns, and cleanup experiments."
+        case .recognizedVoices: "Reusable speaker labels and 'this is me' voice prints."
         case .pepperChat: "Capture screen context and send to Zo, Trello, or clipboard."
         case .meetingTranscript: "Auto-detect calls and transcribe meetings locally."
         case .general: "Startup behavior and app-wide preferences."
@@ -132,6 +135,7 @@ enum SettingsSection: String, CaseIterable, Identifiable {
         case .corrections: "text.badge.checkmark"
         case .models: "brain"
         case .transcriptionLab: "waveform.badge.magnifyingglass"
+        case .recognizedVoices: "person.crop.circle.badge.checkmark"
         case .pepperChat: "bubble.right"
         case .meetingTranscript: "waveform.badge.mic"
         case .general: "gearshape"
@@ -160,6 +164,8 @@ struct SettingsView: View {
     @State private var permissionPollTimer: Timer?
     @State private var selectedSection: SettingsSection = .recording
     @State private var transcriptionLabPreviewSound: NSSound?
+    @State private var recognizedVoices: [RecognizedVoiceProfile] = []
+    @State private var recognizedVoicesErrorMessage: String?
     @StateObject private var dictationTestController: SettingsDictationTestController
     @StateObject private var transcriptionLabController: TranscriptionLabController
 
@@ -197,6 +203,18 @@ struct SettingsView: View {
                         prompt: prompt,
                         includeWindowContext: includeWindowContext
                     )
+                },
+                loadSpeakerProfiles: { entryID in
+                    try appState.loadTranscriptionLabSpeakerProfiles(for: entryID)
+                },
+                saveSpeakerProfile: { profile in
+                    try appState.upsertTranscriptionLabSpeakerProfile(profile)
+                },
+                loadRecognizedVoices: {
+                    try appState.loadRecognizedVoiceProfiles()
+                },
+                updateGlobalVoiceProfile: { localProfile in
+                    try appState.updateGlobalVoiceProfile(from: localProfile)
                 },
                 syncSelectedSpeechModelID: { speechModelID in
                     appState.speechModel = speechModelID
@@ -309,6 +327,7 @@ struct SettingsView: View {
             startPermissionPollingIfNeeded()
             syncTranscriptionLabRerunDefaults()
             transcriptionLabController.reloadEntries()
+            reloadRecognizedVoices()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             refreshScreenRecordingPermission()
@@ -318,6 +337,8 @@ struct SettingsView: View {
             if newSection == .transcriptionLab {
                 syncTranscriptionLabRerunDefaults()
                 transcriptionLabController.reloadEntries()
+            } else if newSection == .recognizedVoices {
+                reloadRecognizedVoices()
             }
         }
         .onChange(of: appState.speechModel) { _, _ in
@@ -390,6 +411,35 @@ struct SettingsView: View {
         )
     }
 
+    private func reloadRecognizedVoices() {
+        do {
+            recognizedVoices = try appState.loadRecognizedVoiceProfiles()
+            recognizedVoicesErrorMessage = nil
+        } catch {
+            recognizedVoices = []
+            recognizedVoicesErrorMessage = "Could not load recognized voices."
+        }
+    }
+
+    private func upsertRecognizedVoiceProfile(_ profile: RecognizedVoiceProfile) {
+        do {
+            try appState.upsertRecognizedVoiceProfile(profile)
+            replaceRecognizedVoiceProfile(profile)
+            recognizedVoicesErrorMessage = nil
+        } catch {
+            recognizedVoicesErrorMessage = "Could not save that recognized voice."
+        }
+    }
+
+    private func replaceRecognizedVoiceProfile(_ updatedProfile: RecognizedVoiceProfile) {
+        guard let existingIndex = recognizedVoices.firstIndex(where: { $0.id == updatedProfile.id }) else {
+            recognizedVoices.append(updatedProfile)
+            return
+        }
+
+        recognizedVoices[existingIndex] = updatedProfile
+    }
+
     private func playTranscriptionLabAudio(for entry: TranscriptionLabEntry) {
         let sound = NSSound(contentsOf: transcriptionLabController.audioURL(for: entry), byReference: false)
         transcriptionLabPreviewSound?.stop()
@@ -457,6 +507,8 @@ struct SettingsView: View {
                 modelsSection
             case .transcriptionLab:
                 transcriptionLabSection
+            case .recognizedVoices:
+                recognizedVoicesSection
             case .pepperChat:
                 pepperChatSection
             case .meetingTranscript:
@@ -863,6 +915,41 @@ struct SettingsView: View {
         }
     }
 
+    private var recognizedVoicesSection: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Ghost Pepper auto-creates reusable voice prints from speaker-tagged lab reruns. Marking more than one voice print as \"This is me\" is allowed.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let recognizedVoicesErrorMessage {
+                Text(recognizedVoicesErrorMessage)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+            }
+
+            if recognizedVoices.isEmpty {
+                ContentUnavailableView(
+                    "No Recognized Voices",
+                    systemImage: "person.crop.circle.badge.questionmark",
+                    description: Text("Run speaker tagging in History to create reusable voice prints.")
+                )
+                .frame(maxWidth: .infinity, minHeight: 280)
+            } else {
+                VStack(alignment: .leading, spacing: 18) {
+                    ForEach(recognizedVoices) { profile in
+                        RecognizedVoiceProfileEditor(
+                            profile: profile,
+                            onChange: { updatedProfile in
+                                upsertRecognizedVoiceProfile(updatedProfile)
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     @State private var showClearHistoryConfirmation = false
 
     private var transcriptionLabBrowser: some View {
@@ -968,6 +1055,38 @@ struct SettingsView: View {
 
                 if let diarizationVisualization = transcriptionLabController.diarizationVisualization {
                     TranscriptionLabDiarizationSummaryView(visualization: diarizationVisualization)
+                }
+
+                if transcriptionLabController.speakerProfilesInDisplayOrder.isEmpty == false {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Speaker identities")
+                            .font(.subheadline.weight(.medium))
+
+                        ForEach(transcriptionLabController.speakerProfilesInDisplayOrder, id: \.speakerID) { profile in
+                            TranscriptionLabSpeakerProfileEditor(
+                                profile: profile,
+                                effectiveDisplayName: transcriptionLabController.displayName(for: profile.speakerID) ?? profile.speakerID,
+                                showsGlobalUpdateButton: transcriptionLabController.hasPendingGlobalVoiceUpdate(for: profile.speakerID),
+                                onDisplayNameChange: { updatedDisplayName in
+                                    transcriptionLabController.updateSpeakerDisplayName(
+                                        updatedDisplayName,
+                                        for: profile.speakerID
+                                    )
+                                },
+                                onIsMeChange: { isMe in
+                                    transcriptionLabController.setSpeakerIsMe(isMe, for: profile.speakerID)
+                                },
+                                onUpdateGlobalVoice: {
+                                    transcriptionLabController.pushSpeakerProfileToGlobalVoice(for: profile.speakerID)
+                                    reloadRecognizedVoices()
+                                }
+                            )
+                        }
+                    }
+                } else if transcriptionLabController.diarizationVisualization != nil {
+                    Text("Run speaker tagging again on this recording to attach editable speaker names and reusable voice prints.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 HStack(alignment: .center, spacing: 12) {
@@ -1681,6 +1800,241 @@ struct SettingsView: View {
     }
 }
 
+private struct TranscriptionLabSpeakerProfileEditor: View {
+    let profile: TranscriptionLabSpeakerProfile
+    let effectiveDisplayName: String
+    let showsGlobalUpdateButton: Bool
+    let onDisplayNameChange: (String) -> Void
+    let onIsMeChange: (Bool) -> Void
+    let onUpdateGlobalVoice: () -> Void
+
+    @State private var draftDisplayName: String
+    @FocusState private var isNameFieldFocused: Bool
+
+    init(
+        profile: TranscriptionLabSpeakerProfile,
+        effectiveDisplayName: String,
+        showsGlobalUpdateButton: Bool,
+        onDisplayNameChange: @escaping (String) -> Void,
+        onIsMeChange: @escaping (Bool) -> Void,
+        onUpdateGlobalVoice: @escaping () -> Void
+    ) {
+        self.profile = profile
+        self.effectiveDisplayName = effectiveDisplayName
+        self.showsGlobalUpdateButton = showsGlobalUpdateButton
+        self.onDisplayNameChange = onDisplayNameChange
+        self.onIsMeChange = onIsMeChange
+        self.onUpdateGlobalVoice = onUpdateGlobalVoice
+        _draftDisplayName = State(initialValue: profile.displayName)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 8) {
+                Text(profile.speakerID)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+
+                if profile.recognizedVoiceID != nil {
+                    Text("Reusable voice print")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(Color(nsColor: .controlBackgroundColor))
+                        )
+                }
+
+                Spacer()
+            }
+
+            HStack(alignment: .center, spacing: 12) {
+                TextField(
+                    "Name this speaker",
+                    text: $draftDisplayName,
+                    prompt: Text(effectiveDisplayName)
+                )
+                .textFieldStyle(.roundedBorder)
+                .focused($isNameFieldFocused)
+                .onSubmit(commitDisplayName)
+                .onChange(of: isNameFieldFocused) { _, isFocused in
+                    if !isFocused {
+                        commitDisplayName()
+                    }
+                }
+
+                Toggle(
+                    "This is me",
+                    isOn: Binding(
+                        get: { profile.isMe },
+                        set: onIsMeChange
+                    )
+                )
+                .toggleStyle(.checkbox)
+                .fixedSize()
+            }
+
+            if profile.evidenceTranscript.isEmpty == false {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Tagged transcript evidence")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+
+                    ReadOnlyTextPane(
+                        text: profile.evidenceTranscript,
+                        minimumHeight: 52,
+                        maximumHeight: 110,
+                        monospaced: false
+                    )
+                }
+            }
+
+            if profile.recognizedVoiceID == nil {
+                Text("This speaker only has a recording-local label because Ghost Pepper could not build a reusable voice print from this sample.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if showsGlobalUpdateButton {
+                Button("Update global voice print") {
+                    commitDisplayName()
+                    onUpdateGlobalVoice()
+                }
+                .buttonStyle(.bordered)
+                .font(.caption)
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
+        .onChange(of: profile.displayName) { _, newValue in
+            if newValue != draftDisplayName {
+                draftDisplayName = newValue
+            }
+        }
+    }
+
+    private func commitDisplayName() {
+        guard draftDisplayName != profile.displayName else {
+            return
+        }
+
+        onDisplayNameChange(draftDisplayName)
+    }
+}
+
+private struct RecognizedVoiceProfileEditor: View {
+    let profile: RecognizedVoiceProfile
+    let onChange: (RecognizedVoiceProfile) -> Void
+
+    @State private var draftDisplayName: String
+    @FocusState private var isNameFieldFocused: Bool
+
+    init(
+        profile: RecognizedVoiceProfile,
+        onChange: @escaping (RecognizedVoiceProfile) -> Void
+    ) {
+        self.profile = profile
+        self.onChange = onChange
+        _draftDisplayName = State(initialValue: profile.displayName)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 12) {
+                TextField("Recognized voice name", text: $draftDisplayName)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($isNameFieldFocused)
+                    .onSubmit(commitDisplayName)
+                    .onChange(of: isNameFieldFocused) { _, isFocused in
+                        if !isFocused {
+                            commitDisplayName()
+                        }
+                    }
+
+                Toggle(
+                    "This is me",
+                    isOn: Binding(
+                        get: { profile.isMe },
+                        set: { isMe in
+                            var updatedProfile = profile
+                            updatedProfile.isMe = isMe
+                            updatedProfile.updatedAt = Date()
+                            onChange(updatedProfile)
+                        }
+                    )
+                )
+                .toggleStyle(.checkbox)
+                .fixedSize()
+            }
+
+            HStack(alignment: .center, spacing: 12) {
+                Text("Updated \(profile.updatedAt.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text("\(profile.updateCount) matches")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+            }
+
+            if profile.evidenceTranscript.isEmpty == false {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Latest transcript evidence")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.secondary)
+
+                    ReadOnlyTextPane(
+                        text: profile.evidenceTranscript,
+                        minimumHeight: 52,
+                        maximumHeight: 110,
+                        monospaced: false
+                    )
+                }
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
+        )
+        .onChange(of: profile.displayName) { _, newValue in
+            if newValue != draftDisplayName {
+                draftDisplayName = newValue
+            }
+        }
+    }
+
+    private func commitDisplayName() {
+        guard draftDisplayName != profile.displayName else {
+            return
+        }
+
+        let normalizedName = draftDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedName.isEmpty == false else {
+            draftDisplayName = profile.displayName
+            return
+        }
+
+        var updatedProfile = profile
+        updatedProfile.displayName = normalizedName
+        updatedProfile.updatedAt = Date()
+        onChange(updatedProfile)
+    }
+}
+
 private struct ScreenRecordingRecoveryView: View {
     let onOpenSettings: () -> Void
 
@@ -2060,7 +2414,7 @@ private struct TranscriptionLabDiarizationSummaryView: View {
         }
 
         if let targetSpeakerID = visualization.targetSpeakerID {
-            return "\(speakerText) and kept \(formattedDuration(visualization.keptAudioDuration)) from \(targetSpeakerID)."
+            return "\(speakerText) and kept \(formattedDuration(visualization.keptAudioDuration)) from \(visualization.displayName(for: targetSpeakerID))."
         }
 
         return "\(speakerText)."
@@ -2082,14 +2436,22 @@ private struct TranscriptionLabDiarizationSummaryView: View {
             GeometryReader { geometry in
                 HStack(spacing: 2) {
                     ForEach(Array(visualization.spans.enumerated()), id: \.offset) { _, span in
-                        Rectangle()
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
                             .fill(speakerColor(for: span.speakerID))
                             .frame(width: segmentWidth(for: span, totalWidth: geometry.size.width))
+                            .overlay {
+                                Text(span.displayName)
+                                    .font(.caption2.weight(.semibold))
+                                    .foregroundStyle(span.isKept ? Color.white : Color.primary)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.65)
+                                    .padding(.horizontal, 6)
+                            }
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
             }
-            .frame(height: 8)
+            .frame(height: 22)
             .clipShape(RoundedRectangle(cornerRadius: 999, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 999, style: .continuous)
@@ -2105,7 +2467,7 @@ private struct TranscriptionLabDiarizationSummaryView: View {
                                     .fill(speakerColor(for: speakerID))
                                     .frame(width: 8, height: 8)
 
-                                Text(speakerID)
+                                Text(visualization.displayName(for: speakerID))
 
                                 if speakerID == visualization.targetSpeakerID {
                                     Text(visualization.usedFallback ? "Target" : "Kept")
@@ -2131,7 +2493,11 @@ private struct TranscriptionLabDiarizationSummaryView: View {
 
             HStack(alignment: .center, spacing: 12) {
                 if let targetSpeakerID = visualization.targetSpeakerID {
-                    Text(visualization.usedFallback ? "Target: \(targetSpeakerID)" : "Kept: \(targetSpeakerID)")
+                    Text(
+                        visualization.usedFallback
+                            ? "Target: \(visualization.displayName(for: targetSpeakerID))"
+                            : "Kept: \(visualization.displayName(for: targetSpeakerID))"
+                    )
                 }
 
                 Text("Kept \(formattedDuration(visualization.keptAudioDuration))")

--- a/GhostPepperTests/FluidAudioSpeechSessionTests.swift
+++ b/GhostPepperTests/FluidAudioSpeechSessionTests.swift
@@ -192,6 +192,34 @@ final class FluidAudioSpeechSessionTests: XCTestCase {
         XCTAssertEqual(transcriptionCallCountValue, 1)
     }
 
+    func testFinalizeFallsBackWhenOnlyOneSpeakerIsDetected() async {
+        let transcriptionCallCount = LockedValue(0)
+        let session = FluidAudioSpeechSession(
+            sampleRate: 10,
+            transcribeFilteredAudio: { _ in
+                await transcriptionCallCount.withValue { $0 += 1 }
+                return "Yeah."
+            }
+        )
+
+        session.appendAudioChunk(Array(repeating: 0, count: 46))
+
+        let result = await session.finalize(
+            spans: [
+                .init(speakerID: "Speaker 0", startTime: 2.48, endTime: 4.24),
+            ]
+        )
+
+        XCTAssertNil(result.filteredTranscript)
+        XCTAssertTrue(result.summary.usedFallback)
+        XCTAssertEqual(result.summary.fallbackReason, .singleDetectedSpeaker)
+        XCTAssertEqual(result.summary.targetSpeakerID, "Speaker 0")
+        XCTAssertEqual(result.summary.keptAudioDuration, 1.76, accuracy: 0.0001)
+        XCTAssertEqual(result.summary.spans.map(\.isKept), [true])
+        let transcriptionCallCountValue = await transcriptionCallCount.get()
+        XCTAssertEqual(transcriptionCallCountValue, 0)
+    }
+
     func testSpeakerTaggedTranscriptTranscribesMergedSpeakerSpansInTimelineOrder() async {
         let capturedAudio = LockedValue<[[Float]]>([])
         let session = FluidAudioSpeechSession(

--- a/GhostPepperTests/FluidAudioSpeechSessionTests.swift
+++ b/GhostPepperTests/FluidAudioSpeechSessionTests.swift
@@ -191,6 +191,73 @@ final class FluidAudioSpeechSessionTests: XCTestCase {
         let transcriptionCallCountValue = await transcriptionCallCount.get()
         XCTAssertEqual(transcriptionCallCountValue, 1)
     }
+
+    func testSpeakerTaggedTranscriptTranscribesMergedSpeakerSpansInTimelineOrder() async {
+        let capturedAudio = LockedValue<[[Float]]>([])
+        let session = FluidAudioSpeechSession(
+            sampleRate: 10,
+            transcribeFilteredAudio: { audio in
+                await capturedAudio.withValue { $0.append(audio) }
+                switch audio {
+                case [0, 1, 2, 3]:
+                    return "speaker a one"
+                case [4, 5, 6, 7, 8]:
+                    return "speaker b"
+                case [9, 10, 11, 12, 13, 14, 15]:
+                    return "speaker a two"
+                default:
+                    return nil
+                }
+            }
+        )
+
+        session.appendAudioChunk(Array(0..<16).map(Float.init))
+
+        let transcript = await session.speakerTaggedTranscript(
+            spans: [
+                .init(speakerID: "Speaker A", startTime: 0.0, endTime: 0.2),
+                .init(speakerID: "Speaker A", startTime: 0.2, endTime: 0.4),
+                .init(speakerID: "Speaker B", startTime: 0.4, endTime: 0.9),
+                .init(speakerID: "Speaker A", startTime: 0.9, endTime: 1.3),
+                .init(speakerID: "Speaker A", startTime: 1.32, endTime: 1.6),
+            ]
+        )
+
+        XCTAssertEqual(
+            transcript,
+            SpeakerTaggedTranscript(
+                segments: [
+                    .init(
+                        speakerID: "Speaker A",
+                        startTime: 0.0,
+                        endTime: 0.4,
+                        text: "speaker a one"
+                    ),
+                    .init(
+                        speakerID: "Speaker B",
+                        startTime: 0.4,
+                        endTime: 0.9,
+                        text: "speaker b"
+                    ),
+                    .init(
+                        speakerID: "Speaker A",
+                        startTime: 0.9,
+                        endTime: 1.6,
+                        text: "speaker a two"
+                    ),
+                ]
+            )
+        )
+        let recordedAudio = await capturedAudio.get()
+        XCTAssertEqual(
+            recordedAudio,
+            [
+                [0, 1, 2, 3],
+                [4, 5, 6, 7, 8],
+                [9, 10, 11, 12, 13, 14, 15],
+            ]
+        )
+    }
 }
 
 private actor LockedValue<Value> {

--- a/GhostPepperTests/FluidAudioSpeechSessionTests.swift
+++ b/GhostPepperTests/FluidAudioSpeechSessionTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import GhostPepper
 
 final class FluidAudioSpeechSessionTests: XCTestCase {
-    func testFinalizeSelectsEarliestSubstantialSpeakerKeepsTargetSpansAndMergesNearbyGaps() async {
+    func testFinalizeSelectsDominantSpeakerKeepsTargetSpansAndMergesNearbyGaps() async {
         let capturedAudio = LockedValue<[Float]>([])
         let session = FluidAudioSpeechSession(
             sampleRate: 10,
@@ -42,6 +42,67 @@ final class FluidAudioSpeechSessionTests: XCTestCase {
         ])
         let captured = await capturedAudio.get()
         XCTAssertEqual(captured, [0, 1, 8, 9, 10, 13, 14, 15, 16, 17])
+    }
+
+    func testFinalizeSelectsDominantSpeakerWhenAnEarlierSpeakerCrossesThreshold() async {
+        let capturedAudio = LockedValue<[Float]>([])
+        let session = FluidAudioSpeechSession(
+            sampleRate: 10,
+            transcribeFilteredAudio: { audio in
+                await capturedAudio.set(audio)
+                return "dominant speaker transcript"
+            }
+        )
+
+        session.appendAudioChunk(Array(0..<50).map(Float.init))
+
+        let result = await session.finalize(
+            spans: [
+                .init(speakerID: "speaker-a", startTime: 0.4, endTime: 0.9),
+                .init(speakerID: "speaker-a", startTime: 1.2, endTime: 1.7),
+                .init(speakerID: "speaker-b", startTime: 2.0, endTime: 4.4),
+            ]
+        )
+
+        XCTAssertEqual(result.filteredTranscript, "dominant speaker transcript")
+        XCTAssertEqual(result.summary.targetSpeakerID, "speaker-b")
+        XCTAssertEqual(result.summary.targetSpeakerDuration, 2.4, accuracy: 0.0001)
+        XCTAssertEqual(result.summary.keptAudioDuration, 2.4, accuracy: 0.0001)
+        XCTAssertFalse(result.summary.usedFallback)
+        XCTAssertEqual(result.summary.spans.map(\.isKept), [false, false, true])
+        XCTAssertEqual(result.summary.mergedKeptSpans, [
+            .init(startTime: 2.0, endTime: 4.4),
+        ])
+        let captured = await capturedAudio.get()
+        XCTAssertEqual(captured, Array(20..<44).map(Float.init))
+    }
+
+    func testFinalizeFallsBackWhenSpeakerDurationsAreTooCloseToCall() async {
+        let transcriptionCallCount = LockedValue(0)
+        let session = FluidAudioSpeechSession(
+            sampleRate: 10,
+            transcribeFilteredAudio: { _ in
+                await transcriptionCallCount.withValue { $0 += 1 }
+                return "unexpected"
+            }
+        )
+
+        session.appendAudioChunk(Array(0..<40).map(Float.init))
+
+        let result = await session.finalize(
+            spans: [
+                .init(speakerID: "speaker-a", startTime: 0.0, endTime: 1.8),
+                .init(speakerID: "speaker-b", startTime: 1.8, endTime: 3.4),
+            ]
+        )
+
+        XCTAssertNil(result.filteredTranscript)
+        XCTAssertTrue(result.summary.usedFallback)
+        XCTAssertEqual(result.summary.fallbackReason, .ambiguousDominantSpeaker)
+        XCTAssertNil(result.summary.targetSpeakerID)
+        XCTAssertTrue(result.summary.mergedKeptSpans.isEmpty)
+        let transcriptionCallCountValue = await transcriptionCallCount.get()
+        XCTAssertEqual(transcriptionCallCountValue, 0)
     }
 
     func testFinalizeFallsBackWhenNoSpeakerReachesThreshold() async {

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -791,6 +791,65 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(recordedCleanupInputs, ["batch transcript"])
     }
 
+    func testAppStateDoesNotRunExternalBatchFallbackWhenSlidingWindowSessionOwnsFinalBatchTranscription() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let streamedChunks = LockedValue<[[Float]]>([])
+        let streamingEvents = LockedValue<[String]>([])
+        var batchTranscriptionCallCount = 0
+
+        appState.speechModel = SpeechModelCatalog.parakeetV3.id
+        appState.recordingTranscriptionSessionFactory = { descriptor in
+            XCTAssertEqual(descriptor, SpeechModelCatalog.parakeetV3)
+            return SlidingWindowRecordingTranscriptionSession(
+                fullBufferTranscription: { _ in nil },
+                handleFactory: {
+                    StreamingRecordingHandle(
+                        appendAudioChunk: { samples in
+                            await streamedChunks.append(samples)
+                        },
+                        finishTranscription: {
+                            await streamingEvents.append("finish")
+                            return "streamed transcript"
+                        },
+                        cancel: {
+                            await streamingEvents.append("cancel")
+                        },
+                        cleanup: {
+                            await streamingEvents.append("cleanup")
+                        }
+                    )
+                }
+            )
+        }
+        appState.transcribeAudioBufferOverride = { _ in
+            batchTranscriptionCallCount += 1
+            return "batch transcript"
+        }
+
+        await appState.prepareRecordingSessionIfNeeded()
+        appState.audioRecorder.onConvertedAudioChunk?([1, 2, 3])
+        appState.audioRecorder.onConvertedAudioChunk?([4, 5, 6])
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: appState.activeRecordingTranscriptionSession,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertEqual(batchTranscriptionCallCount, 0)
+        let recordedChunks = await streamedChunks.get()
+        XCTAssertEqual(recordedChunks, [[1, 2, 3], [4, 5, 6]])
+        let recordedEvents = await streamingEvents.get()
+        XCTAssertEqual(recordedEvents, ["finish", "cleanup"])
+    }
+
     func testFinishRecordingForTestingSkipsWindowContextProviderWhenTranscriptIsMissing() async throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -52,6 +52,7 @@ private final class FakeRecordingTranscriptionSession: RecordingTranscriptionSes
     private(set) var finishCallCount = 0
     private(set) var cancelCallCount = 0
     var finalTranscript: String?
+    let supportsConcurrentFinalization = false
 
     init(finalTranscript: String?) {
         self.finalTranscript = finalTranscript
@@ -1464,6 +1465,49 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertTrue(entries[0].speakerFilteringEnabled)
         XCTAssertTrue(entries[0].speakerFilteringRan)
         XCTAssertFalse(entries[0].speakerFilteringUsedFallback)
+    }
+
+    func testQwenRecordingUsesSpeakerFilteringSession() async throws {
+        guard #available(macOS 15, iOS 18, *) else {
+            throw XCTSkip("Qwen3-ASR requires macOS 15 or later.")
+        }
+
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let transcriptionSession = FakeRecordingTranscriptionSession(finalTranscript: "streamed transcript")
+        var diarizationChunks: [[Float]] = []
+        var factoryCallCount = 0
+
+        appState.speechModel = SpeechModelCatalog.qwen3AsrInt8.id
+        appState.ignoreOtherSpeakers = true
+        appState.recordingTranscriptionSessionFactory = { descriptor in
+            XCTAssertEqual(descriptor, SpeechModelCatalog.qwen3AsrInt8)
+            return transcriptionSession
+        }
+        appState.recordingSessionCoordinatorFactory = {
+            factoryCallCount += 1
+            return RecordingSessionCoordinator(
+                appendAudioChunk: { samples in
+                    diarizationChunks.append(samples)
+                },
+                finish: {
+                    (nil, Self.makeDiarizationSummary(usedFallback: true))
+                }
+            )
+        }
+
+        await appState.prepareRecordingSessionIfNeeded()
+        appState.audioRecorder.onConvertedAudioChunk?([1, 2, 3, 4])
+
+        XCTAssertEqual(factoryCallCount, 1)
+        XCTAssertNotNil(appState.activeRecordingSessionCoordinator)
+        XCTAssertEqual(diarizationChunks, [[1, 2, 3, 4]])
+        XCTAssertEqual(transcriptionSession.appendedChunks, [[1, 2, 3, 4]])
     }
 
     func testAppStateArchivesDiarizationFallbackState() async throws {

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -1633,6 +1633,44 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertNil(appState.audioRecorder.onConvertedAudioChunk)
     }
 
+    func testFluidAudioRecordingWithoutNativeStreamingUsesFinalBatchTranscription() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let cleanupInputs = LockedValue<[String]>([])
+        var batchInputs: [[Float]] = []
+
+        appState.speechModel = SpeechModelCatalog.parakeetV3.id
+        appState.transcribeAudioBufferOverride = { samples in
+            batchInputs.append(samples)
+            return "batch transcript"
+        }
+        appState.cleanedTranscriptionResultOverride = { text, _ in
+            await cleanupInputs.append(text)
+            return (text: text, prompt: "", attemptedCleanup: false, cleanupUsedFallback: false)
+        }
+
+        await appState.prepareRecordingSessionIfNeeded()
+
+        XCTAssertNil(appState.activeRecordingTranscriptionSession)
+        XCTAssertNil(appState.audioRecorder.onConvertedAudioChunk)
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: appState.activeRecordingTranscriptionSession,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertEqual(batchInputs, [[1, 2, 3, 4]])
+        let recordedCleanupInputs = await cleanupInputs.get()
+        XCTAssertEqual(recordedCleanupInputs, ["batch transcript"])
+    }
+
     func testFluidAudioRecordingUsesSpeakerFilteringSession() async throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)
@@ -1685,6 +1723,7 @@ final class GhostPepperTests: XCTestCase {
         }
 
         await appState.prepareRecordingSessionIfNeeded()
+        XCTAssertNil(appState.activeRecordingTranscriptionSession)
         appState.audioRecorder.onConvertedAudioChunk?([0.1, 0.2, 0.3])
         await appState.finishRecordingForTesting(
             audioBuffer: [0.1, 0.2, 0.3],

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -1633,44 +1633,6 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertNil(appState.audioRecorder.onConvertedAudioChunk)
     }
 
-    func testFluidAudioRecordingWithoutNativeStreamingUsesFinalBatchTranscription() async throws {
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
-        defaults.removePersistentDomain(forName: #function)
-        let appState = AppState(
-            hotkeyMonitor: FakeHotkeyMonitor(),
-            chordBindingStore: ChordBindingStore(defaults: defaults),
-            cleanupSettingsDefaults: defaults
-        )
-        let cleanupInputs = LockedValue<[String]>([])
-        var batchInputs: [[Float]] = []
-
-        appState.speechModel = SpeechModelCatalog.parakeetV3.id
-        appState.transcribeAudioBufferOverride = { samples in
-            batchInputs.append(samples)
-            return "batch transcript"
-        }
-        appState.cleanedTranscriptionResultOverride = { text, _ in
-            await cleanupInputs.append(text)
-            return (text: text, prompt: "", attemptedCleanup: false, cleanupUsedFallback: false)
-        }
-
-        await appState.prepareRecordingSessionIfNeeded()
-
-        XCTAssertNil(appState.activeRecordingTranscriptionSession)
-        XCTAssertNil(appState.audioRecorder.onConvertedAudioChunk)
-
-        await appState.finishRecordingForTesting(
-            audioBuffer: [1, 2, 3, 4],
-            recordingSessionCoordinator: nil,
-            recordingTranscriptionSession: appState.activeRecordingTranscriptionSession,
-            archivedWindowContext: nil
-        )
-
-        XCTAssertEqual(batchInputs, [[1, 2, 3, 4]])
-        let recordedCleanupInputs = await cleanupInputs.get()
-        XCTAssertEqual(recordedCleanupInputs, ["batch transcript"])
-    }
-
     func testFluidAudioRecordingUsesSpeakerFilteringSession() async throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)
@@ -1723,7 +1685,6 @@ final class GhostPepperTests: XCTestCase {
         }
 
         await appState.prepareRecordingSessionIfNeeded()
-        XCTAssertNil(appState.activeRecordingTranscriptionSession)
         appState.audioRecorder.onConvertedAudioChunk?([0.1, 0.2, 0.3])
         await appState.finishRecordingForTesting(
             audioBuffer: [0.1, 0.2, 0.3],

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -728,6 +728,69 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(recordedCleanupInputs, ["batch transcript"])
     }
 
+    func testAppStateFallsBackToBatchTranscriptionWhenSlidingWindowStreamReturnsNothing() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let streamedChunks = LockedValue<[[Float]]>([])
+        let streamingEvents = LockedValue<[String]>([])
+        let cleanedInputs = LockedValue<[String]>([])
+        var batchTranscriptionCallCount = 0
+
+        appState.speechModel = SpeechModelCatalog.parakeetV3.id
+        appState.recordingTranscriptionSessionFactory = { descriptor in
+            XCTAssertEqual(descriptor, SpeechModelCatalog.parakeetV3)
+            return SlidingWindowRecordingTranscriptionSession {
+                StreamingRecordingHandle(
+                    appendAudioChunk: { samples in
+                        await streamedChunks.append(samples)
+                    },
+                    finishTranscription: {
+                        await streamingEvents.append("finish")
+                        return ""
+                    },
+                    cancel: {
+                        await streamingEvents.append("cancel")
+                    },
+                    cleanup: {
+                        await streamingEvents.append("cleanup")
+                    }
+                )
+            }
+        }
+        appState.transcribeAudioBufferOverride = { _ in
+            batchTranscriptionCallCount += 1
+            return "batch transcript"
+        }
+        appState.cleanedTranscriptionResultOverride = { text, _ in
+            await cleanedInputs.append(text)
+            return (text: text, prompt: "", attemptedCleanup: false, cleanupUsedFallback: false)
+        }
+
+        await appState.prepareRecordingSessionIfNeeded()
+        appState.audioRecorder.onConvertedAudioChunk?([1, 2, 3])
+        appState.audioRecorder.onConvertedAudioChunk?([4, 5, 6])
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: appState.activeRecordingTranscriptionSession,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertEqual(batchTranscriptionCallCount, 1)
+        let recordedChunks = await streamedChunks.get()
+        XCTAssertEqual(recordedChunks, [[1, 2, 3], [4, 5, 6]])
+        let recordedEvents = await streamingEvents.get()
+        XCTAssertEqual(recordedEvents, ["finish", "cleanup"])
+        let recordedCleanupInputs = await cleanedInputs.get()
+        XCTAssertEqual(recordedCleanupInputs, ["batch transcript"])
+    }
+
     func testFinishRecordingForTestingSkipsWindowContextProviderWhenTranscriptIsMissing() async throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -52,10 +52,12 @@ private final class FakeRecordingTranscriptionSession: RecordingTranscriptionSes
     private(set) var finishCallCount = 0
     private(set) var cancelCallCount = 0
     var finalTranscript: String?
+    let allowsBatchFallback: Bool
     let supportsConcurrentFinalization = false
 
-    init(finalTranscript: String?) {
+    init(finalTranscript: String?, allowsBatchFallback: Bool = false) {
         self.finalTranscript = finalTranscript
+        self.allowsBatchFallback = allowsBatchFallback
     }
 
     func appendAudioChunk(_ samples: [Float]) {
@@ -642,6 +644,120 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(batchTranscriptionCallCount, 0)
         let recordedCleanupInputs = await cleanedInputs.get()
         XCTAssertEqual(recordedCleanupInputs, ["streamed transcript"])
+    }
+
+    func testAppStateSkipsBatchFallbackWhenRecordingSessionDisallowsIt() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let transcriptionSession = FakeRecordingTranscriptionSession(finalTranscript: nil)
+        var batchTranscriptionCallCount = 0
+
+        appState.speechModel = SpeechModelCatalog.parakeetV3.id
+        appState.recordingTranscriptionSessionFactory = { descriptor in
+            XCTAssertEqual(descriptor, SpeechModelCatalog.parakeetV3)
+            return transcriptionSession
+        }
+        appState.transcribeAudioBufferOverride = { _ in
+            batchTranscriptionCallCount += 1
+            return "batch transcript"
+        }
+
+        await appState.prepareRecordingSessionIfNeeded()
+        appState.audioRecorder.onConvertedAudioChunk?([1, 2, 3])
+        appState.audioRecorder.onConvertedAudioChunk?([4, 5, 6])
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: appState.activeRecordingTranscriptionSession,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertEqual(transcriptionSession.finishCallCount, 1)
+        XCTAssertEqual(batchTranscriptionCallCount, 0)
+    }
+
+    func testAppStateFallsBackToBatchTranscriptionWhenRecordingSessionAllowsIt() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let transcriptionSession = FakeRecordingTranscriptionSession(
+            finalTranscript: nil,
+            allowsBatchFallback: true
+        )
+        let cleanedInputs = LockedValue<[String]>([])
+        var batchTranscriptionCallCount = 0
+
+        appState.speechModel = SpeechModelCatalog.parakeetV3.id
+        appState.recordingTranscriptionSessionFactory = { descriptor in
+            XCTAssertEqual(descriptor, SpeechModelCatalog.parakeetV3)
+            return transcriptionSession
+        }
+        appState.transcribeAudioBufferOverride = { _ in
+            batchTranscriptionCallCount += 1
+            return "batch transcript"
+        }
+        appState.cleanedTranscriptionResultOverride = { text, _ in
+            await cleanedInputs.append(text)
+            return (text: text, prompt: "", attemptedCleanup: false, cleanupUsedFallback: false)
+        }
+
+        await appState.prepareRecordingSessionIfNeeded()
+        appState.audioRecorder.onConvertedAudioChunk?([1, 2, 3])
+        appState.audioRecorder.onConvertedAudioChunk?([4, 5, 6])
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: appState.activeRecordingTranscriptionSession,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertEqual(transcriptionSession.finishCallCount, 1)
+        XCTAssertEqual(batchTranscriptionCallCount, 1)
+        let recordedCleanupInputs = await cleanedInputs.get()
+        XCTAssertEqual(recordedCleanupInputs, ["batch transcript"])
+    }
+
+    func testFinishRecordingForTestingSkipsWindowContextProviderWhenTranscriptIsMissing() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        let providerCallCount = LockedValue(0)
+
+        appState.transcribeAudioBufferOverride = { _ in
+            nil
+        }
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: nil,
+            archivedWindowContext: nil,
+            windowContextProvider: {
+                await providerCallCount.set(1)
+                return RecordingOCRPrefetchResult(
+                    context: OCRContext(windowContents: "captured"),
+                    elapsed: 0.25
+                )
+            }
+        )
+
+        let callCount = await providerCallCount.get()
+        XCTAssertEqual(callCount, 0)
     }
 
     func testAppStatePrefersFilteredSpeakerTranscriptOverStreamedTranscript() async throws {
@@ -1669,6 +1785,10 @@ private actor LockedValue<Value> {
 
     func get() -> Value {
         value
+    }
+
+    func set(_ value: Value) {
+        self.value = value
     }
 
     func append<Element>(_ newElement: Element) where Value == [Element] {

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -149,14 +149,14 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(AppStatus.error.rawValue, "Error")
     }
 
-    func testEmptyTranscriptionDispositionCancelsShortRecordings() {
+    func testEmptyTranscriptionDispositionCancelsSubThresholdRecordings() {
         XCTAssertEqual(
             AppState.emptyTranscriptionDisposition(forAudioSampleCount: 7_999),
             .cancel
         )
     }
 
-    func testEmptyTranscriptionDispositionShowsNoSoundForFiveSecondsOrLonger() {
+    func testEmptyTranscriptionDispositionShowsNoSoundDetectedAtThresholdAndAbove() {
         XCTAssertEqual(
             AppState.emptyTranscriptionDisposition(forAudioSampleCount: 8_000),
             .showNoSoundDetected

--- a/GhostPepperTests/ModelManagerTests.swift
+++ b/GhostPepperTests/ModelManagerTests.swift
@@ -58,4 +58,59 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .idle)
         XCTAssertNil(manager.error)
     }
+
+    func testRescueSingleSpeakerSpansUsesSpeechSegmentsWhenOnlyOneSpeakerIsDetected() {
+        let originalSpans = [
+            DiarizationSummary.Span(speakerID: "Speaker 0", startTime: 2.48, endTime: 4.24)
+        ]
+        let speechSegments = [
+            DiarizationSummary.MergedSpan(startTime: 2.204, endTime: 4.5878125)
+        ]
+
+        let rescuedSpans = ModelManager.rescuedSingleSpeakerSpans(
+            from: originalSpans,
+            usingSpeechSegments: speechSegments
+        )
+
+        XCTAssertEqual(
+            rescuedSpans,
+            [
+                DiarizationSummary.Span(
+                    speakerID: "Speaker 0",
+                    startTime: 2.204,
+                    endTime: 4.5878125
+                )
+            ]
+        )
+    }
+
+    func testRescueSingleSpeakerSpansKeepsOriginalSpansWhenMultipleSpeakersAreDetected() {
+        let originalSpans = [
+            DiarizationSummary.Span(speakerID: "Speaker 0", startTime: 0.4, endTime: 1.0),
+            DiarizationSummary.Span(speakerID: "Speaker 1", startTime: 1.2, endTime: 1.8)
+        ]
+        let speechSegments = [
+            DiarizationSummary.MergedSpan(startTime: 0.3, endTime: 1.9)
+        ]
+
+        let rescuedSpans = ModelManager.rescuedSingleSpeakerSpans(
+            from: originalSpans,
+            usingSpeechSegments: speechSegments
+        )
+
+        XCTAssertEqual(rescuedSpans, originalSpans)
+    }
+
+    func testRescueSingleSpeakerSpansKeepsOriginalSpansWhenNoSpeechSegmentsExist() {
+        let originalSpans = [
+            DiarizationSummary.Span(speakerID: "Speaker 0", startTime: 2.48, endTime: 4.24)
+        ]
+
+        let rescuedSpans = ModelManager.rescuedSingleSpeakerSpans(
+            from: originalSpans,
+            usingSpeechSegments: []
+        )
+
+        XCTAssertEqual(rescuedSpans, originalSpans)
+    }
 }

--- a/GhostPepperTests/RecognizedVoiceStoreTests.swift
+++ b/GhostPepperTests/RecognizedVoiceStoreTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+@testable import GhostPepper
+
+final class RecognizedVoiceStoreTests: XCTestCase {
+    func testLoadProfilesReturnsEmptyWhenIndexDoesNotExist() throws {
+        let fixture = makeFixture()
+        let store = RecognizedVoiceStore(directoryURL: fixture.directoryURL)
+
+        XCTAssertEqual(try store.loadProfiles(), [])
+    }
+
+    func testUpsertPersistsProfilesNewestFirst() throws {
+        let fixture = makeFixture()
+        let store = RecognizedVoiceStore(directoryURL: fixture.directoryURL)
+        let olderProfile = makeProfile(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            displayName: "Voice A",
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+        let newerProfile = makeProfile(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            displayName: "Voice B",
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        try store.upsert(olderProfile)
+        try store.upsert(newerProfile)
+
+        XCTAssertEqual(
+            try store.loadProfiles().map(\.id),
+            [newerProfile.id, olderProfile.id]
+        )
+    }
+
+    func testUpsertReplacesExistingProfileWithSameID() throws {
+        let fixture = makeFixture()
+        let store = RecognizedVoiceStore(directoryURL: fixture.directoryURL)
+        let profileID = UUID(uuidString: "00000000-0000-0000-0000-000000000003")!
+
+        try store.upsert(
+            makeProfile(
+                id: profileID,
+                displayName: "Old Name",
+                updatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+        try store.upsert(
+            makeProfile(
+                id: profileID,
+                displayName: "New Name",
+                isMe: true,
+                updatedAt: Date(timeIntervalSince1970: 300)
+            )
+        )
+
+        XCTAssertEqual(
+            try store.loadProfiles(),
+            [
+                makeProfile(
+                    id: profileID,
+                    displayName: "New Name",
+                    isMe: true,
+                    updatedAt: Date(timeIntervalSince1970: 300)
+                )
+            ]
+        )
+    }
+
+    private func makeFixture() -> Fixture {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        return Fixture(directoryURL: directoryURL)
+    }
+
+    private struct Fixture {
+        let directoryURL: URL
+    }
+
+    private func makeProfile(
+        id: UUID = UUID(),
+        displayName: String,
+        isMe: Bool = false,
+        updatedAt: Date
+    ) -> RecognizedVoiceProfile {
+        RecognizedVoiceProfile(
+            id: id,
+            displayName: displayName,
+            isMe: isMe,
+            embedding: Array(repeating: 0.25, count: 256),
+            updateCount: 1,
+            createdAt: Date(timeIntervalSince1970: 50),
+            updatedAt: updatedAt,
+            evidenceTranscript: "This is sample evidence."
+        )
+    }
+}

--- a/GhostPepperTests/RecordingSessionCoordinatorTests.swift
+++ b/GhostPepperTests/RecordingSessionCoordinatorTests.swift
@@ -209,6 +209,44 @@ final class RecordingSessionCoordinatorTests: XCTestCase {
         XCTAssertEqual(recordedEvents, ["finish", "cleanup"])
     }
 
+    func testSlidingWindowRecordingTranscriptionSessionPrefersFullBufferFinalTranscription() async {
+        let fullBuffer = LockedValue<[Float]?>(nil)
+        let events = LockedValue<[String]>([])
+        let session = SlidingWindowRecordingTranscriptionSession(
+            fullBufferTranscription: { samples in
+                await fullBuffer.set(samples)
+                await events.append("batch")
+                return "batch transcript"
+            },
+            handleFactory: {
+                StreamingRecordingHandle(
+                    appendAudioChunk: { _ in },
+                    finishTranscription: {
+                        await events.append("finish")
+                        return "streamed transcript"
+                    },
+                    cancel: {
+                        await events.append("cancel")
+                    },
+                    cleanup: {
+                        await events.append("cleanup")
+                    }
+                )
+            }
+        )
+
+        session.appendAudioChunk([1, 2])
+        session.appendAudioChunk([3, 4])
+
+        let transcript = await session.finishTranscription()
+
+        XCTAssertEqual(transcript, "batch transcript")
+        let recordedBuffer = await fullBuffer.get()
+        XCTAssertEqual(recordedBuffer, [1, 2, 3, 4])
+        let recordedEvents = await events.get()
+        XCTAssertEqual(recordedEvents, ["finish", "batch", "cleanup"])
+    }
+
     func testSlidingWindowRecordingTranscriptionSessionCancelPreventsFinalTranscript() async {
         let events = LockedValue<[String]>([])
         let session = SlidingWindowRecordingTranscriptionSession {

--- a/GhostPepperTests/RecordingSessionCoordinatorTests.swift
+++ b/GhostPepperTests/RecordingSessionCoordinatorTests.swift
@@ -247,6 +247,40 @@ final class RecordingSessionCoordinatorTests: XCTestCase {
         XCTAssertEqual(recordedEvents, ["finish", "batch", "cleanup"])
     }
 
+    func testSlidingWindowRecordingTranscriptionSessionDoesNotFallBackToStreamedTranscriptWhenFullBufferTranscriptionFails() async {
+        let events = LockedValue<[String]>([])
+        let session = SlidingWindowRecordingTranscriptionSession(
+            fullBufferTranscription: { _ in
+                await events.append("batch")
+                return nil
+            },
+            handleFactory: {
+                StreamingRecordingHandle(
+                    appendAudioChunk: { _ in },
+                    finishTranscription: {
+                        await events.append("finish")
+                        return "streamed transcript"
+                    },
+                    cancel: {
+                        await events.append("cancel")
+                    },
+                    cleanup: {
+                        await events.append("cleanup")
+                    }
+                )
+            }
+        )
+
+        session.appendAudioChunk([1, 2])
+        session.appendAudioChunk([3, 4])
+
+        let transcript = await session.finishTranscription()
+
+        XCTAssertNil(transcript)
+        let recordedEvents = await events.get()
+        XCTAssertEqual(recordedEvents, ["finish", "batch", "cleanup"])
+    }
+
     func testSlidingWindowRecordingTranscriptionSessionCancelPreventsFinalTranscript() async {
         let events = LockedValue<[String]>([])
         let session = SlidingWindowRecordingTranscriptionSession {

--- a/GhostPepperTests/RecordingSessionCoordinatorTests.swift
+++ b/GhostPepperTests/RecordingSessionCoordinatorTests.swift
@@ -131,6 +131,65 @@ final class RecordingSessionCoordinatorTests: XCTestCase {
 
         XCTAssertNil(transcript)
     }
+
+    func testSlidingWindowRecordingTranscriptionSessionFlushesQueuedChunksBeforeFinishing() async {
+        let appendedChunks = LockedValue<[[Float]]>([])
+        let events = LockedValue<[String]>([])
+        let session = SlidingWindowRecordingTranscriptionSession {
+            StreamingRecordingHandle(
+                appendAudioChunk: { samples in
+                    await appendedChunks.append(samples)
+                },
+                finishTranscription: {
+                    await events.append("finish")
+                    return "stable transcript"
+                },
+                cancel: {
+                    await events.append("cancel")
+                },
+                cleanup: {
+                    await events.append("cleanup")
+                }
+            )
+        }
+
+        session.appendAudioChunk([1, 2])
+        session.appendAudioChunk([3, 4])
+
+        let transcript = await session.finishTranscription()
+
+        XCTAssertEqual(transcript, "stable transcript")
+        let chunks = await appendedChunks.get()
+        let recordedEvents = await events.get()
+        XCTAssertEqual(chunks, [[1, 2], [3, 4]])
+        XCTAssertEqual(recordedEvents, ["finish", "cleanup"])
+    }
+
+    func testSlidingWindowRecordingTranscriptionSessionCancelPreventsFinalTranscript() async {
+        let events = LockedValue<[String]>([])
+        let session = SlidingWindowRecordingTranscriptionSession {
+            StreamingRecordingHandle(
+                appendAudioChunk: { _ in },
+                finishTranscription: {
+                    await events.append("finish")
+                    return "should not be returned"
+                },
+                cancel: {
+                    await events.append("cancel")
+                },
+                cleanup: {
+                    await events.append("cleanup")
+                }
+            )
+        }
+
+        session.appendAudioChunk([1, 2, 3, 4])
+        session.cancel()
+
+        let transcript = await session.finishTranscription()
+
+        XCTAssertNil(transcript)
+    }
 }
 
 private actor LockedValue<Value> {

--- a/GhostPepperTests/RecordingSessionCoordinatorTests.swift
+++ b/GhostPepperTests/RecordingSessionCoordinatorTests.swift
@@ -81,6 +81,50 @@ final class RecordingSessionCoordinatorTests: XCTestCase {
         ])
     }
 
+    func testSessionBackedCoordinatorWaitsForQueuedChunkProcessingBeforeFinishing() async {
+        let capturedAudio = LockedValue<[Float]>([])
+        let processedChunksQueue = DispatchQueue(label: "RecordingSessionCoordinatorTests.processedChunks")
+        var processedChunks: [[Float]] = []
+        let session = FluidAudioSpeechSession(
+            sampleRate: 10,
+            transcribeFilteredAudio: { audio in
+                await capturedAudio.set(audio)
+                return "coordinator transcript"
+            }
+        )
+        let coordinator = RecordingSessionCoordinator(
+            session: session,
+            processAudioChunk: { samples in
+                Thread.sleep(forTimeInterval: 0.05)
+                processedChunksQueue.sync {
+                    processedChunks.append(samples)
+                }
+            },
+            finish: {
+                [
+                    .init(speakerID: "speaker-a", startTime: 0.0, endTime: 0.4),
+                    .init(speakerID: "speaker-b", startTime: 0.4, endTime: 0.7),
+                    .init(speakerID: "speaker-a", startTime: 0.74, endTime: 1.3),
+                ]
+            }
+        )
+
+        coordinator.appendAudioChunk([0, 1, 2, 3, 4])
+        coordinator.appendAudioChunk([5, 6, 7, 8, 9])
+        coordinator.appendAudioChunk([10, 11, 12, 13, 14])
+        coordinator.appendAudioChunk([15, 16, 17, 18, 19])
+
+        _ = await coordinator.finish()
+
+        let processed = processedChunksQueue.sync { processedChunks }
+        XCTAssertEqual(processed, [
+            [0, 1, 2, 3, 4],
+            [5, 6, 7, 8, 9],
+            [10, 11, 12, 13, 14],
+            [15, 16, 17, 18, 19],
+        ])
+    }
+
     func testChunkedRecordingTranscriptionSessionTranscribesDuringRecordingAndDeduplicatesOverlap() async {
         let transcribedChunks = LockedValue<[String]>([])
         let session = ChunkedRecordingTranscriptionSession(

--- a/GhostPepperTests/SpeakerIdentityResolverTests.swift
+++ b/GhostPepperTests/SpeakerIdentityResolverTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import GhostPepper
+
+final class SpeakerIdentityResolverTests: XCTestCase {
+    func testResolveCreatesRecognizedVoiceForUnmatchedSpeaker() {
+        let entryID = UUID()
+        let now = Date(timeIntervalSince1970: 100)
+        let resolver = SpeakerIdentityResolver(
+            matchDistanceThreshold: 0.2,
+            minimumEmbeddingDuration: 1.0
+        )
+
+        let resolution = resolver.resolve(
+            entryID: entryID,
+            speakers: [
+                SpeakerIdentityInput(
+                    speakerID: "Speaker 0",
+                    audioDuration: 2.4,
+                    evidenceTranscript: "This is the transcript for speaker zero.",
+                    embedding: [1, 0, 0]
+                )
+            ],
+            existingLocalProfiles: [],
+            recognizedVoices: [],
+            now: now
+        )
+
+        XCTAssertEqual(resolution.recognizedVoices.count, 1)
+        XCTAssertEqual(resolution.localProfiles.count, 1)
+
+        let recognizedVoice = try? XCTUnwrap(resolution.recognizedVoices.first)
+        XCTAssertEqual(recognizedVoice?.displayName, "Recognized Voice 1")
+        XCTAssertEqual(recognizedVoice?.isMe, false)
+        XCTAssertEqual(recognizedVoice?.embedding, [1, 0, 0])
+        XCTAssertEqual(recognizedVoice?.updateCount, 1)
+        XCTAssertEqual(
+            recognizedVoice?.evidenceTranscript,
+            "This is the transcript for speaker zero."
+        )
+        XCTAssertEqual(recognizedVoice?.createdAt, now)
+        XCTAssertEqual(recognizedVoice?.updatedAt, now)
+
+        let localProfile = try? XCTUnwrap(resolution.localProfiles.first)
+        XCTAssertEqual(localProfile?.entryID, entryID)
+        XCTAssertEqual(localProfile?.speakerID, "Speaker 0")
+        XCTAssertEqual(localProfile?.displayName, "Recognized Voice 1")
+        XCTAssertEqual(localProfile?.recognizedVoiceID, recognizedVoice?.id)
+        XCTAssertEqual(localProfile?.evidenceTranscript, "This is the transcript for speaker zero.")
+    }
+
+    func testResolveMatchesExistingRecognizedVoiceAndPreservesExistingLocalOverride() {
+        let entryID = UUID()
+        let existingVoiceID = UUID()
+        let oldTime = Date(timeIntervalSince1970: 10)
+        let now = Date(timeIntervalSince1970: 20)
+        let resolver = SpeakerIdentityResolver(
+            matchDistanceThreshold: 0.2,
+            minimumEmbeddingDuration: 1.0
+        )
+
+        let resolution = resolver.resolve(
+            entryID: entryID,
+            speakers: [
+                SpeakerIdentityInput(
+                    speakerID: "Speaker 1",
+                    audioDuration: 3.1,
+                    evidenceTranscript: "Updated evidence from this session.",
+                    embedding: [1, 0, 0]
+                )
+            ],
+            existingLocalProfiles: [
+                TranscriptionLabSpeakerProfile(
+                    entryID: entryID,
+                    speakerID: "Speaker 1",
+                    displayName: "Jesse (room mic)",
+                    isMe: true,
+                    recognizedVoiceID: existingVoiceID,
+                    evidenceTranscript: "Old evidence"
+                )
+            ],
+            recognizedVoices: [
+                RecognizedVoiceProfile(
+                    id: existingVoiceID,
+                    displayName: "Jesse",
+                    isMe: true,
+                    embedding: [1, 0, 0],
+                    updateCount: 2,
+                    createdAt: oldTime,
+                    updatedAt: oldTime,
+                    evidenceTranscript: "Original evidence"
+                )
+            ],
+            now: now
+        )
+
+        XCTAssertEqual(resolution.recognizedVoices.count, 1)
+        XCTAssertEqual(resolution.localProfiles.count, 1)
+
+        let recognizedVoice = try? XCTUnwrap(resolution.recognizedVoices.first)
+        XCTAssertEqual(recognizedVoice?.id, existingVoiceID)
+        XCTAssertEqual(recognizedVoice?.displayName, "Jesse")
+        XCTAssertEqual(recognizedVoice?.isMe, true)
+        XCTAssertEqual(recognizedVoice?.updateCount, 3)
+        XCTAssertEqual(recognizedVoice?.createdAt, oldTime)
+        XCTAssertEqual(recognizedVoice?.updatedAt, now)
+        XCTAssertEqual(recognizedVoice?.evidenceTranscript, "Updated evidence from this session.")
+        XCTAssertEqual(recognizedVoice?.embedding, [1, 0, 0])
+
+        let localProfile = try? XCTUnwrap(resolution.localProfiles.first)
+        XCTAssertEqual(localProfile?.displayName, "Jesse (room mic)")
+        XCTAssertEqual(localProfile?.isMe, true)
+        XCTAssertEqual(localProfile?.recognizedVoiceID, existingVoiceID)
+        XCTAssertEqual(localProfile?.evidenceTranscript, "Updated evidence from this session.")
+    }
+
+    func testResolveLeavesShortSpeakerUnlinkedWhenNoReliableVoicePrintCanBeBuilt() {
+        let entryID = UUID()
+        let resolver = SpeakerIdentityResolver(
+            matchDistanceThreshold: 0.2,
+            minimumEmbeddingDuration: 1.0
+        )
+
+        let resolution = resolver.resolve(
+            entryID: entryID,
+            speakers: [
+                SpeakerIdentityInput(
+                    speakerID: "Speaker 2",
+                    audioDuration: 0.4,
+                    evidenceTranscript: "Brief interruption.",
+                    embedding: [0, 1, 0]
+                )
+            ],
+            existingLocalProfiles: [],
+            recognizedVoices: [],
+            now: Date(timeIntervalSince1970: 30)
+        )
+
+        XCTAssertTrue(resolution.recognizedVoices.isEmpty)
+        XCTAssertEqual(
+            resolution.localProfiles,
+            [
+                TranscriptionLabSpeakerProfile(
+                    entryID: entryID,
+                    speakerID: "Speaker 2",
+                    displayName: "Speaker 2",
+                    isMe: false,
+                    recognizedVoiceID: nil,
+                    evidenceTranscript: "Brief interruption."
+                )
+            ]
+        )
+    }
+}

--- a/GhostPepperTests/SpeechTranscriberTests.swift
+++ b/GhostPepperTests/SpeechTranscriberTests.swift
@@ -37,8 +37,7 @@ final class SpeechTranscriberTests: XCTestCase {
         XCTAssertFalse(SpeechModelCatalog.whisperSmallEnglish.supportsSpeakerFiltering)
         XCTAssertFalse(SpeechModelCatalog.whisperSmallMultilingual.supportsSpeakerFiltering)
         XCTAssertTrue(SpeechModelCatalog.parakeetV3.supportsSpeakerFiltering)
-        // Qwen3-ASR is an encoder-decoder without a diarization output.
-        XCTAssertFalse(SpeechModelCatalog.qwen3AsrInt8.supportsSpeakerFiltering)
+        XCTAssertTrue(SpeechModelCatalog.qwen3AsrInt8.supportsSpeakerFiltering)
     }
 
     func testQwen3AsrInt8Descriptor() {

--- a/GhostPepperTests/TranscriptionLabControllerTests.swift
+++ b/GhostPepperTests/TranscriptionLabControllerTests.swift
@@ -223,7 +223,7 @@ final class TranscriptionLabControllerTests: XCTestCase {
         XCTAssertNil(controller.runningStage)
     }
 
-    func testUpdatingLocalSpeakerIdentityCanPushChangesToGlobalVoicePrint() {
+    func testUpdatingLocalSpeakerIdentityAutoSyncsGlobalVoicePrint() {
         let entry = makeEntry(
             createdAt: Date(),
             speechModelID: "fluid_parakeet-v3",
@@ -287,18 +287,151 @@ final class TranscriptionLabControllerTests: XCTestCase {
         controller.updateSpeakerDisplayName("Jesse", for: "Speaker 0")
         XCTAssertEqual(savedProfiles.last?.displayName, "Jesse")
         XCTAssertEqual(controller.displayName(for: "Speaker 0"), "Jesse")
-        XCTAssertTrue(controller.hasPendingGlobalVoiceUpdate(for: "Speaker 0"))
+        XCTAssertEqual(recognizedVoices[0].displayName, "Jesse")
+        XCTAssertFalse(controller.hasPendingGlobalVoiceUpdate(for: "Speaker 0"))
 
         controller.setSpeakerIsMe(true, for: "Speaker 0")
         XCTAssertEqual(savedProfiles.last?.isMe, true)
-        XCTAssertTrue(controller.hasPendingGlobalVoiceUpdate(for: "Speaker 0"))
+        XCTAssertTrue(recognizedVoices[0].isMe)
+        XCTAssertFalse(controller.hasPendingGlobalVoiceUpdate(for: "Speaker 0"))
+        XCTAssertEqual(notifyRecognizedVoicesDidChangeCallCount, 2)
+    }
 
-        controller.pushSpeakerProfileToGlobalVoice(for: "Speaker 0")
+    func testSelectedEntrySpeakerProfilesPreferLatestRecognizedVoiceData() {
+        let entry = makeEntry(
+            createdAt: Date(),
+            speechModelID: "fluid_parakeet-v3",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)"
+        )
+        let recognizedVoiceID = UUID(uuidString: "00000000-0000-0000-0000-0000000000CC")!
+        let storedProfiles = [
+            TranscriptionLabSpeakerProfile(
+                entryID: entry.id,
+                speakerID: "Speaker 0",
+                displayName: "Old local name",
+                isMe: false,
+                recognizedVoiceID: recognizedVoiceID,
+                evidenceTranscript: "Yeah."
+            )
+        ]
+        let recognizedVoices = [
+            RecognizedVoiceProfile(
+                id: recognizedVoiceID,
+                displayName: "Jesse Vincent",
+                isMe: true,
+                embedding: [1, 0, 0],
+                updateCount: 3,
+                createdAt: Date(timeIntervalSince1970: 10),
+                updatedAt: Date(timeIntervalSince1970: 20),
+                evidenceTranscript: "And that have been around a long time."
+            )
+        ]
+
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
+            loadStageTimings: { [:] },
+            loadEntries: { [entry] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(rawTranscription: "")
+            },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            },
+            loadSpeakerProfiles: { _ in storedProfiles },
+            loadRecognizedVoices: { recognizedVoices }
+        )
+
+        controller.reloadEntries()
+        controller.selectEntry(entry.id)
+
+        XCTAssertEqual(controller.displayName(for: "Speaker 0"), "Jesse Vincent")
+        XCTAssertEqual(
+            controller.speakerProfilesInDisplayOrder,
+            [
+                TranscriptionLabSpeakerProfile(
+                    entryID: entry.id,
+                    speakerID: "Speaker 0",
+                    displayName: "Jesse Vincent",
+                    isMe: true,
+                    recognizedVoiceID: recognizedVoiceID,
+                    evidenceTranscript: "And that have been around a long time."
+                )
+            ]
+        )
+    }
+
+    func testHistorySpeakerIdentityEditsSyncRecognizedVoiceImmediately() {
+        let entry = makeEntry(
+            createdAt: Date(),
+            speechModelID: "fluid_parakeet-v3",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)"
+        )
+        let recognizedVoiceID = UUID(uuidString: "00000000-0000-0000-0000-0000000000DD")!
+        var storedProfiles = [
+            TranscriptionLabSpeakerProfile(
+                entryID: entry.id,
+                speakerID: "Speaker 0",
+                displayName: "Recognized Voice 1",
+                isMe: false,
+                recognizedVoiceID: recognizedVoiceID,
+                evidenceTranscript: "Yeah."
+            )
+        ]
+        var recognizedVoices = [
+            makeRecognizedVoiceProfile(
+                id: recognizedVoiceID,
+                displayName: "Recognized Voice 1",
+                isMe: false,
+                evidenceTranscript: "And that have been around a long time."
+            )
+        ]
+        var notifyRecognizedVoicesDidChangeCallCount = 0
+
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
+            loadStageTimings: { [:] },
+            loadEntries: { [entry] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(rawTranscription: "")
+            },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            },
+            loadSpeakerProfiles: { _ in storedProfiles },
+            saveSpeakerProfile: { profile in
+                storedProfiles = [profile]
+            },
+            loadRecognizedVoices: { recognizedVoices },
+            updateGlobalVoiceProfile: { localProfile in
+                var updatedProfile = recognizedVoices[0]
+                updatedProfile.displayName = localProfile.displayName
+                updatedProfile.isMe = localProfile.isMe
+                updatedProfile.evidenceTranscript = localProfile.evidenceTranscript
+                updatedProfile.updatedAt = Date(timeIntervalSince1970: 200)
+                recognizedVoices[0] = updatedProfile
+                return updatedProfile
+            },
+            notifyRecognizedVoicesDidChange: {
+                notifyRecognizedVoicesDidChangeCallCount += 1
+            }
+        )
+
+        controller.reloadEntries()
+        controller.selectEntry(entry.id)
+
+        controller.updateSpeakerDisplayName("Jesse", for: "Speaker 0")
+        controller.setSpeakerIsMe(true, for: "Speaker 0")
 
         XCTAssertEqual(recognizedVoices[0].displayName, "Jesse")
         XCTAssertTrue(recognizedVoices[0].isMe)
+        XCTAssertEqual(recognizedVoices[0].evidenceTranscript, "And that have been around a long time.")
+        XCTAssertEqual(notifyRecognizedVoicesDidChangeCallCount, 2)
+        XCTAssertEqual(controller.displayName(for: "Speaker 0"), "Jesse")
         XCTAssertFalse(controller.hasPendingGlobalVoiceUpdate(for: "Speaker 0"))
-        XCTAssertEqual(notifyRecognizedVoicesDidChangeCallCount, 1)
     }
 
     func testDisplayedExperimentOutputsDefaultToOriginalOutputs() {
@@ -575,7 +708,8 @@ final class TranscriptionLabControllerTests: XCTestCase {
     private func makeRecognizedVoiceProfile(
         id: UUID,
         displayName: String,
-        isMe: Bool
+        isMe: Bool,
+        evidenceTranscript: String = "Sample evidence"
     ) -> RecognizedVoiceProfile {
         RecognizedVoiceProfile(
             id: id,
@@ -585,7 +719,7 @@ final class TranscriptionLabControllerTests: XCTestCase {
             updateCount: 1,
             createdAt: Date(timeIntervalSince1970: 50),
             updatedAt: Date(timeIntervalSince1970: 100),
-            evidenceTranscript: "Sample evidence"
+            evidenceTranscript: evidenceTranscript
         )
     }
 }

--- a/GhostPepperTests/TranscriptionLabControllerTests.swift
+++ b/GhostPepperTests/TranscriptionLabControllerTests.swift
@@ -156,7 +156,17 @@ final class TranscriptionLabControllerTests: XCTestCase {
                                 text: "tagged rerun"
                             )
                         ]
-                    )
+                    ),
+                    speakerProfiles: [
+                        TranscriptionLabSpeakerProfile(
+                            entryID: entry.id,
+                            speakerID: "Speaker 0",
+                            displayName: "Jesse",
+                            isMe: true,
+                            recognizedVoiceID: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA"),
+                            evidenceTranscript: "tagged rerun"
+                        )
+                    ]
                 )
             },
             runCleanup: { rerunEntry, rawText, cleanupModelKind, prompt, includeWindowContext in
@@ -205,12 +215,90 @@ final class TranscriptionLabControllerTests: XCTestCase {
         XCTAssertEqual(
             controller.displayedSpeakerTaggedTranscriptText,
             """
-            [Speaker 0 | 0.0s-0.6s]
+            [Jesse | 0.0s-0.6s]
             tagged rerun
             """
         )
         XCTAssertNil(controller.errorMessage)
         XCTAssertNil(controller.runningStage)
+    }
+
+    func testUpdatingLocalSpeakerIdentityCanPushChangesToGlobalVoicePrint() {
+        let entry = makeEntry(
+            createdAt: Date(),
+            speechModelID: "fluid_parakeet-v3",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)"
+        )
+        let recognizedVoiceID = UUID(uuidString: "00000000-0000-0000-0000-0000000000BB")!
+        var storedProfiles = [
+            TranscriptionLabSpeakerProfile(
+                entryID: entry.id,
+                speakerID: "Speaker 0",
+                displayName: "Recognized Voice 1",
+                isMe: false,
+                recognizedVoiceID: recognizedVoiceID,
+                evidenceTranscript: "Original evidence"
+            )
+        ]
+        var recognizedVoices = [
+            makeRecognizedVoiceProfile(
+                id: recognizedVoiceID,
+                displayName: "Recognized Voice 1",
+                isMe: false
+            )
+        ]
+        var savedProfiles: [TranscriptionLabSpeakerProfile] = []
+        var notifyRecognizedVoicesDidChangeCallCount = 0
+
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
+            loadStageTimings: { [:] },
+            loadEntries: { [entry] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(rawTranscription: "")
+            },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            },
+            loadSpeakerProfiles: { _ in storedProfiles },
+            saveSpeakerProfile: { profile in
+                storedProfiles = [profile]
+                savedProfiles.append(profile)
+            },
+            loadRecognizedVoices: { recognizedVoices },
+            updateGlobalVoiceProfile: { localProfile in
+                var updatedProfile = recognizedVoices[0]
+                updatedProfile.displayName = localProfile.displayName
+                updatedProfile.isMe = localProfile.isMe
+                updatedProfile.updatedAt = Date(timeIntervalSince1970: 200)
+                recognizedVoices[0] = updatedProfile
+                return updatedProfile
+            },
+            notifyRecognizedVoicesDidChange: {
+                notifyRecognizedVoicesDidChangeCallCount += 1
+            }
+        )
+
+        controller.reloadEntries()
+        controller.selectEntry(entry.id)
+
+        controller.updateSpeakerDisplayName("Jesse", for: "Speaker 0")
+        XCTAssertEqual(savedProfiles.last?.displayName, "Jesse")
+        XCTAssertEqual(controller.displayName(for: "Speaker 0"), "Jesse")
+        XCTAssertTrue(controller.hasPendingGlobalVoiceUpdate(for: "Speaker 0"))
+
+        controller.setSpeakerIsMe(true, for: "Speaker 0")
+        XCTAssertEqual(savedProfiles.last?.isMe, true)
+        XCTAssertTrue(controller.hasPendingGlobalVoiceUpdate(for: "Speaker 0"))
+
+        controller.pushSpeakerProfileToGlobalVoice(for: "Speaker 0")
+
+        XCTAssertEqual(recognizedVoices[0].displayName, "Jesse")
+        XCTAssertTrue(recognizedVoices[0].isMe)
+        XCTAssertFalse(controller.hasPendingGlobalVoiceUpdate(for: "Speaker 0"))
+        XCTAssertEqual(notifyRecognizedVoicesDidChangeCallCount, 1)
     }
 
     func testDisplayedExperimentOutputsDefaultToOriginalOutputs() {
@@ -481,6 +569,23 @@ final class TranscriptionLabControllerTests: XCTestCase {
             speakerFilteringRan: speakerFilteringRan,
             speakerFilteringUsedFallback: speakerFilteringUsedFallback,
             diarizationSummary: diarizationSummary
+        )
+    }
+
+    private func makeRecognizedVoiceProfile(
+        id: UUID,
+        displayName: String,
+        isMe: Bool
+    ) -> RecognizedVoiceProfile {
+        RecognizedVoiceProfile(
+            id: id,
+            displayName: displayName,
+            isMe: isMe,
+            embedding: Array(repeating: 0.25, count: 256),
+            updateCount: 1,
+            createdAt: Date(timeIntervalSince1970: 50),
+            updatedAt: Date(timeIntervalSince1970: 100),
+            evidenceTranscript: "Sample evidence"
         )
     }
 }

--- a/GhostPepperTests/TranscriptionLabControllerTests.swift
+++ b/GhostPepperTests/TranscriptionLabControllerTests.swift
@@ -17,12 +17,13 @@ final class TranscriptionLabControllerTests: XCTestCase {
 
         let controller = TranscriptionLabController(
             defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
             loadStageTimings: { [:] },
             loadEntries: { [olderEntry, newerEntry] },
             audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
-            runTranscription: { _, _ in
+            runTranscription: { _, _, _ in
                 XCTFail("should not rerun during reload")
-                return ""
+                return TranscriptionLabTranscriptionResult(rawTranscription: "")
             },
             runCleanup: { _, _, _, _, _ in
                 XCTFail("should not rerun during reload")
@@ -35,6 +36,7 @@ final class TranscriptionLabControllerTests: XCTestCase {
         XCTAssertEqual(controller.entries.map { $0.id }, [newerEntry.id, olderEntry.id])
         XCTAssertNil(controller.selectedEntryID)
         XCTAssertEqual(controller.selectedSpeechModelID, SpeechModelCatalog.defaultModelID)
+        XCTAssertFalse(controller.usesSpeakerTagging)
         XCTAssertEqual(controller.selectedCleanupModelKind, LocalCleanupModelKind.qwen35_4b_q4_k_m)
     }
 
@@ -46,11 +48,14 @@ final class TranscriptionLabControllerTests: XCTestCase {
         )
         let controller = TranscriptionLabController(
             defaultSpeechModelID: "fluid_parakeet-v3",
+            defaultSpeakerTaggingEnabled: true,
             defaultCleanupModelKind: .qwen35_2b_q4_k_m,
             loadStageTimings: { [:] },
             loadEntries: { [entry] },
             audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
-            runTranscription: { _, _ in "" },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(rawTranscription: "")
+            },
             runCleanup: { _, _, _, _, _ in
                 TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
             }
@@ -60,30 +65,38 @@ final class TranscriptionLabControllerTests: XCTestCase {
         controller.selectEntry(entry.id)
 
         XCTAssertEqual(controller.selectedSpeechModelID, "fluid_parakeet-v3")
+        XCTAssertTrue(controller.usesSpeakerTagging)
         XCTAssertEqual(controller.selectedCleanupModelKind, .qwen35_2b_q4_k_m)
     }
 
-    func testChangingRerunModelsImmediatelyInvokesSyncCallbacks() {
+    func testChangingRerunControlsImmediatelyInvokesSyncCallbacks() {
         var synchronizedSpeechModelIDs: [String] = []
+        var synchronizedSpeakerTaggingStates: [Bool] = []
         var synchronizedCleanupModelKinds: [LocalCleanupModelKind] = []
         let controller = TranscriptionLabController(
             defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
             defaultCleanupModelKind: .qwen35_4b_q4_k_m,
             loadStageTimings: { [:] },
             loadEntries: { [] },
             audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
-            runTranscription: { _, _ in "" },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(rawTranscription: "")
+            },
             runCleanup: { _, _, _, _, _ in
                 TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
             },
             syncSelectedSpeechModelID: { synchronizedSpeechModelIDs.append($0) },
+            syncSpeakerTaggingEnabled: { synchronizedSpeakerTaggingStates.append($0) },
             syncSelectedCleanupModelKind: { synchronizedCleanupModelKinds.append($0) }
         )
 
         controller.selectedSpeechModelID = "fluid_parakeet-v3"
+        controller.usesSpeakerTagging = true
         controller.selectedCleanupModelKind = .qwen35_2b_q4_k_m
 
         XCTAssertEqual(synchronizedSpeechModelIDs, ["fluid_parakeet-v3"])
+        XCTAssertEqual(synchronizedSpeakerTaggingStates, [true])
         XCTAssertEqual(synchronizedCleanupModelKinds, [.qwen35_2b_q4_k_m])
     }
 
@@ -95,11 +108,27 @@ final class TranscriptionLabControllerTests: XCTestCase {
         )
         var executedCleanupPrompt: String?
         var executedSpeechModelID: String?
+        var executedSpeakerTaggingEnabled: Bool?
         var executedCleanupModelKind: LocalCleanupModelKind?
         var executedCleanupIncludesWindowContext: Bool?
         var cleanupInputText: String?
+        let diarizationSummary = DiarizationSummary(
+            spans: [
+                .init(speakerID: "Speaker 0", startTime: 0.0, endTime: 0.6, isKept: true),
+                .init(speakerID: "Speaker 1", startTime: 0.6, endTime: 1.0, isKept: false),
+            ],
+            mergedKeptSpans: [
+                .init(startTime: 0.0, endTime: 0.6),
+            ],
+            targetSpeakerID: "Speaker 0",
+            targetSpeakerDuration: 0.6,
+            keptAudioDuration: 0.6,
+            usedFallback: false,
+            fallbackReason: nil
+        )
         let controller = TranscriptionLabController(
             defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
             loadStageTimings: {
                 [
                     entry.id: TranscriptionLabStageTimings(
@@ -110,11 +139,25 @@ final class TranscriptionLabControllerTests: XCTestCase {
             },
             loadEntries: { [entry] },
             audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
-            runTranscription: { rerunEntry, speechModelID in
+            runTranscription: { rerunEntry, speechModelID, speakerTaggingEnabled in
                 XCTAssertEqual(rerunEntry.id, entry.id)
                 executedSpeechModelID = speechModelID
+                executedSpeakerTaggingEnabled = speakerTaggingEnabled
                 try? await Task.sleep(nanoseconds: 20_000_000)
-                return "raw rerun"
+                return TranscriptionLabTranscriptionResult(
+                    rawTranscription: "raw rerun",
+                    diarizationSummary: diarizationSummary,
+                    speakerTaggedTranscript: SpeakerTaggedTranscript(
+                        segments: [
+                            .init(
+                                speakerID: "Speaker 0",
+                                startTime: 0.0,
+                                endTime: 0.6,
+                                text: "tagged rerun"
+                            )
+                        ]
+                    )
+                )
             },
             runCleanup: { rerunEntry, rawText, cleanupModelKind, prompt, includeWindowContext in
                 XCTAssertEqual(rerunEntry.id, entry.id)
@@ -137,6 +180,7 @@ final class TranscriptionLabControllerTests: XCTestCase {
         controller.reloadEntries()
         controller.selectEntry(entry.id)
         controller.selectedSpeechModelID = "fluid_parakeet-v3"
+        controller.usesSpeakerTagging = true
         controller.selectedCleanupModelKind = .qwen35_4b_q4_k_m
         controller.usesCapturedOCR = false
 
@@ -144,6 +188,7 @@ final class TranscriptionLabControllerTests: XCTestCase {
         await controller.rerunCleanup(prompt: "custom prompt")
 
         XCTAssertEqual(executedSpeechModelID, "fluid_parakeet-v3")
+        XCTAssertEqual(executedSpeakerTaggingEnabled, true)
         XCTAssertEqual(cleanupInputText, "raw rerun")
         XCTAssertEqual(executedCleanupPrompt, "custom prompt")
         XCTAssertEqual(executedCleanupModelKind, .qwen35_4b_q4_k_m)
@@ -157,6 +202,13 @@ final class TranscriptionLabControllerTests: XCTestCase {
         XCTAssertEqual(controller.latestCleanupTranscript?.prompt, "custom prompt")
         XCTAssertEqual(controller.latestCleanupTranscript?.inputText, "raw rerun")
         XCTAssertEqual(controller.latestCleanupTranscript?.rawModelOutput, "clean rerun raw")
+        XCTAssertEqual(
+            controller.displayedSpeakerTaggedTranscriptText,
+            """
+            [Speaker 0 | 0.0s-0.6s]
+            tagged rerun
+            """
+        )
         XCTAssertNil(controller.errorMessage)
         XCTAssertNil(controller.runningStage)
     }
@@ -169,10 +221,13 @@ final class TranscriptionLabControllerTests: XCTestCase {
         )
         let controller = TranscriptionLabController(
             defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
             loadStageTimings: { [:] },
             loadEntries: { [entry] },
             audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
-            runTranscription: { _, _ in "" },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(rawTranscription: "")
+            },
             runCleanup: { _, _, _, _, _ in
                 TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
             }
@@ -214,10 +269,13 @@ final class TranscriptionLabControllerTests: XCTestCase {
         )
         let controller = TranscriptionLabController(
             defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
             loadStageTimings: { [:] },
             loadEntries: { [entry] },
             audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
-            runTranscription: { _, _ in "" },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(rawTranscription: "")
+            },
             runCleanup: { _, _, _, _, _ in
                 TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
             }
@@ -251,10 +309,13 @@ final class TranscriptionLabControllerTests: XCTestCase {
         )
         let controller = TranscriptionLabController(
             defaultSpeechModelID: SpeechModelCatalog.defaultModelID,
+            defaultSpeakerTaggingEnabled: false,
             loadStageTimings: { [:] },
             loadEntries: { [entry] },
             audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
-            runTranscription: { _, _ in "" },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(rawTranscription: "")
+            },
             runCleanup: { _, _, _, _, _ in
                 TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
             }
@@ -264,6 +325,102 @@ final class TranscriptionLabControllerTests: XCTestCase {
         controller.selectEntry(entry.id)
 
         XCTAssertNil(controller.diarizationVisualization)
+    }
+
+    func testExperimentDiarizationVisualizationOverridesArchivedSummaryAfterRerun() async {
+        let archivedSummary = DiarizationSummary(
+            spans: [
+                .init(speakerID: "Speaker 0", startTime: 0.0, endTime: 0.5, isKept: true),
+            ],
+            mergedKeptSpans: [
+                .init(startTime: 0.0, endTime: 0.5),
+            ],
+            targetSpeakerID: "Speaker 0",
+            targetSpeakerDuration: 0.5,
+            keptAudioDuration: 0.5,
+            usedFallback: false,
+            fallbackReason: nil
+        )
+        let experimentSummary = DiarizationSummary(
+            spans: [
+                .init(speakerID: "Speaker 1", startTime: 0.0, endTime: 1.0, isKept: true),
+            ],
+            mergedKeptSpans: [
+                .init(startTime: 0.0, endTime: 1.0),
+            ],
+            targetSpeakerID: "Speaker 1",
+            targetSpeakerDuration: 1.0,
+            keptAudioDuration: 1.0,
+            usedFallback: false,
+            fallbackReason: nil
+        )
+        let entry = makeEntry(
+            createdAt: Date(),
+            speechModelID: "fluid_parakeet-v3",
+            cleanupModelName: "Qwen 3.5 2B (fast cleanup)",
+            audioDuration: 1.5,
+            diarizationSummary: archivedSummary,
+            speakerFilteringEnabled: true,
+            speakerFilteringRan: true,
+            speakerFilteringUsedFallback: false
+        )
+        let controller = TranscriptionLabController(
+            defaultSpeechModelID: "fluid_parakeet-v3",
+            defaultSpeakerTaggingEnabled: true,
+            loadStageTimings: { [:] },
+            loadEntries: { [entry] },
+            audioURLForEntry: { _ in URL(fileURLWithPath: "/tmp/sample.bin") },
+            runTranscription: { _, _, _ in
+                TranscriptionLabTranscriptionResult(
+                    rawTranscription: "rerun",
+                    diarizationSummary: experimentSummary,
+                    speakerTaggedTranscript: SpeakerTaggedTranscript(
+                        segments: [
+                            .init(speakerID: "Speaker 1", startTime: 0.0, endTime: 1.0, text: "rerun")
+                        ]
+                    )
+                )
+            },
+            runCleanup: { _, _, _, _, _ in
+                TranscriptionLabCleanupResult(correctedTranscription: "", cleanupUsedFallback: false)
+            }
+        )
+
+        controller.reloadEntries()
+        controller.selectEntry(entry.id)
+
+        await controller.rerunTranscription()
+
+        XCTAssertEqual(controller.diarizationVisualization?.targetSpeakerID, "Speaker 1")
+        XCTAssertEqual(controller.diarizationVisualization?.keptAudioDuration, 1.0)
+        XCTAssertEqual(
+            controller.displayedSpeakerTaggedTranscriptText,
+            """
+            [Speaker 1 | 0.0s-1.0s]
+            rerun
+            """
+        )
+    }
+
+    func testDiarizationVisualizationTracksSpeakerIDsInDisplayOrder() {
+        let visualization = TranscriptionLabController.DiarizationVisualization(
+            audioDuration: 2.0,
+            targetSpeakerID: "Speaker 1",
+            keptAudioDuration: 1.0,
+            usedFallback: false,
+            fallbackReason: nil,
+            spans: [
+                .init(speakerID: "Speaker 1", startTime: 0.0, endTime: 0.4, isKept: true),
+                .init(speakerID: "Speaker 0", startTime: 0.4, endTime: 0.8, isKept: false),
+                .init(speakerID: "Speaker 1", startTime: 0.8, endTime: 1.2, isKept: true),
+                .init(speakerID: "Speaker 2", startTime: 1.2, endTime: 2.0, isKept: false),
+            ]
+        )
+
+        XCTAssertEqual(
+            visualization.speakerIDsInDisplayOrder,
+            ["Speaker 1", "Speaker 0", "Speaker 2"]
+        )
     }
 
     func testTranscriptionLabTextDiffMarksInsertedAndRemovedRuns() {

--- a/GhostPepperTests/TranscriptionLabRunnerTests.swift
+++ b/GhostPepperTests/TranscriptionLabRunnerTests.swift
@@ -451,6 +451,85 @@ final class TranscriptionLabRunnerTests: XCTestCase {
         XCTAssertEqual(resolvedSpeakerTaggedTranscript, repairedSpeakerTaggedTranscript)
     }
 
+    func testRunnerRepairsSingleSpeakerTranscriptWhenSingleSpeakerFallbackReturnsBogusSegment() async throws {
+        let diarizationSummary = DiarizationSummary(
+            spans: [
+                .init(speakerID: "Speaker 0", startTime: 2.48, endTime: 4.24, isKept: true)
+            ],
+            mergedKeptSpans: [
+                .init(startTime: 2.48, endTime: 4.24)
+            ],
+            targetSpeakerID: "Speaker 0",
+            targetSpeakerDuration: 1.76,
+            keptAudioDuration: 1.76,
+            usedFallback: true,
+            fallbackReason: .singleDetectedSpeaker
+        )
+        let entry = makeEntry()
+        let repairedSpeakerTaggedTranscript = SpeakerTaggedTranscript(
+            segments: [
+                .init(
+                    speakerID: "Speaker 0",
+                    startTime: 2.48,
+                    endTime: 4.24,
+                    text: "And that have been around a long time."
+                )
+            ]
+        )
+        var resolvedSpeakerTaggedTranscript: SpeakerTaggedTranscript?
+
+        let runner = TranscriptionLabRunner(
+            loadAudioBuffer: { _ in [0.1, 0.2, 0.3] },
+            loadSpeechModel: { _ in },
+            transcribe: { _ in
+                "And that have been around a long time."
+            },
+            runSpeakerTagging: { _ in
+                SpeakerTaggedTranscriptionResult(
+                    filteredTranscript: nil,
+                    diarizationSummary: diarizationSummary,
+                    speakerTaggedTranscript: SpeakerTaggedTranscript(
+                        segments: [
+                            .init(
+                                speakerID: "Speaker 0",
+                                startTime: 2.48,
+                                endTime: 4.24,
+                                text: "Yeah."
+                            )
+                        ]
+                    )
+                )
+            },
+            resolveSpeakerProfiles: { entryID, _, summary, speakerTaggedTranscript in
+                XCTAssertEqual(entryID, entry.id)
+                XCTAssertEqual(summary, diarizationSummary)
+                resolvedSpeakerTaggedTranscript = speakerTaggedTranscript
+                return []
+            },
+            clean: { _, _, _ in
+                XCTFail("cleanup should not run in this test")
+                return TextCleanerResult(
+                    text: "",
+                    performance: TextCleanerPerformance(modelCallDuration: nil, postProcessDuration: nil)
+                )
+            },
+            correctionStore: CorrectionStore(defaults: UserDefaults(suiteName: #function)!)
+        )
+
+        let result = try await runner.rerunTranscription(
+            entry: entry,
+            speechModelID: "fluid_parakeet-v3",
+            speakerTaggingEnabled: true,
+            acquirePipeline: { true },
+            releasePipeline: {}
+        )
+
+        XCTAssertEqual(result.rawTranscription, "And that have been around a long time.")
+        XCTAssertEqual(result.diarizationSummary, diarizationSummary)
+        XCTAssertEqual(result.speakerTaggedTranscript, repairedSpeakerTaggedTranscript)
+        XCTAssertEqual(resolvedSpeakerTaggedTranscript, repairedSpeakerTaggedTranscript)
+    }
+
     private func makeEntry() -> TranscriptionLabEntry {
         TranscriptionLabEntry(
             id: UUID(),

--- a/GhostPepperTests/TranscriptionLabRunnerTests.swift
+++ b/GhostPepperTests/TranscriptionLabRunnerTests.swift
@@ -372,6 +372,85 @@ final class TranscriptionLabRunnerTests: XCTestCase {
         XCTAssertEqual(transcribeCallCount, 1)
     }
 
+    func testRunnerRepairsSingleSpeakerTranscriptWhenEmptyFilteredFallbackReturnsBogusSegment() async throws {
+        let diarizationSummary = DiarizationSummary(
+            spans: [
+                .init(speakerID: "Speaker 0", startTime: 2.48, endTime: 4.32, isKept: true)
+            ],
+            mergedKeptSpans: [
+                .init(startTime: 2.48, endTime: 4.32)
+            ],
+            targetSpeakerID: "Speaker 0",
+            targetSpeakerDuration: 1.84,
+            keptAudioDuration: 1.84,
+            usedFallback: true,
+            fallbackReason: .emptyFilteredTranscription
+        )
+        let entry = makeEntry()
+        let repairedSpeakerTaggedTranscript = SpeakerTaggedTranscript(
+            segments: [
+                .init(
+                    speakerID: "Speaker 0",
+                    startTime: 2.48,
+                    endTime: 4.32,
+                    text: "And that have been around a long time."
+                )
+            ]
+        )
+        var resolvedSpeakerTaggedTranscript: SpeakerTaggedTranscript?
+
+        let runner = TranscriptionLabRunner(
+            loadAudioBuffer: { _ in [0.1, 0.2, 0.3] },
+            loadSpeechModel: { _ in },
+            transcribe: { _ in
+                "And that have been around a long time."
+            },
+            runSpeakerTagging: { _ in
+                SpeakerTaggedTranscriptionResult(
+                    filteredTranscript: nil,
+                    diarizationSummary: diarizationSummary,
+                    speakerTaggedTranscript: SpeakerTaggedTranscript(
+                        segments: [
+                            .init(
+                                speakerID: "Speaker 0",
+                                startTime: 2.48,
+                                endTime: 4.32,
+                                text: "Yeah."
+                            )
+                        ]
+                    )
+                )
+            },
+            resolveSpeakerProfiles: { entryID, _, summary, speakerTaggedTranscript in
+                XCTAssertEqual(entryID, entry.id)
+                XCTAssertEqual(summary, diarizationSummary)
+                resolvedSpeakerTaggedTranscript = speakerTaggedTranscript
+                return []
+            },
+            clean: { _, _, _ in
+                XCTFail("cleanup should not run in this test")
+                return TextCleanerResult(
+                    text: "",
+                    performance: TextCleanerPerformance(modelCallDuration: nil, postProcessDuration: nil)
+                )
+            },
+            correctionStore: CorrectionStore(defaults: UserDefaults(suiteName: #function)!)
+        )
+
+        let result = try await runner.rerunTranscription(
+            entry: entry,
+            speechModelID: "fluid_parakeet-v3",
+            speakerTaggingEnabled: true,
+            acquirePipeline: { true },
+            releasePipeline: {}
+        )
+
+        XCTAssertEqual(result.rawTranscription, "And that have been around a long time.")
+        XCTAssertEqual(result.diarizationSummary, diarizationSummary)
+        XCTAssertEqual(result.speakerTaggedTranscript, repairedSpeakerTaggedTranscript)
+        XCTAssertEqual(resolvedSpeakerTaggedTranscript, repairedSpeakerTaggedTranscript)
+    }
+
     private func makeEntry() -> TranscriptionLabEntry {
         TranscriptionLabEntry(
             id: UUID(),

--- a/GhostPepperTests/TranscriptionLabRunnerTests.swift
+++ b/GhostPepperTests/TranscriptionLabRunnerTests.swift
@@ -32,6 +32,10 @@ final class TranscriptionLabRunnerTests: XCTestCase {
                 transcribedBuffers.append(audioBuffer)
                 return "The default should be Quen three point five four b."
             },
+            runSpeakerTagging: { _ in
+                XCTFail("speaker tagging should be disabled for this rerun")
+                return nil
+            },
             clean: { text, prompt, modelKind in
                 XCTAssertEqual(text, "The default should be Quen three point five four b.")
                 XCTAssertEqual(modelKind, .full)
@@ -54,15 +58,16 @@ final class TranscriptionLabRunnerTests: XCTestCase {
             correctionStore: correctionStore
         )
 
-        let rawTranscription = try await runner.rerunTranscription(
+        let transcriptionResult = try await runner.rerunTranscription(
             entry: entry,
             speechModelID: "fluid_parakeet-v3",
+            speakerTaggingEnabled: false,
             acquirePipeline: { true },
             releasePipeline: {}
         )
         let result = try await runner.rerunCleanup(
             entry: entry,
-            rawTranscription: rawTranscription,
+            rawTranscription: transcriptionResult.rawTranscription,
             cleanupModelKind: .full,
             prompt: TextCleaner.defaultPrompt,
             includeWindowContext: true,
@@ -72,7 +77,9 @@ final class TranscriptionLabRunnerTests: XCTestCase {
 
         XCTAssertEqual(loadedSpeechModels, ["fluid_parakeet-v3"])
         XCTAssertEqual(transcribedBuffers, [[0.1, 0.2, 0.3]])
-        XCTAssertEqual(rawTranscription, "The default should be Quen three point five four b.")
+        XCTAssertEqual(transcriptionResult.rawTranscription, "The default should be Quen three point five four b.")
+        XCTAssertNil(transcriptionResult.diarizationSummary)
+        XCTAssertNil(transcriptionResult.speakerTaggedTranscript)
         XCTAssertEqual(result.correctedTranscription, "The default should be Qwen 3.5 4B.")
         XCTAssertFalse(result.cleanupUsedFallback)
         XCTAssertEqual(
@@ -99,6 +106,10 @@ final class TranscriptionLabRunnerTests: XCTestCase {
                 XCTFail("should not transcribe when busy")
                 return nil
             },
+            runSpeakerTagging: { _ in
+                XCTFail("should not run speaker tagging when busy")
+                return nil
+            },
             clean: { _, _, _ in
                 XCTFail("should not clean when busy")
                 return TextCleanerResult(
@@ -113,6 +124,7 @@ final class TranscriptionLabRunnerTests: XCTestCase {
             _ = try await runner.rerunTranscription(
                 entry: makeEntry(),
                 speechModelID: "fluid_parakeet-v3",
+                speakerTaggingEnabled: false,
                 acquirePipeline: { false },
                 releasePipeline: {}
             )
@@ -127,6 +139,7 @@ final class TranscriptionLabRunnerTests: XCTestCase {
             loadAudioBuffer: { _ in [0.1] },
             loadSpeechModel: { _ in },
             transcribe: { _ in "raw text" },
+            runSpeakerTagging: { _ in nil },
             clean: { _, _, _ in
                 TextCleanerResult(
                     text: "raw text",
@@ -162,6 +175,7 @@ final class TranscriptionLabRunnerTests: XCTestCase {
             loadAudioBuffer: { _ in [0.1] },
             loadSpeechModel: { _ in },
             transcribe: { _ in "raw text" },
+            runSpeakerTagging: { _ in nil },
             clean: { _, prompt, _ in
                 TextCleanerResult(
                     text: "raw text",
@@ -197,6 +211,134 @@ final class TranscriptionLabRunnerTests: XCTestCase {
             TextCleaner.formatCleanupInput(userInput: "raw text")
         )
         XCTAssertEqual(result.transcript?.rawModelOutput, "...")
+    }
+
+    func testRunnerUsesSpeakerTaggedResultWhenRequested() async throws {
+        let diarizationSummary = DiarizationSummary(
+            spans: [
+                .init(speakerID: "Speaker 0", startTime: 0.0, endTime: 0.6, isKept: true),
+                .init(speakerID: "Speaker 1", startTime: 0.6, endTime: 1.0, isKept: false),
+            ],
+            mergedKeptSpans: [
+                .init(startTime: 0.0, endTime: 0.6),
+            ],
+            targetSpeakerID: "Speaker 0",
+            targetSpeakerDuration: 0.6,
+            keptAudioDuration: 0.6,
+            usedFallback: false,
+            fallbackReason: nil
+        )
+        var transcribeCallCount = 0
+        var speakerTaggingCallCount = 0
+        let runner = TranscriptionLabRunner(
+            loadAudioBuffer: { _ in [0.1, 0.2, 0.3] },
+            loadSpeechModel: { _ in },
+            transcribe: { _ in
+                transcribeCallCount += 1
+                return "full transcript"
+            },
+            runSpeakerTagging: { audioBuffer in
+                speakerTaggingCallCount += 1
+                XCTAssertEqual(audioBuffer, [0.1, 0.2, 0.3])
+                return SpeakerTaggedTranscriptionResult(
+                    filteredTranscript: "filtered transcript",
+                    diarizationSummary: diarizationSummary,
+                    speakerTaggedTranscript: SpeakerTaggedTranscript(
+                        segments: [
+                            .init(
+                                speakerID: "Speaker 0",
+                                startTime: 0.0,
+                                endTime: 0.6,
+                                text: "filtered transcript"
+                            )
+                        ]
+                    )
+                )
+            },
+            clean: { _, _, _ in
+                XCTFail("cleanup should not run in this test")
+                return TextCleanerResult(
+                    text: "",
+                    performance: TextCleanerPerformance(modelCallDuration: nil, postProcessDuration: nil)
+                )
+            },
+            correctionStore: CorrectionStore(defaults: UserDefaults(suiteName: #function)!)
+        )
+
+        let result = try await runner.rerunTranscription(
+            entry: makeEntry(),
+            speechModelID: "fluid_parakeet-v3",
+            speakerTaggingEnabled: true,
+            acquirePipeline: { true },
+            releasePipeline: {}
+        )
+
+        XCTAssertEqual(result.rawTranscription, "filtered transcript")
+        XCTAssertEqual(result.diarizationSummary, diarizationSummary)
+        XCTAssertEqual(
+            result.speakerTaggedTranscript,
+            SpeakerTaggedTranscript(
+                segments: [
+                    .init(
+                        speakerID: "Speaker 0",
+                        startTime: 0.0,
+                        endTime: 0.6,
+                        text: "filtered transcript"
+                    )
+                ]
+            )
+        )
+        XCTAssertEqual(speakerTaggingCallCount, 1)
+        XCTAssertEqual(transcribeCallCount, 0)
+    }
+
+    func testRunnerFallsBackToFullTranscriptionWhenSpeakerTaggingFallsBack() async throws {
+        let diarizationSummary = DiarizationSummary(
+            spans: [],
+            mergedKeptSpans: [],
+            targetSpeakerID: nil,
+            targetSpeakerDuration: 0,
+            keptAudioDuration: 0,
+            usedFallback: true,
+            fallbackReason: .ambiguousDominantSpeaker
+        )
+        var transcribeCallCount = 0
+        let runner = TranscriptionLabRunner(
+            loadAudioBuffer: { _ in [0.1, 0.2, 0.3] },
+            loadSpeechModel: { _ in },
+            transcribe: { _ in
+                transcribeCallCount += 1
+                return "full transcript"
+            },
+            runSpeakerTagging: { _ in
+                SpeakerTaggedTranscriptionResult(
+                    filteredTranscript: nil,
+                    diarizationSummary: diarizationSummary,
+                    speakerTaggedTranscript: nil
+                )
+            },
+            clean: { _, _, _ in
+                XCTFail("cleanup should not run in this test")
+                return TextCleanerResult(
+                    text: "",
+                    performance: TextCleanerPerformance(modelCallDuration: nil, postProcessDuration: nil)
+                )
+            },
+            correctionStore: CorrectionStore(defaults: UserDefaults(suiteName: #function)!)
+        )
+
+        let result = try await runner.rerunTranscription(
+            entry: makeEntry(),
+            speechModelID: "fluid_parakeet-v3",
+            speakerTaggingEnabled: true,
+            acquirePipeline: { true },
+            releasePipeline: {}
+        )
+
+        XCTAssertEqual(result.rawTranscription, "full transcript")
+        XCTAssertEqual(result.diarizationSummary, diarizationSummary)
+        XCTAssertNil(result.speakerTaggedTranscript)
+        XCTAssertEqual(transcribeCallCount, 1)
     }
 
     private func makeEntry() -> TranscriptionLabEntry {

--- a/GhostPepperTests/TranscriptionLabRunnerTests.swift
+++ b/GhostPepperTests/TranscriptionLabRunnerTests.swift
@@ -230,6 +230,17 @@ final class TranscriptionLabRunnerTests: XCTestCase {
         )
         var transcribeCallCount = 0
         var speakerTaggingCallCount = 0
+        let entry = makeEntry()
+        let resolvedProfiles = [
+            TranscriptionLabSpeakerProfile(
+                entryID: entry.id,
+                speakerID: "Speaker 0",
+                displayName: "Jesse",
+                isMe: true,
+                recognizedVoiceID: UUID(uuidString: "00000000-0000-0000-0000-0000000000CC"),
+                evidenceTranscript: "filtered transcript"
+            )
+        ]
         let runner = TranscriptionLabRunner(
             loadAudioBuffer: { _ in [0.1, 0.2, 0.3] },
             loadSpeechModel: { _ in },
@@ -255,6 +266,25 @@ final class TranscriptionLabRunnerTests: XCTestCase {
                     )
                 )
             },
+            resolveSpeakerProfiles: { entryID, audioBuffer, summary, speakerTaggedTranscript in
+                XCTAssertEqual(entryID, entry.id)
+                XCTAssertEqual(audioBuffer, [0.1, 0.2, 0.3])
+                XCTAssertEqual(summary, diarizationSummary)
+                XCTAssertEqual(
+                    speakerTaggedTranscript,
+                    SpeakerTaggedTranscript(
+                        segments: [
+                            .init(
+                                speakerID: "Speaker 0",
+                                startTime: 0.0,
+                                endTime: 0.6,
+                                text: "filtered transcript"
+                            )
+                        ]
+                    )
+                )
+                return resolvedProfiles
+            },
             clean: { _, _, _ in
                 XCTFail("cleanup should not run in this test")
                 return TextCleanerResult(
@@ -266,7 +296,7 @@ final class TranscriptionLabRunnerTests: XCTestCase {
         )
 
         let result = try await runner.rerunTranscription(
-            entry: makeEntry(),
+            entry: entry,
             speechModelID: "fluid_parakeet-v3",
             speakerTaggingEnabled: true,
             acquirePipeline: { true },
@@ -288,6 +318,7 @@ final class TranscriptionLabRunnerTests: XCTestCase {
                 ]
             )
         )
+        XCTAssertEqual(result.speakerProfiles, resolvedProfiles)
         XCTAssertEqual(speakerTaggingCallCount, 1)
         XCTAssertEqual(transcribeCallCount, 0)
     }

--- a/GhostPepperTests/TranscriptionLabSpeakerProfileStoreTests.swift
+++ b/GhostPepperTests/TranscriptionLabSpeakerProfileStoreTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import GhostPepper
+
+final class TranscriptionLabSpeakerProfileStoreTests: XCTestCase {
+    func testLoadProfilesReturnsEmptyWhenEntryHasNoSavedProfiles() throws {
+        let fixture = makeFixture()
+        let store = TranscriptionLabSpeakerProfileStore(directoryURL: fixture.directoryURL)
+
+        XCTAssertEqual(
+            try store.loadProfiles(for: UUID(uuidString: "00000000-0000-0000-0000-000000000010")!),
+            []
+        )
+    }
+
+    func testUpsertPersistsProfilesForEntryInSpeakerOrder() throws {
+        let fixture = makeFixture()
+        let store = TranscriptionLabSpeakerProfileStore(directoryURL: fixture.directoryURL)
+        let entryID = UUID(uuidString: "00000000-0000-0000-0000-000000000011")!
+        let firstProfile = makeProfile(entryID: entryID, speakerID: "Speaker 1", displayName: "Alice")
+        let secondProfile = makeProfile(entryID: entryID, speakerID: "Speaker 0", displayName: "Bob")
+
+        try store.upsert(firstProfile)
+        try store.upsert(secondProfile)
+
+        XCTAssertEqual(
+            try store.loadProfiles(for: entryID),
+            [secondProfile, firstProfile]
+        )
+    }
+
+    func testUpsertReplacesExistingSpeakerProfile() throws {
+        let fixture = makeFixture()
+        let store = TranscriptionLabSpeakerProfileStore(directoryURL: fixture.directoryURL)
+        let entryID = UUID(uuidString: "00000000-0000-0000-0000-000000000012")!
+
+        try store.upsert(
+            makeProfile(
+                entryID: entryID,
+                speakerID: "Speaker 0",
+                displayName: "Speaker 0"
+            )
+        )
+        try store.upsert(
+            makeProfile(
+                entryID: entryID,
+                speakerID: "Speaker 0",
+                displayName: "Jesse",
+                isMe: true,
+                recognizedVoiceID: UUID(uuidString: "00000000-0000-0000-0000-000000000099")!
+            )
+        )
+
+        XCTAssertEqual(
+            try store.loadProfiles(for: entryID),
+            [
+                makeProfile(
+                    entryID: entryID,
+                    speakerID: "Speaker 0",
+                    displayName: "Jesse",
+                    isMe: true,
+                    recognizedVoiceID: UUID(uuidString: "00000000-0000-0000-0000-000000000099")!
+                )
+            ]
+        )
+    }
+
+    private func makeFixture() -> Fixture {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        return Fixture(directoryURL: directoryURL)
+    }
+
+    private struct Fixture {
+        let directoryURL: URL
+    }
+
+    private func makeProfile(
+        entryID: UUID,
+        speakerID: String,
+        displayName: String,
+        isMe: Bool = false,
+        recognizedVoiceID: UUID? = nil
+    ) -> TranscriptionLabSpeakerProfile {
+        TranscriptionLabSpeakerProfile(
+            entryID: entryID,
+            speakerID: speakerID,
+            displayName: displayName,
+            isMe: isMe,
+            recognizedVoiceID: recognizedVoiceID,
+            evidenceTranscript: "Evidence for \(speakerID)."
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-04-20-speaker-identities.md
+++ b/docs/superpowers/plans/2026-04-20-speaker-identities.md
@@ -1,0 +1,110 @@
+# Speaker Identities Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add durable recognized voices for transcription-lab speaker tagging, with local/global naming controls and speaker labels directly on the lab timeline.
+
+**Architecture:** Keep the existing lab archive format unchanged. Add one global recognized-voices store plus one lab-scoped speaker-snapshot store, resolve names after reruns using extracted speaker embeddings, and surface those resolved names in the lab UI and a new settings pane.
+
+**Tech Stack:** Swift, SwiftUI, Codable JSON stores, FluidAudio diarizer embeddings, XCTest, xcodebuild
+
+---
+
+## Chunk 1: Persistence And Matching
+
+### Task 1: Add the failing store tests
+
+**Files:**
+- Create: `GhostPepperTests/RecognizedVoiceStoreTests.swift`
+- Create: `GhostPepperTests/TranscriptionLabSpeakerProfileStoreTests.swift`
+- Test: `GhostPepperTests/RecognizedVoiceStoreTests.swift`
+- Test: `GhostPepperTests/TranscriptionLabSpeakerProfileStoreTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 2: Run the new store tests and verify they fail for missing types**
+- [ ] **Step 3: Add `RecognizedVoiceProfile`, `RecognizedVoiceStore`, `TranscriptionLabSpeakerProfile`, and `TranscriptionLabSpeakerProfileStore`**
+- [ ] **Step 4: Run the store tests and verify they pass**
+- [ ] **Step 5: Commit**
+
+### Task 2: Add the failing matching tests
+
+**Files:**
+- Create: `GhostPepper/SpeakerIdentity/SpeakerIdentityMatcher.swift`
+- Create: `GhostPepperTests/SpeakerIdentityMatcherTests.swift`
+- Test: `GhostPepperTests/SpeakerIdentityMatcherTests.swift`
+
+- [ ] **Step 1: Write tests for auto-match, auto-create, and explicit global update behavior**
+- [ ] **Step 2: Run the matcher tests and verify they fail**
+- [ ] **Step 3: Implement minimal matching and embedding averaging logic**
+- [ ] **Step 4: Run the matcher tests and verify they pass**
+- [ ] **Step 5: Commit**
+
+## Chunk 2: Lab Identity Resolution
+
+### Task 3: Add the failing controller tests
+
+**Files:**
+- Modify: `GhostPepper/Lab/TranscriptionLabController.swift`
+- Modify: `GhostPepperTests/TranscriptionLabControllerTests.swift`
+
+- [ ] **Step 1: Add tests for resolved speaker names, local rename state, and promote-global affordances**
+- [ ] **Step 2: Run the controller tests and verify they fail**
+- [ ] **Step 3: Extend `TranscriptionLabController` with speaker profile view state and rename/update actions**
+- [ ] **Step 4: Run the controller tests and verify they pass**
+- [ ] **Step 5: Commit**
+
+### Task 4: Add the failing app-state tests
+
+**Files:**
+- Modify: `GhostPepper/AppState.swift`
+- Modify: `GhostPepperTests/GhostPepperTests.swift`
+
+- [ ] **Step 1: Add tests proving lab reruns create or match recognized voices and snapshot lab speaker profiles**
+- [ ] **Step 2: Run the focused app-state tests and verify they fail**
+- [ ] **Step 3: Wire the new stores and speaker-identity resolution into lab reruns**
+- [ ] **Step 4: Run the focused app-state tests and verify they pass**
+- [ ] **Step 5: Commit**
+
+## Chunk 3: UI
+
+### Task 5: Add the failing settings and timeline tests where practical
+
+**Files:**
+- Modify: `GhostPepper/UI/SettingsWindow.swift`
+- Modify: `GhostPepperTests/TranscriptionLabControllerTests.swift`
+- Test: `GhostPepperTests/MeetingTranscriptWindowPresentationTests.swift`
+
+- [ ] **Step 1: Add view-model-level tests for timeline label inputs and recognized-voice section data**
+- [ ] **Step 2: Run the focused tests and verify they fail**
+- [ ] **Step 3: Add the `Recognized Voices` settings section**
+- [ ] **Step 4: Add lab speaker editor rows, resolved speaker transcript rendering, and direct timeline labels for all speakers**
+- [ ] **Step 5: Run the focused tests and verify they pass**
+- [ ] **Step 6: Commit**
+
+## Chunk 4: Verification And Release
+
+### Task 6: Verify the whole slice
+
+**Files:**
+- Modify: `GhostPepper.xcodeproj` (only if required by compiler errors)
+
+- [ ] **Step 1: Run the focused test suites**
+
+```bash
+xcodebuild test -project GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS' -skipMacroValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY='' -only-testing:GhostPepperTests/RecognizedVoiceStoreTests -only-testing:GhostPepperTests/TranscriptionLabSpeakerProfileStoreTests -only-testing:GhostPepperTests/SpeakerIdentityMatcherTests -only-testing:GhostPepperTests/TranscriptionLabControllerTests -only-testing:GhostPepperTests/GhostPepperTests
+```
+
+- [ ] **Step 2: Run a release build**
+
+```bash
+xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Release -destination 'platform=macOS,arch=arm64' -skipMacroValidation DEVELOPMENT_TEAM=87WJ58S66M CODE_SIGN_IDENTITY='Apple Development' build
+```
+
+- [ ] **Step 3: Copy the built app into `/Applications/GhostPepper.app`**
+
+```bash
+ditto build/Build/Products/Release/GhostPepper.app /Applications/GhostPepper.app
+```
+
+- [ ] **Step 4: Confirm the installed app is signed and reflects the fresh build**
+- [ ] **Step 5: Commit**

--- a/docs/superpowers/specs/2026-04-20-speaker-identities-design.md
+++ b/docs/superpowers/specs/2026-04-20-speaker-identities-design.md
@@ -1,0 +1,187 @@
+# Speaker Identities Design
+
+## Goal
+
+Add durable speaker identities on top of transcription-lab speaker tagging so Jesse can:
+
+- see speaker names directly on the speaker-tagging timeline
+- rename speakers locally within a lab recording
+- optionally push a local rename into a global recognized-voices store
+- mark multiple recognized voices as `me`
+- carry those global voice identities forward into future speaker-tagged lab reruns
+
+This slice is intentionally limited to the transcription lab and global settings. The live meeting transcript flow still only produces `me` versus `others`, so it does not have the per-speaker diarization data needed for the same identity workflow yet.
+
+## Current Context
+
+- The transcription lab already stores archived recordings and can rerun speaker tagging.
+- Speaker-tagged reruns already produce:
+  - diarized spans
+  - a speaker-tagged transcript
+  - a color timeline in Settings
+- The current app only exposes anonymous session-local speaker IDs such as `Speaker 0`.
+- Ghost Pepper already depends on `FluidAudio`, and that package exposes:
+  - speaker embedding extraction through `DiarizerManager.extractSpeakerEmbedding(from:)`
+  - cosine-distance speaker matching helpers
+  - speaker enrollment APIs for future extensions
+
+## Non-Goals
+
+- no live meeting diarization
+- no retroactive relabeling of past lab recordings after a global voice changes
+- no attempt to rewrite existing lab archive formats
+- no automatic merging UI for similar global voices in this slice
+
+## Approach Options
+
+### Option 1: Local aliases only
+
+Store per-recording speaker names and never create a global identity store.
+
+Pros:
+
+- smallest code change
+- no matching risk
+
+Cons:
+
+- does not help future sessions
+- does not support recognized voices settings
+
+### Option 2: Global profiles backed by stored enrollment audio
+
+Persist a short audio sample for each global voice, then pre-enroll those voices into Sortformer before future diarization runs.
+
+Pros:
+
+- reuses Sortformer enrollment directly
+- avoids storing explicit embedding vectors
+
+Cons:
+
+- matching behavior becomes opaque
+- harder to explain or debug why a match happened
+- awkward to show confidence or update a profile incrementally
+
+### Option 3: Global profiles backed by extracted embeddings
+
+Extract an embedding for each speaker from merged speaker audio, persist the embedding with metadata, and match future speakers by cosine distance.
+
+Pros:
+
+- explicit, testable matching behavior
+- easy to snapshot a session-local resolved name while keeping future matching global
+- easy to allow multiple voice prints per person
+
+Cons:
+
+- introduces a new persistent store
+- first use may need to download the diarizer embedding models
+
+## Chosen Design
+
+Use global recognized voices backed by extracted embeddings, with a separate per-lab-recording speaker snapshot.
+
+### Data Model
+
+Add a global `RecognizedVoiceStore` under Application Support with:
+
+- `RecognizedVoiceProfile`
+  - `id`
+  - `displayName`
+  - `isMe`
+  - `embedding`
+  - `updateCount`
+  - `createdAt`
+  - `updatedAt`
+  - `evidenceTranscript`
+
+Add a separate lab-scoped `TranscriptionLabSpeakerProfileStore` with per-entry speaker snapshots:
+
+- `TranscriptionLabSpeakerProfile`
+  - `entryID`
+  - `speakerID`
+  - `displayName`
+  - `isMe`
+  - `recognizedVoiceID`
+  - `evidenceTranscript`
+
+These stores are separate from the existing transcription-lab archive so existing entries keep loading unchanged.
+
+### Matching
+
+When a speaker-tagged rerun completes:
+
+1. merge all spans for each speaker
+2. extract the speaker-only audio
+3. extract one speaker embedding from that merged audio
+4. compare that embedding against all global recognized voices
+5. if the closest match is inside a conservative auto-match threshold, snapshot that global identity onto the lab recording
+6. otherwise create a new global recognized voice with placeholder naming and snapshot that onto the lab recording
+
+If the same global voice matches again later, update its stored embedding by averaging the old and new normalized embeddings, then re-normalizing.
+
+### Local Versus Global Naming
+
+The lab recording owns the displayed name for that recording.
+
+- Renaming a speaker inside the recording updates only the lab-scoped snapshot.
+- After a local change, show an inline `Update global voice print` action.
+- Pressing that action writes the current local name and `isMe` value into the linked global recognized voice.
+- Past recordings are not relabeled when a global profile changes.
+
+This preserves Jesse’s “future sessions only” rule.
+
+### UI
+
+#### Transcription Lab
+
+Extend the lab speaker-tagging detail with:
+
+- labels drawn directly on the timeline for all speakers
+- a per-speaker editor row showing:
+  - color
+  - current display name
+  - `This is me` checkbox
+  - evidence transcript snippet
+  - inline `Update global voice print` button when local and global values differ
+- the speaker-tagged transcript rendered with resolved display names instead of raw `Speaker N`
+
+#### Settings
+
+Add a new Settings section: `Recognized Voices`.
+
+Show one row per global voice print with:
+
+- editable name
+- `This is me` checkbox
+- last updated date
+- evidence transcript
+
+This is a voice-print list, not a person graph. Multiple rows may be marked as `me`.
+
+## Error Handling
+
+- If embedding extraction fails for a speaker, keep the raw speaker ID for that speaker and do not create a global profile.
+- If diarizer embedding models fail to download or load, speaker tagging still succeeds; only identity matching is skipped.
+- If a recording has too little usable speaker audio, skip identity creation for that speaker.
+
+## Testing
+
+Add focused tests for:
+
+- recognized voice store persistence
+- lab speaker snapshot store persistence
+- controller formatting and display-name resolution
+- matching logic:
+  - auto-match to an existing recognized voice
+  - auto-create a new recognized voice when no match exists
+  - local rename does not mutate the global profile until explicitly promoted
+  - global updates do not rewrite older lab snapshots
+- timeline display order still follows diarization span order
+
+## Risks
+
+- embedding thresholds may need tuning on real recordings
+- auto-created voice prints can still duplicate the same person when the audio is poor
+- this does not yet solve live meeting diarization because that pipeline does not emit per-speaker spans


### PR DESCRIPTION
## Summary
- Reduce stop-path transcription latency and preserve the existing live Parakeet fallback behavior after reverting the attempted removal of the fake streaming path.
- Add lab speaker-tagging workflows: rerun toggle, speaker-tagged transcript output, speaker labels on the timeline, and fallback repair when diarization produces unusable filtered text.
- Add recognized voice identities with global voice prints, local meeting labels, `This is me` support, history entries that render against the latest global voice data, and settings UI for recognized voices.
- Harden diarization/speaker tagging so single-speaker tagging failures fall back or rescue boundaries with VAD instead of replacing a correct transcript with a tail fragment like `Yeah.`.
- Fix the GhostPepper signing team so local Release builds sign with Jesse's team by default.

## Testing
- `xcodebuild test -project GhostPepper.xcodeproj -scheme GhostPepper -destination 'platform=macOS' -skipMacroValidation` — 316 tests, 0 failures
- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Release -destination 'platform=macOS,arch=arm64' -skipMacroValidation build`
- Installed `/Applications/GhostPepper.app` verifies as `Apple Development: Jesse Vincent (P82MJJHK76)` on team `87WJ58S66M`

Follow-up to the already-merged streaming transcription work in #81.
