### PR TITLE
fix(settings): make entire sidebar row hit-testable

### DIFF
--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -257,6 +257,11 @@ struct SettingsView: View {
                         .padding(.horizontal, 12)
                         .padding(.vertical, 10)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        // Make the full row (icon + text + surrounding padding + trailing
+                        // whitespace) hit-testable. Without this, SwiftUI hit-tests a plain
+                        // Button against the opaque pixels of its label — so clicks landed only
+                        // on the visible text/icon, not the empty space in the row. (Fixes #74.)
+                        .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         .background(
                             RoundedRectangle(cornerRadius: 12, style: .continuous)
                                 .fill(selectedSection == section ? Color(nsColor: .selectedContentBackgroundColor).opacity(0.22) : .clear)
@@ -272,7 +277,6 @@ struct SettingsView: View {
                         )
                     }
                     .buttonStyle(.plain)
-                    .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                 }
 
                 Spacer(minLength: 0)


### PR DESCRIPTION
## Summary

Fixes #74 -- sidebar navigation items in Ghost Pepper Settings had inconsistent hit targets:
- the icon responded only to clicks on its non-transparent pixels
- the title text responded only to the exact width of the string
- the description text (multi-line) responded only within the longest line
- the padding and the trailing whitespace of the Spacer were not clickable at all

## Root cause

`Button` with `.buttonStyle(.plain)` hit-tests against the **label's opaque rendered content**, not against the label's frame. The `.contentShape(RoundedRectangle(...))` modifier was applied to the Button itself, outside the label -- which doesn't propagate into label hit testing.

## Fix

Move `.contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))` **inside** the label, immediately after the HStack's `.frame(maxWidth: .infinity, alignment: .leading)` and before the row `.background(...)`. The whole rounded-rect row (icon + text + surrounding padding + trailing whitespace) is now the hit region.

Diff is 5 lines: move one modifier and add a short comment explaining why it must live inside the label.

## Verification

Visually, every row in the Settings sidebar now activates from any pixel inside its rounded-rect bounds -- including the empty space to the right of the title, the multi-line description's wrap area, and the padding around the icon. The selected-state border and fill are unchanged (still rendered by `.background`/`.overlay` after the `.contentShape`).

## Test plan

- [ ] Open Settings on macOS 15+
- [ ] Click in the padding around each sidebar icon -- row selects
- [ ] Click to the right of any title text -- row selects
- [ ] Click in the whitespace below/beside a multi-line description -- row selects
- [ ] Selected-row highlight and border still render correctly

Closes #74