### PR TITLE
Restore default local signing team

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -730,7 +730,7 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					5EBC085BD56A3725D371FB1A = {
-						DevelopmentTeam = 87WJ58S66M;
+						DevelopmentTeam = BBVMGXR9AY;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -955,7 +955,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 87WJ58S66M;
+				DEVELOPMENT_TEAM = BBVMGXR9AY;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				INFOPLIST_FILE = GhostPepper/Info.plist;
@@ -1102,7 +1102,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 87WJ58S66M;
+				DEVELOPMENT_TEAM = BBVMGXR9AY;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				INFOPLIST_FILE = GhostPepper/Info.plist;


### PR DESCRIPTION
## Summary
- Change the GhostPepper target signing team back from `87WJ58S66M` to `BBVMGXR9AY`.
- Restore the target attribute plus Debug and Release `DEVELOPMENT_TEAM` values to the previous local signing configuration.

## Testing
- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -showBuildSettings -skipMacroValidation | rg "DEVELOPMENT_TEAM|CODE_SIGN_STYLE|CODE_SIGN_IDENTITY"` — confirmed `DEVELOPMENT_TEAM = BBVMGXR9AY`
- `xcodebuild -project GhostPepper.xcodeproj -scheme GhostPepper -configuration Debug -destination 'platform=macOS' -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
