### PR TITLE
Fix Bluetooth headphones switching to HFP profile during/after recording

### DIFF
--- a/GhostPepper/Audio/AudioRecorder.swift
+++ b/GhostPepper/Audio/AudioRecorder.swift
@@ -25,12 +25,7 @@ final class AudioRecorder {
         AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 16000, channels: 1, interleaved: false)!
     }()
 
-    /// Pre-warm the audio engine so the first recording starts faster.
-    func prewarm() {
-        applyTargetDeviceIfNeeded()
-        _ = engine.inputNode // Force node initialization
-        engine.prepare()
-    }
+    func prewarm() {}
 
     /// Reset the audio engine to pick up a newly selected input route.
     /// Call this after changing the microphone selection in Settings.
@@ -219,6 +214,7 @@ final class AudioRecorder {
 
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
+        rebuildEngine()
         onRecordingStopped?()
 
         let result = snapshotBuffer()


### PR DESCRIPTION
## Problem

Users with Bluetooth headphones experience them switching into the low-quality headset (HFP/HSP) profile while Ghost Pepper is running — even when not actively recording. This causes noticeably worse audio quality for music and calls.

Two causes:

1. **Prewarm at startup**: `AudioRecorder.prewarm()` accessed `engine.inputNode` and called `engine.prepare()` — enough for CoreAudio to claim the microphone input, which triggers the HFP profile switch on Bluetooth devices.
2. **Engine retained after stop**: After `stopRecording()`, the `AVAudioEngine` instance was kept alive (by design, to speed up the next recording start). But a stopped engine with an initialized `inputNode` still holds CoreAudio's device reference, keeping headphones in HFP until the next recording starts.

## Fix

- **Disable prewarm** — `prewarm()` is now a no-op. The latency benefit was small; the HFP impact is significant.
- **Rebuild engine after stop** — call `rebuildEngine()` at the end of `stopRecording()` so CoreAudio releases the input device immediately when the user finishes dictating.

## Test

1. Connect Bluetooth headphones
2. Launch Ghost Pepper — headphones should stay in stereo (A2DP) mode
3. Record a dictation, stop — headphones should return to stereo immediately