### PR TITLE
fix: pause and resume music around recording using AppleScript

### DIFF
--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -710,7 +710,7 @@ class AppState: ObservableObject {
             } else {
                 textCleanupManager.cancelPromptPrefill()
             }
-            mediaPlaybackController.pauseIfPlaying()
+            await mediaPlaybackController.pauseIfPlaying()
             audioRecorder.targetDeviceID = selectedInputDeviceIDProvider()
             try audioRecorder.startRecording()
             debugLogStore.record(category: .hotkey, message: "Recording started.")

--- a/GhostPepper/Info.plist
+++ b/GhostPepper/Info.plist
@@ -31,5 +31,7 @@
     </array>
     <key>NSMicrophoneUsageDescription</key>
     <string>Ghost Pepper needs microphone access to record your voice for transcription.</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Ghost Pepper uses Apple Events to detect whether music is playing in Spotify or Music so it can pause and resume playback while you record.</string>
 </dict>
 </plist>

--- a/GhostPepper/Media/MediaPlaybackController.swift
+++ b/GhostPepper/Media/MediaPlaybackController.swift
@@ -1,9 +1,13 @@
 import Foundation
+import AppKit
 import Darwin
+import os.log
+
+private let logger = Logger(subsystem: "com.github.matthartman.ghostpepper", category: "MediaPlayback")
 
 /// Pauses system media playback during recording and resumes when done.
-/// Uses the private MediaRemote framework via dynamic loading.
-/// Gracefully degrades if the framework is unavailable.
+/// Uses MediaRemote (private) for the actual play/pause commands and
+/// AppleScript to query whether Spotify or Music is currently playing.
 final class MediaPlaybackController {
     private let enabled: () -> Bool
 
@@ -11,6 +15,7 @@ final class MediaPlaybackController {
 
     private let frameworkHandle: UnsafeMutableRawPointer?
     private let sendCommand: SendCommandFunc?
+    private var didPausePlayback = false
 
     private static let kMRPlay: UInt32 = 0
     private static let kMRPause: UInt32 = 1
@@ -25,11 +30,8 @@ final class MediaPlaybackController {
         frameworkHandle = handle
 
         if let handle {
-            if let sym = dlsym(handle, "MRMediaRemoteSendCommand") {
-                sendCommand = unsafeBitCast(sym, to: SendCommandFunc.self)
-            } else {
-                sendCommand = nil
-            }
+            sendCommand = dlsym(handle, "MRMediaRemoteSendCommand")
+                .map { unsafeBitCast($0, to: SendCommandFunc.self) }
         } else {
             sendCommand = nil
         }
@@ -41,21 +43,54 @@ final class MediaPlaybackController {
         }
     }
 
-    /// Pause media if currently playing. Call before recording starts.
-    /// Sends the pause command — it's a no-op if nothing is playing.
-    /// Does NOT auto-resume afterward; the user presses play themselves.
-    /// This avoids the bug where sending kMRPlay opens Apple Music
-    /// even when nothing was playing before recording started.
-    func pauseIfPlaying() {
+    /// Pauses media if Spotify or Apple Music is currently playing.
+    /// Uses AppleScript to query player state (requires NSAppleEventsUsageDescription
+    /// in Info.plist so macOS can prompt the user for authorization).
+    func pauseIfPlaying() async {
         guard enabled(), let sendCommand else { return }
-        _ = sendCommand(Self.kMRPause, nil)
+
+        let isPlaying = await Self.queryMediaAppsIsPlaying()
+        logger.debug("pauseIfPlaying: isPlaying=\(isPlaying)")
+
+        if isPlaying {
+            _ = sendCommand(Self.kMRPause, nil)
+            didPausePlayback = true
+        }
     }
 
-    /// No-op. Kept for API compatibility.
-    /// We no longer auto-resume because sending kMRPlay when nothing was
-    /// playing causes Apple Music to launch (macOS routes the play command
-    /// to the default media handler).
+    /// Resumes media playback only if we paused it. Call after recording ends.
     func resumeIfPaused() {
-        // Intentionally empty — user resumes media manually.
+        guard enabled(), didPausePlayback, let sendCommand else { return }
+        logger.debug("resumeIfPaused: sending kMRPlay")
+        didPausePlayback = false
+        _ = sendCommand(Self.kMRPlay, nil)
+    }
+
+    /// Asks Spotify and Apple Music (only if running) for their player state via AppleScript.
+    /// Returns true if either reports "playing".
+    private static func queryMediaAppsIsPlaying() async -> Bool {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global().async {
+                let runningBundleIDs = Set(NSWorkspace.shared.runningApplications.compactMap { $0.bundleIdentifier })
+                let candidates: [(bundleID: String, appName: String)] = [
+                    ("com.spotify.client", "Spotify"),
+                    ("com.apple.Music", "Music")
+                ]
+                for candidate in candidates {
+                    guard runningBundleIDs.contains(candidate.bundleID) else { continue }
+                    let script = "tell application id \"\(candidate.bundleID)\" to return player state as string"
+                    var error: NSDictionary?
+                    if let appleScript = NSAppleScript(source: script) {
+                        let result = appleScript.executeAndReturnError(&error)
+                        logger.debug("AppleScript \(candidate.appName): state=\(result.stringValue ?? "nil")")
+                        if result.stringValue == "playing" {
+                            continuation.resume(returning: true)
+                            return
+                        }
+                    }
+                }
+                continuation.resume(returning: false)
+            }
+        }
     }
 }


### PR DESCRIPTION
Previously the app either:
- Did not resume playback after recording (resumeIfPaused was a no-op)
- Would spuriously resume or launch Apple Music even when nothing was playing before recording started

Changes:
- Use AppleScript to query Spotify/Music player state before pausing, so we only send kMRPause if something is actually playing
- Track didPausePlayback flag; only send kMRPlay on resume if we paused
- Add NSAppleEventsUsageDescription to Info.plist so macOS can prompt the user for Automation permission on first use
- pauseIfPlaying() is now async to support the AppleScript query

The MediaRemote query functions (MRMediaRemoteGetNowPlayingApplicationIsPlaying) are entitlement-gated and return incorrect results from unsigned apps, which is why AppleScript is used for state detection while MediaRemote is still used to send the actual play/pause commands.