### PR TITLE
Persist selected microphones by CoreAudio UID

### DIFF
--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Combine
+import CoreAudio
 import ServiceManagement
 
 enum AppStatus: String {
@@ -159,6 +160,8 @@ class AppState: ObservableObject {
     private let cleanupSettingsDefaults: UserDefaults
     private let inputMonitoringChecker: () -> Bool
     private let inputMonitoringPrompter: () -> Void
+    private let selectedInputDeviceIDProvider: () -> AudioDeviceID?
+    private let resetAudioRecorder: () -> Void
     private var hotkeyMonitorStarted = false
 
     private static let cleanupBackendDefaultsKey = "cleanupBackend"
@@ -169,6 +172,7 @@ class AppState: ObservableObject {
     private static let pepperChatEnabledDefaultsKey = "pepperChatEnabled"
     private static let emptyTranscriptionCancelThresholdSampleCount = 8_000 // ~0.5 seconds — show "no sound" hint for almost all failed recordings
     private static let speechModelErrorPrefix = "Failed to load speech model: "
+    static let liveRecordingNoInputErrorMessage = "Failed to start recording: No audio input device available."
 
     nonisolated static let defaultPushToTalkChord = KeyChord(keys: Set([
         PhysicalKey(keyCode: 54),  // Right Command
@@ -208,7 +212,9 @@ class AppState: ObservableObject {
         transcriptionLabSpeakerProfileStore: TranscriptionLabSpeakerProfileStore = TranscriptionLabSpeakerProfileStore(),
         appRelauncher: AppRelaunching? = nil,
         inputMonitoringChecker: @escaping () -> Bool = PermissionChecker.checkInputMonitoring,
-        inputMonitoringPrompter: @escaping () -> Void = PermissionChecker.promptInputMonitoring
+        inputMonitoringPrompter: @escaping () -> Void = PermissionChecker.promptInputMonitoring,
+        selectedInputDeviceIDProvider: @escaping () -> AudioDeviceID? = { AudioDeviceManager.selectedInputDeviceID() },
+        resetAudioRecorder: (() -> Void)? = nil
     ) {
         self.hotkeyMonitor = hotkeyMonitor
         self.chordBindingStore = chordBindingStore
@@ -222,6 +228,10 @@ class AppState: ObservableObject {
         self.appRelauncher = appRelauncher ?? AppRelauncher()
         self.inputMonitoringChecker = inputMonitoringChecker
         self.inputMonitoringPrompter = inputMonitoringPrompter
+        self.selectedInputDeviceIDProvider = selectedInputDeviceIDProvider
+        self.resetAudioRecorder = resetAudioRecorder ?? { [audioRecorder] in
+            audioRecorder.resetForDeviceChange()
+        }
         self.pushToTalkChord = chordBindingStore.binding(for: .pushToTalk) ?? AppState.defaultPushToTalkChord
         self.toggleToTalkChord = chordBindingStore.binding(for: .toggleToTalk) ?? AppState.defaultToggleToTalkChord
         self.pepperChatChord = chordBindingStore.binding(for: .pepperChat) ?? AppState.defaultPepperChatChord
@@ -698,7 +708,7 @@ class AppState: ObservableObject {
                 textCleanupManager.cancelPromptPrefill()
             }
             mediaPlaybackController.pauseIfPlaying()
-            audioRecorder.targetDeviceID = AudioDeviceManager.selectedInputDeviceID()
+            audioRecorder.targetDeviceID = selectedInputDeviceIDProvider()
             try audioRecorder.startRecording()
             debugLogStore.record(category: .hotkey, message: "Recording started.")
             soundEffects.playStart()
@@ -1021,9 +1031,20 @@ class AppState: ObservableObject {
         return session
     }()
 
+    var canReloadAudioInput: Bool {
+        Self.isLiveRecordingNoInputError(errorMessage)
+    }
+
     func resetAudioEngine() {
-        audioRecorder.targetDeviceID = AudioDeviceManager.selectedInputDeviceID()
-        audioRecorder.resetForDeviceChange()
+        audioRecorder.targetDeviceID = selectedInputDeviceIDProvider()
+        resetAudioRecorder()
+
+        if shouldClearLiveRecordingNoInputErrorAfterAudioReset {
+            errorMessage = nil
+            status = .ready
+            debugLogStore.record(category: .model, message: "Audio engine reset cleared stale no-input recording error.")
+        }
+
         debugLogStore.record(category: .model, message: "Audio engine reset for device change.")
     }
 
@@ -1928,5 +1949,13 @@ class AppState: ObservableObject {
         case .idle, .loading:
             return (currentStatus, currentErrorMessage)
         }
+    }
+
+    private var shouldClearLiveRecordingNoInputErrorAfterAudioReset: Bool {
+        status == .error && !isRecording && !isTranscribing && Self.isLiveRecordingNoInputError(errorMessage)
+    }
+
+    private static func isLiveRecordingNoInputError(_ message: String?) -> Bool {
+        message == liveRecordingNoInputErrorMessage
     }
 }

--- a/GhostPepper/Audio/AudioDeviceManager.swift
+++ b/GhostPepper/Audio/AudioDeviceManager.swift
@@ -3,10 +3,13 @@ import Foundation
 
 struct AudioInputDevice: Identifiable, Equatable {
     let id: AudioDeviceID
+    let uid: String
     let name: String
 }
 
 class AudioDeviceManager {
+    private static let selectedInputDeviceIDKey = "selectedInputDeviceID"
+    private static let selectedInputDeviceUIDKey = "selectedInputDeviceUID"
 
     /// Returns all available audio input devices.
     static func listInputDevices() -> [AudioInputDevice] {
@@ -31,8 +34,9 @@ class AudioDeviceManager {
         return deviceIDs.compactMap { deviceID -> AudioInputDevice? in
             // Check if device has input channels
             guard hasInputChannels(deviceID: deviceID) else { return nil }
+            guard let uid = deviceUID(deviceID: deviceID), !uid.isEmpty else { return nil }
             guard let name = deviceName(deviceID: deviceID) else { return nil }
-            return AudioInputDevice(id: deviceID, name: name)
+            return AudioInputDevice(id: deviceID, uid: uid, name: name)
         }
     }
 
@@ -55,14 +59,29 @@ class AudioDeviceManager {
     /// Persists the selected input device ID for Ghost Pepper's use.
     /// Does NOT change the system-wide default — the device is set directly
     /// on the audio unit when recording starts.
-    static func setSelectedInputDevice(_ deviceID: AudioDeviceID) {
-        UserDefaults.standard.set(Int(deviceID), forKey: "selectedInputDeviceID")
+    static func setSelectedInputDevice(
+        _ deviceID: AudioDeviceID,
+        defaults: UserDefaults = .standard,
+        uidForDeviceID: (AudioDeviceID) -> String? = AudioDeviceManager.deviceUID
+    ) {
+        guard let uid = uidForDeviceID(deviceID), !uid.isEmpty else {
+            return
+        }
+
+        defaults.set(uid, forKey: selectedInputDeviceUIDKey)
     }
 
     /// Returns the user's selected input device ID, or nil to use the system default.
-    static func selectedInputDeviceID() -> AudioDeviceID? {
-        let stored = UserDefaults.standard.integer(forKey: "selectedInputDeviceID")
-        return stored > 0 ? AudioDeviceID(stored) : nil
+    static func selectedInputDeviceID(
+        defaults: UserDefaults = .standard,
+        inputDevices: () -> [AudioInputDevice] = AudioDeviceManager.listInputDevices,
+        uidForDeviceID: (AudioDeviceID) -> String? = AudioDeviceManager.deviceUID
+    ) -> AudioDeviceID? {
+        guard let uid = selectedInputDeviceUID(defaults: defaults, uidForDeviceID: uidForDeviceID) else {
+            return nil
+        }
+
+        return inputDevices().first(where: { $0.uid == uid })?.id
     }
 
     /// Sets the system default input device.
@@ -110,9 +129,39 @@ class AudioDeviceManager {
         return bufferList.reduce(0) { $0 + Int($1.mNumberChannels) } > 0
     }
 
+    static func selectedInputDeviceUID(
+        defaults: UserDefaults = .standard,
+        uidForDeviceID: (AudioDeviceID) -> String? = AudioDeviceManager.deviceUID
+    ) -> String? {
+        if let uid = defaults.string(forKey: selectedInputDeviceUIDKey), !uid.isEmpty {
+            return uid
+        }
+
+        guard let legacyStoredID = defaults.object(forKey: selectedInputDeviceIDKey) as? Int,
+              legacyStoredID > 0,
+              let uid = uidForDeviceID(AudioDeviceID(legacyStoredID)),
+              !uid.isEmpty else {
+            return nil
+        }
+
+        defaults.set(uid, forKey: selectedInputDeviceUIDKey)
+        return uid
+    }
+
+    static func deviceUID(deviceID: AudioDeviceID) -> String? {
+        deviceStringProperty(deviceID: deviceID, selector: kAudioDevicePropertyDeviceUID)
+    }
+
     private static func deviceName(deviceID: AudioDeviceID) -> String? {
+        deviceStringProperty(deviceID: deviceID, selector: kAudioDevicePropertyDeviceNameCFString)
+    }
+
+    private static func deviceStringProperty(
+        deviceID: AudioDeviceID,
+        selector: AudioObjectPropertySelector
+    ) -> String? {
         var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyDeviceNameCFString,
+            mSelector: selector,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )

--- a/GhostPepper/UI/MenuBarView.swift
+++ b/GhostPepper/UI/MenuBarView.swift
@@ -62,6 +62,11 @@ struct MenuBarView: View {
                     .foregroundStyle(.red)
                     .padding(.horizontal, 14)
 
+                if appState.canReloadAudioInput {
+                    Button("Reload Audio Input") {
+                        appState.resetAudioEngine()
+                    }
+                }
                 if error.contains("Input Monitoring") {
                     Button("Open Input Monitoring Settings") {
                         PermissionChecker.openInputMonitoringSettings()

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -1880,6 +1880,128 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(PermissionChecker.microphoneStatus(), .denied)
     }
 
+    func testAudioDeviceManagerPersistsSelectedDeviceUID() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        AudioDeviceManager.setSelectedInputDevice(157, defaults: defaults) { deviceID in
+            XCTAssertEqual(deviceID, 157)
+            return "studio-display"
+        }
+
+        XCTAssertEqual(defaults.string(forKey: "selectedInputDeviceUID"), "studio-display")
+    }
+
+    func testAudioDeviceManagerMigratesLegacyDeviceIDToUIDAndResolvesCurrentDeviceID() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        defaults.set(157, forKey: "selectedInputDeviceID")
+
+        let resolvedID = AudioDeviceManager.selectedInputDeviceID(
+            defaults: defaults,
+            inputDevices: {
+                [AudioInputDevice(id: 142, uid: "studio-display", name: "Studio Display Microphone")]
+            },
+            uidForDeviceID: { deviceID in
+                XCTAssertEqual(deviceID, 157)
+                return "studio-display"
+            }
+        )
+
+        XCTAssertEqual(resolvedID, 142)
+        XCTAssertEqual(defaults.string(forKey: "selectedInputDeviceUID"), "studio-display")
+    }
+
+    func testAudioDeviceManagerResolvesCurrentDeviceIDFromSavedUID() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        defaults.set("studio-display", forKey: "selectedInputDeviceUID")
+
+        let resolvedID = AudioDeviceManager.selectedInputDeviceID(
+            defaults: defaults,
+            inputDevices: {
+                [AudioInputDevice(id: 142, uid: "studio-display", name: "Studio Display Microphone")]
+            },
+            uidForDeviceID: { _ in
+                XCTFail("saved UID should skip legacy device ID lookup")
+                return nil
+            }
+        )
+
+        XCTAssertEqual(resolvedID, 142)
+    }
+
+    func testAudioDeviceManagerReturnsNilWhenSavedUIDDoesNotResolve() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        defaults.set("missing-device", forKey: "selectedInputDeviceUID")
+
+        let resolvedID = AudioDeviceManager.selectedInputDeviceID(
+            defaults: defaults,
+            inputDevices: { [] },
+            uidForDeviceID: { _ in
+                XCTFail("saved UID should skip legacy device ID lookup")
+                return nil
+            }
+        )
+
+        XCTAssertNil(resolvedID)
+    }
+
+    func testResetAudioEngineClearsLiveRecordingNoInputErrorWhenIdle() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        var resetCallCount = 0
+        let appState = AppState(
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            selectedInputDeviceIDProvider: { 142 },
+            resetAudioRecorder: {
+                resetCallCount += 1
+            }
+        )
+        appState.status = .error
+        appState.errorMessage = AppState.liveRecordingNoInputErrorMessage
+
+        appState.resetAudioEngine()
+
+        XCTAssertEqual(appState.audioRecorder.targetDeviceID, 142)
+        XCTAssertEqual(resetCallCount, 1)
+        XCTAssertEqual(appState.status, .ready)
+        XCTAssertNil(appState.errorMessage)
+    }
+
+    func testResetAudioEngineKeepsUnrelatedErrorState() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        var resetCallCount = 0
+        let appState = AppState(
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            selectedInputDeviceIDProvider: { nil },
+            resetAudioRecorder: {
+                resetCallCount += 1
+            }
+        )
+        appState.status = .error
+        appState.errorMessage = "Microphone access required"
+
+        appState.resetAudioEngine()
+
+        XCTAssertEqual(resetCallCount, 1)
+        XCTAssertEqual(appState.status, .error)
+        XCTAssertEqual(appState.errorMessage, "Microphone access required")
+    }
+
     private static func makeDiarizationSummary(usedFallback: Bool) -> DiarizationSummary {
         DiarizationSummary(
             spans: [


### PR DESCRIPTION
Fix for #87 

Edit: 
Been using this fix for days now, everything seems to work right.

Agentspeak below:

--- 

## Summary
- Persist selected microphones by CoreAudio UID instead of transient `AudioDeviceID` values.
- Re-resolve the active input on audio reset and surface `Reload Audio Input` only for stale no-input failures.
- Add focused tests for UID migration, device resolution, and idle error recovery.

## Plan

This is the plan/prompt I used to with codex 5.4 to fix it:

```md
# Plan

## Overview

### Problem
Ghost Pepper’s live/hotkey recorder can get stuck in warning-triangle mode with:

- `Failed to start recording: No audio input device available.`

When that happens:
- the menu bar icon switches to the warning triangle
- the hotkey path is wedged behind `status == .error`
- Settings test dictation can still work because it creates a fresh `AudioRecorder()`
- changing the microphone in Settings currently rebuilds the engine but does not reliably recover the warning state

### Observed evidence
The failing machine session already proved that raw `AudioDeviceID` persistence is unstable for this use case:
- Ghost Pepper preferences contained `selectedInputDeviceID = 157`
- CoreAudio resolved both device ID `142` and device ID `157` to `Studio Display Microphone`
- Ghost Pepper successfully opened the Studio Display microphone earlier in the session, then later failed after device churn

That means the selected microphone remained the same logical device while its `AudioDeviceID` changed.

### Authoritative Apple documentation
Apple’s CoreAudio docs support a UID-based device identity model:

- `kAudioDevicePropertyDeviceUID`
  - <https://developer.apple.com/documentation/coreaudio/kaudiodevicepropertydeviceuid>
- `AudioHardwareSystem.device(forUID:)`
  - <https://developer.apple.com/documentation/coreaudio/audiohardwaresystem/device(foruid:)>
- `AudioHardwareDevice`
  - <https://developer.apple.com/documentation/coreaudio/audiohardwaredevice>

Relevant Apple statements:

> `kAudioDevicePropertyDeviceUID`

> `AudioHardwareSystem.device(forUID:)`

> `Hidden devices can only be obtained from the system by UID.`

### Existing Ghost Pepper intent to preserve
Ghost Pepper intentionally targets the chosen device directly on the audio unit instead of changing the system default device:

> `Does NOT change the system-wide default — the device is set directly on the audio unit when recording starts.`

`AudioRecorder` also intentionally keeps one engine alive for hotkey latency:

> `Kept alive across recordings so AVFAudio does not have to re-run device discovery on every hotkey press. We only rebuild when the user explicitly changes the target input device or asks for an audio reset.`

The fix must preserve both of those choices.

### Chosen fix
Do **not** move recovery logic into every hotkey press, do **not** add wake observers, and do **not** widen the live start path.

Instead:
- keep the current failure-driven architecture
- replace the durable microphone identity behind the existing selection accessor with a UID-backed model
- keep direct audio-unit targeting exactly as is
- when the app is already in warning-triangle mode for this failure, expose an explicit reload action in the menu
- make that reload action rebuild the shared recorder, re-resolve the selected microphone via UID, and clear the stale error state when the reset succeeds

This keeps the code change local and fixes the real bug: Ghost Pepper cannot currently recover its chosen mic after `AudioDeviceID` churn.

## User Decisions

- Preserve direct device targeting through `kAudioOutputUnitProperty_CurrentDevice`.
- Do not change the system-wide default microphone.
- Choose failure-driven recovery, not proactive bind-time or wake-time recovery.
- Add a reload action to the warning-triangle menu state.

## Explicit Flow Decisions

### 1. Keep the existing runtime architecture
Do not add new global recovery triggers such as:
- wake observers
- device-list change observers
- extra hotkey-path preflight logic on every recording attempt beyond what already exists

Reason:
- the current app already has a visible broken state (`.error` + warning triangle)
- the problem to solve is recovery from that state, not preventing every possible first post-churn failure

### 2. Fix the persisted identity, not the direct-targeting model
Current durable selection is stored as:
- `selectedInputDeviceID`

That is the wrong durable identity because the same logical microphone can reappear under a different `AudioDeviceID`.

Add a new canonical key:
- `selectedInputDeviceUID`

Why a new key instead of replacing the old key in place:
- existing installs already persist an integer under `selectedInputDeviceID`
- a new key makes migration explicit and testable
- the old key can be treated as legacy input during migration instead of mixing two data types in one defaults slot
- the simplest correct reload path still needs a stable way to recover the user’s chosen mic after ID churn; UID is that identity

Rejected alternatives:
- keep raw `AudioDeviceID`
  - rejected because the observed failure already disproved its durability
- persist microphone name
  - rejected because names are not guaranteed unique or stable
- replace the existing defaults key in place
  - rejected because it complicates migration and fallback behavior for little benefit

### 3. Do not move resolution logic into new places unnecessarily
Do not introduce a new “resolve before every hotkey press” architecture.

Instead:
- keep the current call sites that already ask `AudioDeviceManager` for the selected input device ID
- change the implementation of `AudioDeviceManager.selectedInputDeviceID()` so it resolves the current `AudioDeviceID` from the stored UID

This is the critical simplification.

It means:
- no new architectural step is added to the hotkey event path
- existing recorder start/reset paths automatically benefit from UID-backed resolution
- the app stays structurally the same while the selected-device lookup becomes correct

### 4. Recovery happens only when the app is already broken
The warning triangle is the explicit user-facing recovery state.

When the app is in that state for a live-recording input-device failure:
- show a reload action in the menu
- clicking reload should run the shared recorder reset path
- after reload, the next hotkey press should use the re-resolved current device ID

Do not add automatic retry loops or hidden background recovery in this first fix.

### 5. Reuse `resetAudioEngine()` as the recovery primitive
`AppState.resetAudioEngine()` already exists and already rebuilds the shared recorder.

The chosen fix should make this the single recovery primitive by extending it to:
- set `audioRecorder.targetDeviceID` using the UID-backed selected-device resolver
- rebuild/prewarm the recorder
- clear stale no-input error state when idle

That same method should be used by:
- microphone changes in Settings
- the new warning-triangle menu reload action

### 6. Scope of the reload menu action
Add the reload action only for the relevant broken state.

Specifically:
- when `appState.errorMessage` represents the live recording no-input failure
- not for arbitrary unrelated errors

The existing `MenuBarView` already conditionally shows error-specific actions for Input Monitoring, Accessibility, and Microphone permissions. The reload action should follow that existing pattern.

## Files to modify

Primary files:
- `Audio/AudioDeviceManager.swift`
- `AppState.swift`
- `UI/MenuBarView.swift`

Likely touched call-site file only if needed by compile fallout or selection display updates:
- `UI/SettingsWindow.swift`

Tests:
- `Tests/GhostPepperTests.swift`
- `Tests/AudioRecorderTests.swift` only if a new seam lands there indirectly
- add a focused `AudioDeviceManager` test file if that is the cleanest place to cover migration and UID resolution behavior

## Reuse

### Existing production code to reuse
- `AudioDeviceManager.listInputDevices()`
  - extend this instead of adding a second enumerator
- `AudioDeviceManager.setSelectedInputDevice(_:)`
  - keep this public API and change its persistence behavior internally
- `AudioDeviceManager.selectedInputDeviceID()`
  - keep this public API and change its implementation to resolve the current ID from UID
- `AudioDeviceManager.defaultInputDeviceID()`
  - keep as the fallback when no saved UID can be resolved
- `AppState.resetAudioEngine()`
  - make this the single shared recovery action
- `SettingsView.recordingSection`
  - it already persists the selected device and triggers the shared reset path
- `MenuBarView` error-action pattern
  - it already shows conditional buttons for permission-related errors

### Existing behavior to preserve
- direct audio-unit targeting in `AudioRecorder.applyTargetDeviceIfNeeded()`
- shared `AVAudioEngine` model in `AudioRecorder`
- current hotkey start/stop flow in `AppState.startRecording()` / `stopRecordingAndTranscribe()`
- fresh-recorder behavior in Settings test dictation

## Steps

1. **Extend `AudioInputDevice` with a stable UID.**
   - Add `uid: String` alongside the current `id` and `name` fields.
   - Extend `AudioDeviceManager.listInputDevices()` to fetch each device’s `kAudioDevicePropertyDeviceUID`.
   - Add a small helper to read device UID by `AudioDeviceID`.

2. **Make UID the durable microphone identity.**
   - Add a new defaults key such as `selectedInputDeviceUID`.
   - Update `AudioDeviceManager.setSelectedInputDevice(_:)` so it persists the selected device UID.
   - Keep the public API name unchanged so the UI call sites stay small.

3. **Add legacy migration from `selectedInputDeviceID`.**
   - If `selectedInputDeviceUID` is absent but legacy `selectedInputDeviceID` exists:
     - try to read the UID for that current ID
     - if successful, persist the UID under the new key
     - do not delete the old key as part of this first patch unless there is a strong reason to do so
   - This migration only needs to preserve existing users; it does not need to be clever if the old ID is already gone.

4. **Change `selectedInputDeviceID()` to resolve from UID.**
   - `AudioDeviceManager.selectedInputDeviceID()` should:
     - read the saved UID
     - find the currently available input device with that UID
     - return its current `AudioDeviceID`
     - fall back to `nil` if the UID does not resolve
   - `nil` keeps the current “use system default input device” behavior intact.

5. **Leave the start path structurally alone.**
   - Do not add new preflight logic to `AppState.startRecording()`.
   - Let it keep doing:
     - `audioRecorder.targetDeviceID = AudioDeviceManager.selectedInputDeviceID()`
     - `try audioRecorder.startRecording()`
   - The important change is that `selectedInputDeviceID()` is now correct after re-enumeration.

6. **Turn `resetAudioEngine()` into a real broken-state recovery action.**
   - Extend `AppState.resetAudioEngine()` so it:
     - re-resolves the selected device via `AudioDeviceManager.selectedInputDeviceID()`
     - rebuilds/prewarms the shared recorder
     - clears stale no-input recording errors when the app is idle
     - returns the app to `.ready` if the reset succeeded and the app is not actively recording/transcribing
   - Keep unrelated error handling untouched.

7. **Add a reload action to the warning-triangle menu state.**
   - In `MenuBarView`, under the existing error text, add a button for the live-recording no-input failure.
   - The action should call `appState.resetAudioEngine()`.
   - Use the existing conditional error-action pattern already used for permission errors.
   - Keep the button scoped to this failure class instead of showing it for all errors.

8. **Ensure Settings mic changes use the improved reset path.**
   - Keep the existing Settings microphone picker behavior.
   - The `.onChange` handler already calls `appState.resetAudioEngine()`.
   - After the `resetAudioEngine()` improvements above, this path should also clear the stale warning state and recover correctly.

9. **Add focused tests for UID-backed selection.**
   - Cover migration from legacy integer ID to UID-backed persistence.
   - Cover resolving the current `AudioDeviceID` from a saved UID.
   - Cover unresolved saved UID -> `nil` fallback.
   - If CoreAudio access is too awkward to unit test directly, add minimal injectable lookup closures to `AudioDeviceManager` rather than skipping tests.

10. **Add app-state recovery tests.**
    - Add a test that when `AppState` is idle with the no-input recording error set, calling `resetAudioEngine()` clears the stale error and returns to `.ready` only if a narrow seam can be added without widening app architecture.
    - Add a test that unrelated error types are not incorrectly cleared by this path if the same seam exists.
    - If that seam would be disproportionate, keep this behavior in manual verification instead of forcing broad production refactors for testability.

11. **Keep UI testing minimal.**
    - Do not build a large view-testing harness for `MenuBarView` unless there is already an obvious pattern for it.
    - Manual verification of the new reload button is sufficient if a cheap unit test is not straightforward.

12. **Run targeted tests.**
    - Run the relevant GhostPepper tests after implementation.
    - Prefer the project’s normal macOS unit-test invocation.
    - At minimum, run the tests covering the new UID resolution logic and `AppState` recovery behavior.

## Follow-up Manual Flow Test Pass

### 1. Basic recovery from warning-triangle mode
1. Launch Ghost Pepper.
2. Trigger the original live-recording failure if possible.
3. Confirm the menu bar icon becomes the warning triangle.
4. Open the menu.
5. Confirm the error text is shown.
6. Confirm the new reload action is shown for this failure.
7. Click reload.
8. Press the recording hotkey again.
9. Confirm recording works.

### 2. Settings change recovery
1. Put the app into the same warning-triangle state.
2. Open Settings -> Recording.
3. Change the selected microphone.
4. Confirm the app clears the stale error state and returns to usable recording behavior.
5. Change back to the original microphone.
6. Confirm recording still works.

### 3. Device re-enumeration with the same logical microphone
1. Select `Studio Display Microphone` or another external mic whose `AudioDeviceID` can change.
2. Confirm recording works.
3. Trigger device churn:
   - reconnect display/dock, or
   - sleep/wake, or
   - otherwise cause CoreAudio to re-enumerate the device
4. Attempt recording.
5. If the app enters warning-triangle mode, click reload.
6. Confirm the app recovers the same logical microphone without forcing the user to pick it again in Settings.

### 4. Fallback behavior when the saved device is gone
1. Select a non-default microphone.
2. Remove that device completely.
3. Trigger reload.
4. Confirm Ghost Pepper falls back to the system default input device instead of staying permanently broken.

### 5. Regression guard
1. Confirm permission-related error flows in the menu still show their existing buttons.
2. Confirm the reload action does not appear for unrelated errors.
3. Confirm Settings test dictation still works.

```