### PR TITLE
feat(qa): robust local Q&A search with in-process fallback + answer verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,17 @@ Resources/models/
 Config/LocalSigning.xcconfig
 GhostPepper/Secrets.swift
 
+# Local Codex project memory/config
+.codex/
+
+# Local agent/skill tooling and settings (not shared)
+.claude/
+.agents/
+skills-lock.json
+
+# qmd search index (generated at runtime; not shipped — see build-dmg.sh)
+.qmd/
+
 # macOS
 .DS_Store
 

--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		478299189CD80630739E9150 /* MeetingQASystemPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87733132E66F36BCE7103250 /* MeetingQASystemPrompt.swift */; };
 		47B377ADA2B2F12226744122 /* MeetingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE672F443903BF4B47EF96EF /* MeetingDetector.swift */; };
 		4961DAF729CE58AAAACBC1AC /* MeetingQAAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFEA05207B7965A3D44D000 /* MeetingQAAgentTests.swift */; };
+		1AFEA05207B7965A3D44D0FF /* QwenToolCallParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFEA05207B7965A3D44D0AA /* QwenToolCallParserTests.swift */; };
 		4CFBE4928A2B811D649B4140 /* TextCleanupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C0D4F04FFD2C13DEACA238 /* TextCleanupManager.swift */; };
 		4DD74E9C222518EEB0DA2A9B /* RecordingOCRPrefetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */; };
 		4EAE492B8F7F4CB18D2E0FE9 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5407DA5D09555EDD69CA54 /* AudioRecorder.swift */; };
@@ -228,6 +229,7 @@
 		19DE683197A1CFDF171F2F38 /* ghost-pepper-character.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ghost-pepper-character.png"; sourceTree = "<group>"; };
 		1AC12AC919C182CDEF77DB11 /* CommandKSearchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandKSearchSheet.swift; sourceTree = "<group>"; };
 		1AFEA05207B7965A3D44D000 /* MeetingQAAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingQAAgentTests.swift; sourceTree = "<group>"; };
+		1AFEA05207B7965A3D44D0AA /* QwenToolCallParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QwenToolCallParserTests.swift; sourceTree = "<group>"; };
 		1DC632CC6DD4F55F2FA05480 /* FrontmostWindowOCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmostWindowOCRService.swift; sourceTree = "<group>"; };
 		1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogStoreTests.swift; sourceTree = "<group>"; };
 		207AAC1CBC60052D1493D13D /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
@@ -829,6 +831,7 @@
 				64F59E7884CF5A1ABFB3C387 /* PathSandboxTests.swift */,
 				59666FBC728BF70A61983188 /* PerformanceTraceTests.swift */,
 				ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */,
+				1AFEA05207B7965A3D44D0AA /* QwenToolCallParserTests.swift */,
 				7ECFAFC0144B6B9203BF4EE0 /* RecognizedVoiceStoreTests.swift */,
 				80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */,
 				AD0C972BC69839C41ACA2E8C /* RecordingSessionCoordinatorTests.swift */,
@@ -1145,6 +1148,7 @@
 				AB0AC6DC19EC0DB440F5B123 /* KeyChordTests.swift in Sources */,
 				EA0A1ECE203067342B2E2CF6 /* MarkdownArchivePathsTests.swift in Sources */,
 				4961DAF729CE58AAAACBC1AC /* MeetingQAAgentTests.swift in Sources */,
+				1AFEA05207B7965A3D44D0FF /* QwenToolCallParserTests.swift in Sources */,
 				190EA523BC8AAF93599DD038 /* MeetingQASystemPromptTests.swift in Sources */,
 				04654E621041E2A81CC2CFC7 /* MeetingQAToolsTests.swift in Sources */,
 				DC6FA0D74F38335D52B5DFA2 /* MeetingQAToolsWriteFileTests.swift in Sources */,

--- a/GhostPepper.xcodeproj/xcshareddata/xcschemes/GhostPepper.xcscheme
+++ b/GhostPepper.xcodeproj/xcshareddata/xcschemes/GhostPepper.xcscheme
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2650"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5EBC085BD56A3725D371FB1A"
+               BuildableName = "GhostPepper.app"
+               BlueprintName = "GhostPepper"
+               ReferencedContainer = "container:GhostPepper.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7EC925A714005FEB57488230"
+               BuildableName = "GhostPepperTests.xctest"
+               BlueprintName = "GhostPepperTests"
+               ReferencedContainer = "container:GhostPepper.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5EBC085BD56A3725D371FB1A"
+            BuildableName = "GhostPepper.app"
+            BlueprintName = "GhostPepper"
+            ReferencedContainer = "container:GhostPepper.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+</Scheme>

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1089,7 +1089,10 @@ class AppState: ObservableObject {
                     maxIterations = 15
                 case .local(let kind):
                     provider = LocalLLMProvider(cleanupManager: self.textCleanupManager, modelKind: kind)
-                    maxIterations = 10
+                    // Same budget as Claude; "list all X" queries on 9B+ local
+                    // models often need a few search rounds + a synthesis turn,
+                    // which the prior cap of 10 cut too close on.
+                    maxIterations = 15
                 }
                 let agent = MeetingQAAgent(provider: provider, backend: backend, archiveRoot: archiveRoot, maxIterations: maxIterations)
                 // Build the conversation: every prior (Q, A) becomes alternating
@@ -1437,30 +1440,36 @@ class AppState: ObservableObject {
 
     // MARK: - Index updates
 
-    private var peopleIndexBuilder: (model: ClaudeAPIModel, builder: IndexBuilder)?
+    private var peopleIndexBuilder: (backend: AgentBackend, builder: IndexBuilder)?
 
-    /// Lazily constructs the per-kind index builder, returning nil if the
-    /// Claude API key isn't configured (incremental updates skip silently in
-    /// that case — the user will still get to build an index on demand once
-    /// they configure a key).
+    /// Lazily constructs the per-kind index builder. Uses the same
+    /// `agentBackend` selection that drives Q&A: a Claude model needs an API
+    /// key (returns nil if missing, so incremental updates skip silently until
+    /// a key is configured), while a local model runs on-device with no key.
     ///
-    /// Cache is keyed on the model — if the user changes their selection in
-    /// Settings or the build sheet, the next call recreates the builder with
+    /// Cache is keyed on the backend — if the user changes their selection in
+    /// the build sheet or Q&A picker, the next call recreates the builder with
     /// the new model rather than returning a stale one.
     private func indexBuilder(for kind: IndexKind) -> IndexBuilder? {
         switch kind {
         case .people:
-            guard let key = KeychainHelper.get(AnthropicProvider.keychainKey), !key.isEmpty else {
-                return nil
+            let backend = AgentBackend.resolveFromDefaults()
+            let provider: LLMProvider
+            switch backend {
+            case .claude(let model):
+                guard let key = KeychainHelper.get(AnthropicProvider.keychainKey), !key.isEmpty else {
+                    return nil
+                }
+                provider = AnthropicProvider(model: model, apiKey: key)
+            case .local(let modelKind):
+                provider = LocalLLMProvider(cleanupManager: self.textCleanupManager, modelKind: modelKind)
             }
-            let model = ClaudeAPIModel(rawValue: self.claudeAPIModel) ?? .sonnet
-            if let existing = peopleIndexBuilder, existing.model == model {
+            if let existing = peopleIndexBuilder, existing.backend == backend {
                 return existing.builder
             }
-            let provider = AnthropicProvider(model: model, apiKey: key)
             let saveDir = MeetingTranscriptSettings.effectiveSaveDirectory()
-            let builder = IndexBuilder(provider: provider, model: model, saveDir: saveDir)
-            peopleIndexBuilder = (model, builder)
+            let builder = IndexBuilder(provider: provider, backend: backend, saveDir: saveDir)
+            peopleIndexBuilder = (backend, builder)
             return builder
         }
     }

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -55,6 +55,9 @@ enum LocalCleanupModelKind: String, CaseIterable, Equatable, Identifiable {
     case qwen35_0_8b_q4_k_m
     case qwen35_2b_q4_k_m
     case qwen35_4b_q4_k_m
+    case qwen35_9b_q4_k_m
+    case qwen35_27b_q4_k_m
+    case qwen35_35b_a3b_q4_k_m
     case deepseek_r1_qwen_7b_q4_k_m
 
     var id: String { rawValue }
@@ -164,10 +167,54 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         recommendation: nil
     )
 
+    /// Qwen 3.5 9B — dense, a solid step up from 4B for the agent loop while
+    /// staying small (~5.7 GB) and fast. Genuine `<tool_call>` tool-caller.
+    static let qwen35_9BModel = CleanupModelDescriptor(
+        kind: .qwen35_9b_q4_k_m,
+        displayName: "Qwen 3.5 9B Q4_K_M (Agent)",
+        sizeDescription: "~5.7 GB",
+        fileName: "Qwen3.5-9B-Q4_K_M.gguf",
+        url: "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf",
+        maxTokenCount: 16384,
+        recommendation: nil
+    )
+
+    /// Qwen 3.5 27B — dense, strongest dense quality that still fits a 48 GB
+    /// machine (~16.7 GB). Slower than the MoE since all 27B params are active
+    /// per token, but high quality for the agent loop.
+    static let qwen35_27BModel = CleanupModelDescriptor(
+        kind: .qwen35_27b_q4_k_m,
+        displayName: "Qwen 3.5 27B Q4_K_M (Agent)",
+        sizeDescription: "~16.7 GB",
+        fileName: "Qwen3.5-27B-Q4_K_M.gguf",
+        url: "https://huggingface.co/unsloth/Qwen3.5-27B-GGUF/resolve/main/Qwen3.5-27B-Q4_K_M.gguf",
+        maxTokenCount: 16384,
+        recommendation: nil
+    )
+
+    /// Qwen 3.5 35B-A3B — a Mixture-of-Experts model: 35B total parameters
+    /// (large-model reasoning quality) but only ~3B active per token, so it
+    /// runs at roughly 9B-dense speed. Added specifically for the agentic
+    /// meeting Q&A loop, where reliable `<tool_call>` emission and multi-hop
+    /// reasoning matter more than the tiny cleanup models can deliver. Needs
+    /// ~22 GB on disk and comfortable headroom on a 32 GB+ machine.
+    static let qwen35_35bA3BModel = CleanupModelDescriptor(
+        kind: .qwen35_35b_a3b_q4_k_m,
+        displayName: "Qwen 3.5 35B-A3B Q4_K_M (Agent)",
+        sizeDescription: "~22 GB",
+        fileName: "Qwen3.5-35B-A3B-Q4_K_M.gguf",
+        url: "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF/resolve/main/Qwen3.5-35B-A3B-Q4_K_M.gguf",
+        maxTokenCount: 16384,
+        recommendation: nil
+    )
+
     static let cleanupModels = [
         compactModel,
         recommendedFastModel,
         recommendedFullModel,
+        qwen35_9BModel,
+        qwen35_27BModel,
+        qwen35_35bA3BModel,
         deepseekR1Qwen7BModel,
     ]
     static let fastModel = recommendedFastModel

--- a/GhostPepper/GhostPepperApp.swift
+++ b/GhostPepper/GhostPepperApp.swift
@@ -54,6 +54,7 @@ struct GhostPepperApp: App {
                     Task {
                         await appState.initialize()
                         appState.showMeetingTranscriptWindow()
+                        lazyUpdater.controller.askForSurveyAfterUpdateIfNeeded()
                     }
                 } else {
                     onboardingController.show(appState: appState) {
@@ -61,6 +62,7 @@ struct GhostPepperApp: App {
                         Task {
                             await appState.initialize()
                             appState.showMeetingTranscriptWindow()
+                            lazyUpdater.controller.askForSurveyAfterUpdateIfNeeded()
                         }
                     }
                 }

--- a/GhostPepper/Indexing/IndexBuilder.swift
+++ b/GhostPepper/Indexing/IndexBuilder.swift
@@ -10,15 +10,15 @@ import CryptoKit
 /// so two close-together meeting stops can't race on the same dossier file.
 @MainActor
 final class IndexBuilder {
-    private let provider: AnthropicProvider
-    private let model: ClaudeAPIModel
+    private let provider: LLMProvider
+    let backend: AgentBackend
     private let saveDir: URL
 
     private var perKindChain: [IndexKind: Task<Void, Never>] = [:]
 
-    init(provider: AnthropicProvider, model: ClaudeAPIModel, saveDir: URL) {
+    init(provider: LLMProvider, backend: AgentBackend, saveDir: URL) {
         self.provider = provider
-        self.model = model
+        self.backend = backend
         self.saveDir = saveDir
     }
 
@@ -35,7 +35,7 @@ final class IndexBuilder {
         let url = MarkdownArchivePaths.entryURL(in: saveDir, kind: kind, slug: slug)
         guard var entry = try? IndexEntryFile.read(from: url) else { return }
         entry.generation = GenerationMetadata(
-            model: model.rawValue,
+            model: backend.encoded,
             promptKind: promptKind,
             promptHash: promptHash,
             generatedAt: Date()
@@ -97,13 +97,15 @@ final class IndexBuilder {
             switch event {
             case .textDelta(let delta):
                 merged += delta
-            case .toolUse, .stop:
+            case .toolUse, .malformedToolCall, .stop:
+                // Merge is a pure-generation call with no tools; ignore any
+                // (mal)formed tool-call noise a local model might emit.
                 break
             }
         }
         let body = merged.trimmingCharacters(in: .whitespacesAndNewlines)
         let generation = GenerationMetadata(
-            model: model.rawValue,
+            model: backend.encoded,
             promptKind: "merge-dossier-body",
             promptHash: Self.hashPrompt(system),
             generatedAt: Date()
@@ -122,14 +124,21 @@ final class IndexBuilder {
         let covered = Self.coveredMeetings(in: saveDir, kind: kind)
         let unprocessedCount = allMeetings.filter { !covered.contains($0) }.count
         let existingEntries = Self.countExistingEntries(in: saveDir, kind: kind)
-        let range = ClaudePricing.estimateBuildCostRange(model: model, meetingCount: unprocessedCount)
+        // Local models are free; only Claude has a per-token cost to estimate.
+        let range: (low: Double, high: Double)
+        switch backend {
+        case .claude(let model):
+            range = ClaudePricing.estimateBuildCostRange(model: model, meetingCount: unprocessedCount)
+        case .local:
+            range = (0, 0)
+        }
         return IndexBuildEstimate(
             totalMeetingCount: allMeetings.count,
             alreadyProcessedCount: allMeetings.count - unprocessedCount,
             existingEntryCount: existingEntries,
             likelyLowUSD: range.low,
             likelyHighUSD: range.high,
-            modelDisplayName: model.shortDisplayName
+            modelDisplayName: backend.shortDisplayName
         )
     }
 
@@ -377,14 +386,16 @@ final class IndexBuilder {
     private func makeAgent(systemPrompt: String, indexRoot: URL) -> MeetingQAAgent {
         let readTools = MeetingQATools(root: saveDir)
         let writeTools = MeetingQATools(root: indexRoot)
+        let searchHandler: AgentToolHandler = { input in
+            let query = (input["query"] as? String) ?? (input["pattern"] as? String) ?? ""
+            let path = input["path"] as? String
+            let caseInsensitive = (input["case_insensitive"] as? Bool) ?? true
+            let maxResults = (input["max_results"] as? Int) ?? 50
+            return try await readTools.qmdSearch(query: query, path: path, caseInsensitive: caseInsensitive, maxResults: maxResults)
+        }
         let handlers: [String: AgentToolHandler] = [
-            "grep": { input in
-                let pattern = (input["pattern"] as? String) ?? ""
-                let path = input["path"] as? String
-                let caseInsensitive = (input["case_insensitive"] as? Bool) ?? true
-                let maxResults = (input["max_results"] as? Int) ?? 50
-                return try await readTools.grep(pattern: pattern, path: path, caseInsensitive: caseInsensitive, maxResults: maxResults)
-            },
+            "qmd_search": searchHandler,
+            "grep": searchHandler,
             "read_file": { input in
                 let path = (input["path"] as? String) ?? ""
                 let offset = (input["offset"] as? Int) ?? 1
@@ -403,7 +414,7 @@ final class IndexBuilder {
         ]
         return MeetingQAAgent(
             provider: provider,
-            backend: .claude(model),
+            backend: backend,
             systemPrompt: systemPrompt,
             toolHandlers: handlers,
             toolDefinitions: Self.indexingToolDefinitions(),
@@ -502,7 +513,7 @@ final class IndexBuilder {
 
         \(preview)\(suffix)
 
-        Use `list_dir` and `grep` to explore the rest yourself, then `write_file` one dossier per canonical person.
+        Use `list_dir` and `qmd_search` to explore the rest yourself, then `write_file` one dossier per canonical person.
         """
     }
 }

--- a/GhostPepper/Indexing/IndexSystemPrompt.swift
+++ b/GhostPepper/Indexing/IndexSystemPrompt.swift
@@ -23,7 +23,7 @@ enum IndexSystemPrompt {
         ## Tools
 
         - `list_dir(path)` — discover date folders in the archive (YYYY-MM-DD/).
-        - `grep(pattern, ...)` — find name mentions across meetings. Cheaper than reading whole files.
+        - `qmd_search(query, ...)` — find name mentions across meetings. Cheaper than reading whole files.
         - `read_file(path, offset, limit)` — read meeting transcripts to gather context.
         - `write_file(path, content)` — write a dossier entry. Path must be a flat `<slug>.md` filename in the index directory.
 
@@ -105,7 +105,7 @@ enum IndexSystemPrompt {
            rather than overwriting. Treat every existing entry as the source
            of truth for that person's canonical name and existing aliases.
         2. `list_dir` the archive root to enumerate date folders.
-        3. For each date folder, `list_dir` to find meetings. `grep` is your
+        3. For each date folder, `list_dir` to find meetings. `qmd_search` is your
            friend for finding capitalized name patterns and `**Attendees:**`
            lines.
         4. Build a working canonical-name list as you go. When you encounter a
@@ -185,7 +185,7 @@ enum IndexSystemPrompt {
         ## Tools
 
         - `read_file(path, offset, limit)` — read the new meeting transcript and existing dossiers.
-        - `grep(pattern, ...)` — confirm a name's context if needed.
+        - `qmd_search(query, ...)` — confirm a name's context if needed.
         - `list_dir(path)` — list the index directory if you need to discover existing entries.
         - `write_file(path, content)` — write or overwrite a dossier entry.
 

--- a/GhostPepper/Meeting/GranolaImporter.swift
+++ b/GhostPepper/Meeting/GranolaImporter.swift
@@ -249,11 +249,14 @@ final class GranolaImporter: ObservableObject {
             let slug = Self.slugify(title)
             let filePath = directory.appendingPathComponent(dateFolder).appendingPathComponent("\(slug).md")
 
-            // Skip if file already has both transcript and summary (fully enriched)
+            // Skip only if the file already has real transcript and summary
+            // content. Placeholder sections from native Ghost Pepper notes
+            // should still be eligible for Granola enrichment.
             let fileExists = FileManager.default.fileExists(atPath: filePath.path)
             if fileExists {
                 if let existing = try? String(contentsOf: filePath, encoding: .utf8),
-                   existing.contains("## Transcript") && existing.contains("## Summary") { continue }
+                   Self.sectionHasRealContent(in: existing, header: "Transcript"),
+                   Self.sectionHasRealContent(in: existing, header: "Summary") { continue }
             }
 
             // Fetch with transcript
@@ -429,7 +432,20 @@ final class GranolaImporter: ObservableObject {
         }
         guard inSection else { return nil }
         let joined = collected.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-        return joined.isEmpty ? nil : joined
+        if joined.isEmpty { return nil }
+
+        switch header {
+        case "Notes" where joined == "*No notes.*" || joined == "*No notes yet.*":
+            return nil
+        case "Transcript" where joined == "*No transcript yet.*":
+            return nil
+        default:
+            return joined
+        }
+    }
+
+    private static func sectionHasRealContent(in markdown: String, header: String) -> Bool {
+        extractSectionBody(from: markdown, header: header) != nil
     }
 
     private static func extractTranscript(from transcriptData: Any?) -> String {

--- a/GhostPepper/Meeting/MeetingMarkdownWriter.swift
+++ b/GhostPepper/Meeting/MeetingMarkdownWriter.swift
@@ -33,6 +33,9 @@ struct MeetingMarkdownWriter {
         if let articleBody = transcript.articleBody {
             return renderReaderMarkdown(transcript: transcript, articleBody: articleBody)
         }
+        if transcript.importedFrom?.lowercased() == "granola" {
+            return renderImportedGranolaMarkdown(transcript: transcript)
+        }
         return renderMeetingMarkdown(transcript: transcript)
     }
 
@@ -101,6 +104,59 @@ struct MeetingMarkdownWriter {
     }
 
     @MainActor
+    private static func renderImportedGranolaMarkdown(transcript: MeetingTranscript) -> String {
+        var lines: [String] = []
+
+        lines.append("---")
+        lines.append("title: \"\(escapeYAMLString(transcript.meetingName))\"")
+        if let importedDateString = transcript.importedDateString, !importedDateString.isEmpty {
+            lines.append("date: \"\(escapeYAMLString(importedDateString))\"")
+        } else {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            lines.append("date: \"\(iso.string(from: transcript.startDate))\"")
+        }
+        if let granolaId = transcript.granolaId, !granolaId.isEmpty {
+            lines.append("granola_id: \"\(escapeYAMLString(granolaId))\"")
+        }
+        lines.append("source_type: meeting")
+        lines.append("imported_from: granola")
+        lines.append("---")
+        lines.append("")
+
+        lines.append("# \(transcript.meetingName)")
+        lines.append("")
+
+        if let summary = transcript.summary, !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.append("## Summary")
+            lines.append("")
+            lines.append(summary)
+            lines.append("")
+        }
+
+        if !transcript.notes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            lines.append("## Notes")
+            lines.append("")
+            lines.append(transcript.notes)
+            lines.append("")
+        }
+
+        let rawTranscript = transcript.rawTranscriptMarkdown?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !rawTranscript.isEmpty || !transcript.segments.isEmpty {
+            lines.append("## Transcript")
+            lines.append("")
+            if !rawTranscript.isEmpty {
+                lines.append(rawTranscript)
+            } else {
+                appendRenderedTranscriptSegments(transcript.segments, to: &lines)
+            }
+            lines.append("")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    @MainActor
     private static func renderReaderMarkdown(transcript: MeetingTranscript, articleBody: String) -> String {
         var lines: [String] = []
 
@@ -157,6 +213,8 @@ struct MeetingMarkdownWriter {
         var article = ""
         var importedFrom: String?
         var sourceURL: String?
+        var granolaId: String?
+        var importedDateString: String?
         var inFrontmatter = false
         var frontmatterSeen = false
         var inNotes = false
@@ -165,6 +223,7 @@ struct MeetingMarkdownWriter {
         var inChapters = false
         var inArticle = false
         var transcriptLines: [String] = []
+        var transcriptSectionLines: [String] = []
 
         for line in lines {
             // Parse YAML frontmatter (--- blocks)
@@ -179,11 +238,16 @@ struct MeetingMarkdownWriter {
                 }
             }
             if inFrontmatter {
-                if line.hasPrefix("imported_from:") {
-                    importedFrom = line.replacingOccurrences(of: "imported_from:", with: "").trimmingCharacters(in: .whitespaces)
-                }
-                if line.hasPrefix("source:") {
-                    sourceURL = line.replacingOccurrences(of: "source:", with: "").trimmingCharacters(in: .whitespaces)
+                if let value = frontmatterValue(from: line, key: "title"), title == fileURL.deletingPathExtension().lastPathComponent {
+                    title = value
+                } else if let value = frontmatterValue(from: line, key: "date") {
+                    importedDateString = value
+                } else if let value = frontmatterValue(from: line, key: "granola_id") {
+                    granolaId = value
+                } else if let value = frontmatterValue(from: line, key: "imported_from") {
+                    importedFrom = value
+                } else if let value = frontmatterValue(from: line, key: "source") {
+                    sourceURL = value
                 }
                 continue
             }
@@ -224,6 +288,7 @@ struct MeetingMarkdownWriter {
                 notes += (notes.isEmpty ? "" : "\n") + line
             }
             if inTranscript {
+                transcriptSectionLines.append(line)
                 if line == "*No transcript yet.*" { continue }
                 if !line.isEmpty {
                     transcriptLines.append(line)
@@ -237,7 +302,8 @@ struct MeetingMarkdownWriter {
             }
         }
 
-        let transcript = MeetingTranscript(meetingName: title)
+        let startDate = importedDateString.flatMap(parseImportedDate) ?? Date()
+        let transcript = MeetingTranscript(meetingName: title, startDate: startDate)
         transcript.notes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedSummary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
         transcript.summary = trimmedSummary.isEmpty ? nil : trimmedSummary
@@ -245,6 +311,12 @@ struct MeetingMarkdownWriter {
         transcript.articleBody = trimmedArticle.isEmpty ? nil : trimmedArticle
         transcript.importedFrom = importedFrom
         transcript.sourceURL = sourceURL
+        transcript.granolaId = granolaId
+        transcript.importedDateString = importedDateString
+        let rawTranscript = transcriptSectionLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !rawTranscript.isEmpty && rawTranscript != "*No transcript yet.*" {
+            transcript.rawTranscriptMarkdown = rawTranscript
+        }
 
         // Parse transcript lines: **[00:00] Me:** text
         for line in transcriptLines {
@@ -331,6 +403,39 @@ struct MeetingMarkdownWriter {
     }
 
     // MARK: - Helpers
+
+    private static func appendRenderedTranscriptSegments(_ segments: [TranscriptSegment], to lines: inout [String]) {
+        for segment in segments {
+            let timestamp = segment.formattedTimestamp
+            let speaker = segment.speaker.displayName
+            lines.append("**[\(timestamp)] \(speaker):** \(segment.text)  ")
+        }
+    }
+
+    private static func frontmatterValue(from line: String, key: String) -> String? {
+        let prefix = "\(key):"
+        guard line.hasPrefix(prefix) else { return nil }
+        var value = String(line.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces)
+        if value.hasPrefix("\""), value.hasSuffix("\""), value.count >= 2 {
+            value.removeFirst()
+            value.removeLast()
+        }
+        return value.replacingOccurrences(of: "\\\"", with: "\"")
+    }
+
+    private static func escapeYAMLString(_ value: String) -> String {
+        value.replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private static func parseImportedDate(_ value: String) -> Date? {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = iso.date(from: value) {
+            return date
+        }
+        iso.formatOptions = [.withInternetDateTime]
+        return iso.date(from: value)
+    }
 
     /// Formats a date as "2026-04-07" for folder names.
     private static func dateFolderName(for date: Date) -> String {

--- a/GhostPepper/Meeting/MeetingTranscript.swift
+++ b/GhostPepper/Meeting/MeetingTranscript.swift
@@ -65,6 +65,23 @@ final class MeetingTranscript: ObservableObject {
     /// Optional source URL — used by Reader entries.
     var sourceURL: String?
 
+    // Imported-note preservation. These fields let parse→render round-trip a
+    // Granola-imported note (or any note carrying YAML frontmatter) without
+    // losing identity or the imported transcript text. The render path checks
+    // `importedFrom` to decide whether to emit a frontmatter block; the raw
+    // transcript body is re-emitted verbatim when there are no live segments.
+    /// Granola note id (`granola_id` in frontmatter). Preserved so re-saves
+    /// don't strip the identity that links a note back to Granola.
+    var granolaId: String?
+    /// Original `date:` frontmatter string, verbatim — preserved so re-saves
+    /// don't replace it with `Date()` reformatted as "(in progress)".
+    var importedDateString: String?
+    /// Raw body of the `## Transcript` section as read from disk. When
+    /// segments are empty on render, we emit this verbatim so an imported
+    /// transcript survives a parse→render round-trip exactly, regardless of
+    /// whether the fallback timestamp-less parser produced segments.
+    var rawTranscriptMarkdown: String?
+
     let sessionID: UUID
 
     init(

--- a/GhostPepper/QA/AgentBackend.swift
+++ b/GhostPepper/QA/AgentBackend.swift
@@ -31,12 +31,7 @@ enum AgentBackend: Equatable {
     /// catalog. nonisolated so MeetingQAAgent's runLoop (which runs on a
     /// non-MainActor Task) can call it when emitting usage events.
     private static func localDisplayName(for kind: LocalCleanupModelKind) -> String {
-        switch kind {
-        case .qwen35_0_8b_q4_k_m: return "Qwen 3.5 0.8B"
-        case .qwen35_2b_q4_k_m: return "Qwen 3.5 2B"
-        case .qwen35_4b_q4_k_m: return "Qwen 3.5 4B"
-        case .deepseek_r1_qwen_7b_q4_k_m: return "DeepSeek R1 7B"
-        }
+        kind.qaBaseDisplayName
     }
 
     /// Cost in USD for one round-trip's worth of usage. Local is always free.
@@ -97,5 +92,55 @@ enum AgentBackend: Equatable {
         let resolved: AgentBackend = .claude(model)
         defaults.set(resolved.encoded, forKey: "agentBackend")
         return resolved
+    }
+}
+
+extension LocalCleanupModelKind {
+    var qaBaseDisplayName: String {
+        switch self {
+        case .qwen35_0_8b_q4_k_m: return "Qwen 3.5 0.8B"
+        case .qwen35_2b_q4_k_m: return "Qwen 3.5 2B"
+        case .qwen35_4b_q4_k_m: return "Qwen 3.5 4B"
+        case .qwen35_9b_q4_k_m: return "Qwen 3.5 9B"
+        case .qwen35_27b_q4_k_m: return "Qwen 3.5 27B"
+        case .qwen35_35b_a3b_q4_k_m: return "Qwen 3.5 35B-A3B"
+        case .deepseek_r1_qwen_7b_q4_k_m: return "DeepSeek R1 7B"
+        }
+    }
+
+    var qaProfileLabel: String {
+        switch self {
+        case .qwen35_0_8b_q4_k_m, .qwen35_2b_q4_k_m:
+            return "Fast"
+        case .qwen35_4b_q4_k_m:
+            return "Balanced"
+        case .qwen35_9b_q4_k_m, .qwen35_35b_a3b_q4_k_m:
+            return "Quality"
+        case .qwen35_27b_q4_k_m:
+            return "Long context"
+        case .deepseek_r1_qwen_7b_q4_k_m:
+            return "Experimental"
+        }
+    }
+
+    var qaPickerDisplayName: String {
+        "\(qaBaseDisplayName) (\(qaProfileLabel))"
+    }
+
+    var qaProfileDescription: String {
+        switch self {
+        case .qwen35_0_8b_q4_k_m, .qwen35_2b_q4_k_m:
+            return "Fast local answers; best for quick lookups after qmd has found the evidence."
+        case .qwen35_4b_q4_k_m:
+            return "Balanced local model; useful for short Q&A, but larger models are better for timelines and synthesis."
+        case .qwen35_9b_q4_k_m:
+            return "Recommended local starting point for source-backed Q&A and tool use."
+        case .qwen35_27b_q4_k_m:
+            return "Best dense local option here for longer evidence packets, if your machine has the memory."
+        case .qwen35_35b_a3b_q4_k_m:
+            return "Quality-oriented MoE option; good experiment for local synthesis with Qwen-style tool calls."
+        case .deepseek_r1_qwen_7b_q4_k_m:
+            return "Experimental for Q&A; reasoning models can expose planning text, so Ghost Pepper applies extra verification."
+        }
     }
 }

--- a/GhostPepper/QA/LLMProvider.swift
+++ b/GhostPepper/QA/LLMProvider.swift
@@ -33,6 +33,11 @@ struct LLMTool {
 enum ProviderEvent {
     case textDelta(String)
     case toolUse(id: String, name: String, input: [String: Any])
+    /// A tool call the backend recognized as a tool-call attempt but could not
+    /// turn into a usable `toolUse` (unparseable JSON, no inferable tool). The
+    /// agent loop re-prompts the model instead of ending the turn. Only the
+    /// local Qwen backend emits this; structured backends (Anthropic) do not.
+    case malformedToolCall(raw: String)
     case stop(reason: StopReason, usage: ProviderUsage)
 }
 

--- a/GhostPepper/QA/LocalLLMProvider.swift
+++ b/GhostPepper/QA/LocalLLMProvider.swift
@@ -40,6 +40,10 @@ struct LocalLLMProvider: LLMProvider {
                             let id = "qtu_\(idCounter)_\(Int(Date().timeIntervalSince1970 * 1000))"
                             emittedToolCall = true
                             continuation.yield(.toolUse(id: id, name: name, input: input))
+                        case .malformedToolCall(let raw):
+                            // Don't surface to the user as text; let the agent
+                            // loop decide to re-prompt.
+                            continuation.yield(.malformedToolCall(raw: raw))
                         }
                     }
                 }
@@ -124,7 +128,13 @@ struct LocalLLMProvider: LLMProvider {
             {"name": "<tool name>", "arguments": {<json arguments>}}
             </tool_call>
 
-            You may emit multiple tool_call blocks in a single turn. After each round of tools, the user message will contain <tool_response> blocks with the results — read them and either continue answering or call more tools. When you've gathered enough information, write your final answer in plain text with no tool_call tags.
+            When the user asks about meetings, transcripts, people in the archive, dates, or timelines, do not answer from memory and do not describe a plan. Emit a tool_call first.
+            Good first call for person timelines:
+            <tool_call>
+            {"name":"qmd_search","arguments":{"query":"Person Full Name","case_insensitive":true,"max_results":50}}
+            </tool_call>
+
+            You may emit multiple tool_call blocks in a single turn. After each round of tools, the user message will contain <tool_response> blocks with the results — read them and either continue answering or call more tools. When you've gathered enough information, write your final answer in plain text with no tool_call tags and no hidden analysis.
             """
         }
         body += "\n"

--- a/GhostPepper/QA/MeetingQAAgent.swift
+++ b/GhostPepper/QA/MeetingQAAgent.swift
@@ -11,9 +11,10 @@ final class MeetingQAAgent {
     private let summarizeInput: (String, [String: Any]) -> String
     private let summarizeOutput: (String, String, Bool) -> String
     private let maxIterations: Int
+    private let answerVerificationEnabled: Bool
 
     /// Backward-compatible Q&A initializer. Wires up the standard
-    /// MeetingQASystemPrompt and the read-only grep / read_file / list_dir tools
+    /// MeetingQASystemPrompt and the read-only qmd_search / read_file / list_dir tools
     /// scoped to the meeting archive.
     convenience init(
         provider: LLMProvider,
@@ -22,14 +23,16 @@ final class MeetingQAAgent {
         maxIterations: Int = 15
     ) {
         let tools = MeetingQATools(root: archiveRoot)
+        let searchHandler: AgentToolHandler = { input in
+            let query = (input["query"] as? String) ?? (input["pattern"] as? String) ?? ""
+            let path = input["path"] as? String
+            let caseInsensitive = (input["case_insensitive"] as? Bool) ?? true
+            let maxResults = (input["max_results"] as? Int) ?? 50
+            return try await tools.qmdSearch(query: query, path: path, caseInsensitive: caseInsensitive, maxResults: maxResults)
+        }
         let handlers: [String: AgentToolHandler] = [
-            "grep": { input in
-                let pattern = (input["pattern"] as? String) ?? ""
-                let path = input["path"] as? String
-                let caseInsensitive = (input["case_insensitive"] as? Bool) ?? true
-                let maxResults = (input["max_results"] as? Int) ?? 50
-                return try await tools.grep(pattern: pattern, path: path, caseInsensitive: caseInsensitive, maxResults: maxResults)
-            },
+            "qmd_search": searchHandler,
+            "grep": searchHandler,
             "read_file": { input in
                 let path = (input["path"] as? String) ?? ""
                 let offset = (input["offset"] as? Int) ?? 1
@@ -53,7 +56,8 @@ final class MeetingQAAgent {
             toolDefinitions: Self.qaToolDefinitions(),
             summarizeInput: Self.summarizeQAInput,
             summarizeOutput: Self.summarizeQAOutput,
-            maxIterations: maxIterations
+            maxIterations: maxIterations,
+            answerVerificationEnabled: true
         )
     }
 
@@ -68,7 +72,8 @@ final class MeetingQAAgent {
         toolDefinitions: [LLMTool],
         summarizeInput: @escaping (String, [String: Any]) -> String,
         summarizeOutput: @escaping (String, String, Bool) -> String,
-        maxIterations: Int = 15
+        maxIterations: Int = 15,
+        answerVerificationEnabled: Bool = false
     ) {
         self.provider = provider
         self.backend = backend
@@ -78,6 +83,7 @@ final class MeetingQAAgent {
         self.summarizeInput = summarizeInput
         self.summarizeOutput = summarizeOutput
         self.maxIterations = maxIterations
+        self.answerVerificationEnabled = answerVerificationEnabled
     }
 
     func ask(_ question: String) -> AsyncThrowingStream<QAEvent, Error> {
@@ -102,6 +108,16 @@ final class MeetingQAAgent {
         var cumulativeUsage = ProviderUsage.zero
         var hasUsedTools = false
         var didSynthesisFallback = false
+        var didMalformedRecovery = false
+        var didNoToolRecovery = false
+        var didVerificationRecovery = false
+        var toolObservations: [MeetingQAToolObservation] = []
+        // After the synthesis fallback fires, the next round trip must produce
+        // plain text — a stubborn local model otherwise just emits more tool
+        // calls and we never recover. Suppress tools for that single turn so
+        // the model literally can't call them (both the per-call tools param
+        // and the LocalLLMProvider's `<tools>` system block are gated on this).
+        var suppressToolsNextTurn = false
 
         for _ in 0..<maxIterations {
             if Task.isCancelled {
@@ -115,9 +131,12 @@ final class MeetingQAAgent {
             var stopReason: StopReason = .other("missing")
             var iterationUsage: ProviderUsage = .zero
             var assistantTextBuffer = ""
+            var malformedRaw: String? = nil
 
+            let iterationTools = suppressToolsNextTurn ? [] : toolDefinitions
+            suppressToolsNextTurn = false
             do {
-                for try await event in provider.complete(system: systemPrompt, messages: messages, tools: toolDefinitions) {
+                for try await event in provider.complete(system: systemPrompt, messages: messages, tools: iterationTools) {
                     if Task.isCancelled {
                         continuation.yield(.status("Stopped"))
                         continuation.finish()
@@ -126,10 +145,16 @@ final class MeetingQAAgent {
                     switch event {
                     case .textDelta(let delta):
                         assistantTextBuffer += delta
-                        continuation.yield(.text(delta))
+                        if !backend.isLocal {
+                            continuation.yield(.text(delta))
+                        }
                     case .toolUse(let id, let name, let input):
                         pendingToolCalls.append((id, name, input))
                         assistantBlocks.append(.toolUse(id: id, name: name, input: input))
+                    case .malformedToolCall(let raw):
+                        // Captured, not streamed to the user — handled after the
+                        // turn so we can re-prompt instead of ending on a blob.
+                        malformedRaw = raw
                     case .stop(let reason, let usage):
                         stopReason = reason
                         iterationUsage = usage
@@ -160,6 +185,7 @@ final class MeetingQAAgent {
                 for call in pendingToolCalls {
                     continuation.yield(.toolCall(id: call.id, name: call.name, inputSummary: summarizeInput(call.name, call.input), fullInput: call.input))
                     let (output, isError) = await runTool(name: call.name, input: call.input)
+                    toolObservations.append(MeetingQAToolObservation(name: call.name, input: call.input, output: output, isError: isError))
                     continuation.yield(.toolResult(id: call.id, summary: summarizeOutput(call.name, output, isError), fullOutput: output, isError: isError))
                     toolResultBlocks.append(.toolResult(toolUseId: call.id, content: output, isError: isError))
                 }
@@ -167,8 +193,70 @@ final class MeetingQAAgent {
                 continue
             }
 
+            // Malformed tool call the backend couldn't parse or infer a tool
+            // from. Push back once with the correct format before giving up,
+            // rather than ending the turn on an unparseable blob. (Only the
+            // local Qwen backend emits this; structured backends never do.)
+            if let raw = malformedRaw {
+                if !didMalformedRecovery {
+                    didMalformedRecovery = true
+                    var blocks = assistantBlocks
+                    blocks.append(.text("<tool_call>\n\(raw)\n</tool_call>"))
+                    messages.append(LLMMessage(role: .assistant, content: blocks))
+                    messages.append(LLMMessage(role: .user, content: [.text(Self.malformedToolCallRecoveryPrompt)]))
+                    continuation.yield(.status("Recovering from a malformed tool call…"))
+                    continue
+                }
+                continuation.yield(.error("The model produced malformed tool calls repeatedly and could not recover."))
+                continuation.finish()
+                return
+            }
+
             switch stopReason {
             case .endTurn:
+                if backend.isLocal,
+                   !hasUsedTools,
+                   shouldRetryLocalAnswerWithoutTools(userMessages: initialMessages, assistantText: assistantTextBuffer) {
+                    if !didNoToolRecovery {
+                        didNoToolRecovery = true
+                        let question = Self.latestUserQuestion(in: initialMessages) ?? ""
+                        let inputs = Self.localArchiveSearchInputs(for: question)
+                        continuation.yield(.status("Searching archive before local answer…"))
+                        var assistantToolBlocks: [LLMContentBlock] = []
+                        var userToolResultBlocks: [LLMContentBlock] = []
+                        for (index, input) in inputs.enumerated() {
+                            let toolUseId = "local_qmd_search_\(index)_\(Int(Date().timeIntervalSince1970 * 1000))"
+                            continuation.yield(.toolCall(
+                                id: toolUseId,
+                                name: "qmd_search",
+                                inputSummary: summarizeInput("qmd_search", input),
+                                fullInput: input
+                            ))
+                            let (output, isError) = await runTool(name: "qmd_search", input: input)
+                            toolObservations.append(MeetingQAToolObservation(name: "qmd_search", input: input, output: output, isError: isError))
+                            continuation.yield(.toolResult(
+                                id: toolUseId,
+                                summary: summarizeOutput("qmd_search", output, isError),
+                                fullOutput: output,
+                                isError: isError
+                            ))
+                            assistantToolBlocks.append(.toolUse(id: toolUseId, name: "qmd_search", input: input))
+                            userToolResultBlocks.append(.toolResult(toolUseId: toolUseId, content: output, isError: isError))
+                            if !isError && !MeetingQATools.isNoMatchesOutput(output) {
+                                break
+                            }
+                        }
+                        hasUsedTools = true
+                        messages.append(LLMMessage(role: .assistant, content: assistantToolBlocks))
+                        messages.append(LLMMessage(role: .user, content: userToolResultBlocks))
+                        continue
+                    }
+
+                    continuation.yield(.error(Self.localNoToolFailureMessage))
+                    continuation.finish()
+                    return
+                }
+
                 // Synthesis fallback: weak local models sometimes do tool calls
                 // and then stop without writing an answer. Push them once with
                 // an explicit "now answer" message before giving up. Skipped if
@@ -176,17 +264,47 @@ final class MeetingQAAgent {
                 // or if we already tried synthesis once.
                 if assistantTextBuffer.isEmpty && hasUsedTools && !didSynthesisFallback {
                     didSynthesisFallback = true
+                    suppressToolsNextTurn = true
                     if !assistantBlocks.isEmpty {
                         messages.append(LLMMessage(role: .assistant, content: assistantBlocks))
                     }
-                    let synthesisPrompt = """
-                    Now write your final answer to the user's original question, citing source files as path:line. \
-                    If your searches did not find enough to answer fully, summarize what you searched, what you found, \
-                    and what the closest match was. Do not call any more tools — just write the answer.
-                    """
+                    let evidence = MeetingQAEvidencePacket(observations: toolObservations)
+                    let synthesisPrompt = Self.synthesisPrompt(evidence: evidence)
                     messages.append(LLMMessage(role: .user, content: [.text(synthesisPrompt)]))
                     continuation.yield(.status("Synthesizing answer from tool results…"))
                     continue
+                }
+                if answerVerificationEnabled,
+                   backend.isLocal,
+                   hasUsedTools,
+                   !assistantTextBuffer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    let evidence = MeetingQAEvidencePacket(observations: toolObservations)
+                    let question = Self.latestUserQuestion(in: initialMessages) ?? Self.latestUserQuestion(in: messages) ?? ""
+                    let verification = MeetingQAAnswerVerifier.validate(
+                        answer: assistantTextBuffer,
+                        question: question,
+                        evidence: evidence,
+                        archiveRoot: nil
+                    )
+                    if !verification.isValid {
+                        if !didVerificationRecovery {
+                            didVerificationRecovery = true
+                            suppressToolsNextTurn = true
+                            messages.append(LLMMessage(
+                                role: .user,
+                                content: [.text(Self.verificationRecoveryPrompt(reasons: verification.reasons, evidence: evidence))]
+                            ))
+                            continuation.yield(.status("Checking answer against source evidence…"))
+                            continue
+                        }
+
+                        continuation.yield(.text(Self.fallbackAnswer(question: question, evidence: evidence)))
+                        continuation.finish()
+                        return
+                    }
+                }
+                if backend.isLocal && !assistantTextBuffer.isEmpty {
+                    continuation.yield(.text(assistantTextBuffer))
                 }
                 continuation.finish()
                 return
@@ -232,14 +350,236 @@ final class MeetingQAAgent {
         )))
     }
 
+    private func shouldRetryLocalAnswerWithoutTools(userMessages: [LLMMessage], assistantText: String) -> Bool {
+        guard !assistantText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        guard let latestQuestion = Self.latestUserQuestion(in: userMessages)?.lowercased() else { return false }
+
+        let asksAboutArchive = [
+            "meeting", "meetings", "transcript", "timeline", "summarize", "summary",
+            "who", "when", "where", "what did", "with ", "about "
+        ].contains { latestQuestion.contains($0) }
+        guard asksAboutArchive else { return false }
+
+        let text = assistantText.lowercased()
+        if text.contains("qmd_search") || text.contains("list_dir") || text.contains("read_file") || text.contains("tool") {
+            return true
+        }
+        if text.contains("without knowing") || text.contains("can't extract") || text.contains("impossible") || text.contains("perhaps") {
+            return true
+        }
+        // A local archive answer with no citations is usually a hallucination
+        // or a plan. Force one tool attempt before showing it.
+        return Self.extractCitationLikePaths(from: assistantText).isEmpty
+    }
+
+    private static func latestUserQuestion(in messages: [LLMMessage]) -> String? {
+        for message in messages.reversed() where message.role == .user {
+            let text = message.content.compactMap { block -> String? in
+                if case .text(let t) = block { return t }
+                return nil
+            }.joined(separator: "\n")
+            if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return text
+            }
+        }
+        return nil
+    }
+
+    static func localArchiveSearchInput(for question: String) -> [String: Any] {
+        localArchiveSearchInput(query: localArchiveSearchQuery(for: question))
+    }
+
+    static func localArchiveSearchInputs(for question: String) -> [[String: Any]] {
+        localArchiveSearchQueries(for: question).map(localArchiveSearchInput(query:))
+    }
+
+    private static func localArchiveSearchInput(query: String) -> [String: Any] {
+        [
+            "query": query,
+            "case_insensitive": true,
+            "max_results": 50,
+        ]
+    }
+
+    static func localArchiveSearchQueries(for question: String) -> [String] {
+        let primary = localArchiveSearchQuery(for: question)
+        let parts = primary
+            .split(separator: " ")
+            .map { $0.trimmingCharacters(in: .punctuationCharacters) }
+            .filter { $0.count >= 3 }
+
+        var queries: [String] = [primary]
+        if parts.count > 1 {
+            queries.append(contentsOf: parts)
+        }
+        var seen: Set<String> = []
+        return queries.filter { query in
+            let normalized = query.lowercased()
+            guard !normalized.isEmpty, !seen.contains(normalized) else { return false }
+            seen.insert(normalized)
+            return true
+        }
+    }
+
+    static func localArchiveSearchQuery(for question: String) -> String {
+        let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return trimmed }
+
+        if let quoted = firstRegexCapture(in: trimmed, pattern: #""([^"]{2,})""#) {
+            return quoted
+        }
+
+        for marker in ["with", "about", "regarding"] {
+            if let phrase = phraseAfter(marker: marker, in: trimmed), !phrase.isEmpty {
+                return phrase
+            }
+        }
+
+        let capitalizedPattern = #"\b[A-Z][A-Za-z'\-]+(?:\s+[A-Z][A-Za-z'\-]+){0,3}\b"#
+        let capitalized = regexCaptures(in: trimmed, pattern: capitalizedPattern)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !["Can", "What", "Who", "When", "Where", "Tell"].contains($0) }
+            .sorted { lhs, rhs in
+                if lhs.split(separator: " ").count != rhs.split(separator: " ").count {
+                    return lhs.split(separator: " ").count > rhs.split(separator: " ").count
+                }
+                return lhs.count > rhs.count
+            }
+        if let best = capitalized.first {
+            return best
+        }
+
+        return trimmed
+    }
+
+    private static func phraseAfter(marker: String, in question: String) -> String? {
+        let escaped = NSRegularExpression.escapedPattern(for: marker)
+        guard let raw = firstRegexCapture(
+            in: question,
+            pattern: #"(?i)\b"# + escaped + #"\s+([A-Za-z0-9][A-Za-z0-9'\-]*(?:\s+[A-Za-z0-9][A-Za-z0-9'\-]*){0,5})"#
+        ) else {
+            return nil
+        }
+
+        let stopWords: Set<String> = [
+            "a", "an", "and", "as", "at", "before", "for", "from", "in", "into",
+            "meeting", "meetings", "of", "on", "or", "prior", "previous", "that",
+            "the", "timeline", "to", "where", "who", "with",
+        ]
+        let kept = raw
+            .split(separator: " ")
+            .prefix { token in
+                let normalized = token.lowercased().trimmingCharacters(in: .punctuationCharacters)
+                return !stopWords.contains(normalized)
+            }
+            .map(String.init)
+        let phrase = kept.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+        return phrase.isEmpty ? nil : phrase
+    }
+
+    private static func firstRegexCapture(in text: String, pattern: String) -> String? {
+        regexCaptures(in: text, pattern: pattern).first
+    }
+
+    private static func regexCaptures(in text: String, pattern: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let ns = text as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        return regex.matches(in: text, range: range).compactMap { match in
+            let captureRange = match.numberOfRanges > 1 ? match.range(at: 1) : match.range(at: 0)
+            guard captureRange.location != NSNotFound else { return nil }
+            return ns.substring(with: captureRange)
+        }
+    }
+
+    private static func extractCitationLikePaths(from text: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: #"\b\d{4}-\d{2}-\d{2}/[A-Za-z0-9_\-\.]+\.md(?::\d+)?"#) else {
+            return []
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard let r = Range(match.range, in: text) else { return nil }
+            return String(text[r])
+        }
+    }
+
+    /// Sent back to the model after it emits a tool call we can't parse or map
+    /// to a tool, nudging it to either retry in the exact wire format or answer
+    /// in plain text.
+    static let malformedToolCallRecoveryPrompt = """
+    Your previous tool call could not be parsed — it was missing a valid "name" or had malformed JSON. \
+    To call a tool, emit it in exactly this format:
+    <tool_call>
+    {"name": "<tool name>", "arguments": { ... }}
+    </tool_call>
+    where "name" is one of the available tools. Either retry the tool call in that exact format, or, if you \
+    already have enough information, write your final answer in plain text with no tags.
+    """
+
+    /// Sent to local models that respond to an archive question with prose
+    /// instead of using tools. Kept short and concrete because small models
+    /// obey direct corrections better than long policy blocks.
+    static let localNoToolRecoveryPrompt = """
+    You answered without searching the archive. Do not explain your plan and do not say what you would do.
+
+    Call a tool now. Start with qmd_search using the most distinctive exact name or phrase from the user's question. \
+    For a timeline about a person, search that person's full name first; if no results come back, search name variants. \
+    After tool results arrive, answer chronologically with citations as path:line.
+    """
+
+    static let localNoToolFailureMessage = """
+    The local model answered without searching the meeting archive, even after Ghost Pepper asked it to use qmd_search. \
+    I suppressed that answer because it would not be source-backed. Try a stronger local Q&A model, or switch this question to Claude.
+    """
+
+    static func synthesisPrompt(evidence: MeetingQAEvidencePacket) -> String {
+        """
+        Now write your final answer to the user's original question, citing source files as path:line. \
+        Tools are unavailable for this reply.
+
+        Use only the source evidence below. Every factual claim needs a citation. \
+        Direct quotes must match the source text exactly.
+
+        \(evidence.compactSummary(maxSnippets: 60))
+        """
+    }
+
+    static func verificationRecoveryPrompt(reasons: [String], evidence: MeetingQAEvidencePacket) -> String {
+        let reasonText = reasons.isEmpty ? "The draft was not grounded enough." : reasons.map { "- \($0)" }.joined(separator: "\n")
+        return """
+        Your draft was not grounded well enough, so it was not shown to the user.
+
+        Fix these issues:
+        \(reasonText)
+
+        Write the final answer now. Use only the source evidence below. Cite every factual claim as path:line. \
+        Direct quotes must match the source text exactly. Do not call tools. Do not explain your plan.
+
+        \(evidence.compactSummary(maxSnippets: 80))
+        """
+    }
+
+    static func fallbackAnswer(question: String, evidence: MeetingQAEvidencePacket) -> String {
+        if evidence.isEmpty {
+            return """
+            I couldn't find source evidence strong enough to answer that reliably.
+            """
+        }
+        return """
+        I found source evidence, but the local model did not produce a fully verified answer. Here are the strongest source lines I found:
+
+        \(evidence.compactSummary(maxSnippets: 24))
+        """
+    }
+
     // MARK: - Q&A defaults
 
     static func summarizeQAInput(name: String, input: [String: Any]) -> String {
         switch name {
-        case "grep":
-            let pattern = (input["pattern"] as? String) ?? ""
+        case "qmd_search", "grep":
+            let pattern = (input["query"] as? String) ?? (input["pattern"] as? String) ?? ""
             let path = (input["path"] as? String).flatMap { $0.isEmpty ? nil : $0 }
-            return path.map { "pattern=\"\(pattern)\", path=\"\($0)\"" } ?? "pattern=\"\(pattern)\""
+            return path.map { "query=\"\(pattern)\", path=\"\($0)\"" } ?? "query=\"\(pattern)\""
         case "read_file":
             let path = (input["path"] as? String) ?? "?"
             let offset = (input["offset"] as? Int) ?? 1
@@ -262,18 +602,18 @@ final class MeetingQAAgent {
     }
 
     static func qaToolDefinitions() -> [LLMTool] {
-        let grep = LLMTool(
-            name: "grep",
-            description: "Search the meeting archive for a regex pattern. Returns each match with 2 lines of context before and after, so you usually have enough to answer without a follow-up read_file. Match groups are separated by `--`. Lines marked with `:` are matches; lines marked with `-` are surrounding context. Prefer this over read_file when looking for names, dates, or specific phrases — it's much cheaper than reading whole files.",
+        let qmdSearch = LLMTool(
+            name: "qmd_search",
+            description: "Search the meeting archive with qmd BM25 keyword search. Returns each result with nearby line-numbered context, so you usually have enough to answer without a follow-up read_file. Result groups are separated by `--`. Lines marked with `:` are matches; lines marked with `-` are surrounding context. Prefer this over read_file when looking for names, dates, companies, or specific phrases.",
             inputSchema: [
                 "type": "object",
                 "properties": [
-                    "pattern": ["type": "string", "description": "Regex pattern. Use plain strings for names. Use \\b for word boundaries."],
+                    "query": ["type": "string", "description": "Keywords or a short quoted phrase to search for. Use plain names, company names, dates, and distinctive terms."],
                     "path": ["type": "string", "description": "Optional subdirectory or file relative to the archive root."],
                     "case_insensitive": ["type": "boolean", "default": true],
                     "max_results": ["type": "integer", "default": 50, "maximum": 200],
                 ] as [String: Any],
-                "required": ["pattern"],
+                "required": ["query"],
             ]
         )
         let readFile = LLMTool(
@@ -300,6 +640,334 @@ final class MeetingQAAgent {
                 "required": ["path"],
             ]
         )
-        return [grep, readFile, listDir]
+        return [qmdSearch, readFile, listDir]
+    }
+}
+
+struct MeetingQAToolObservation {
+    let name: String
+    let input: [String: Any]
+    let output: String
+    let isError: Bool
+}
+
+struct MeetingQAEvidenceSnippet: Equatable {
+    let path: String
+    let line: Int
+    let text: String
+    let isMatch: Bool
+}
+
+struct MeetingQAEvidencePacket {
+    let snippets: [MeetingQAEvidenceSnippet]
+    let rawText: String
+
+    init(observations: [MeetingQAToolObservation]) {
+        let usable = observations.filter { !$0.isError }
+        self.rawText = usable.map(\.output).joined(separator: "\n")
+        self.snippets = usable.flatMap(Self.parseObservation)
+    }
+
+    var isEmpty: Bool { snippets.isEmpty }
+
+    var observedPaths: Set<String> {
+        Set(snippets.map(\.path))
+    }
+
+    func compactSummary(maxSnippets: Int = 60, maxLineLength: Int = 260) -> String {
+        guard !snippets.isEmpty else {
+            return "Source evidence: no matching source lines were returned by the tools."
+        }
+
+        let sorted = snippets.sorted {
+            if $0.path != $1.path { return $0.path < $1.path }
+            return $0.line < $1.line
+        }
+        let lines = sorted.prefix(max(1, maxSnippets)).map { snippet in
+            let text = Self.truncate(snippet.text.isEmpty ? "(blank line)" : snippet.text, maxLength: maxLineLength)
+            return "- \(snippet.path):\(snippet.line) \(text)"
+        }
+        var summary = "Source evidence:\n" + lines.joined(separator: "\n")
+        if sorted.count > maxSnippets {
+            summary += "\n- ... \(sorted.count - maxSnippets) more source lines omitted"
+        }
+        return summary
+    }
+
+    func containsQuote(_ quote: String) -> Bool {
+        let normalizedQuote = Self.normalizeForQuoteCheck(quote)
+        guard normalizedQuote.count >= 8 else { return true }
+        let normalizedRaw = Self.normalizeForQuoteCheck(rawText)
+        if normalizedRaw.contains(normalizedQuote) { return true }
+
+        let normalizedSnippetText = Self.normalizeForQuoteCheck(snippets.map(\.text).joined(separator: "\n"))
+        return normalizedSnippetText.contains(normalizedQuote)
+    }
+
+    private static func parseObservation(_ observation: MeetingQAToolObservation) -> [MeetingQAEvidenceSnippet] {
+        switch observation.name {
+        case "read_file":
+            let path = (observation.input["path"] as? String) ?? ""
+            return parseReadFileOutput(path: path, output: observation.output)
+        default:
+            return parsePathLineOutput(observation.output)
+        }
+    }
+
+    private static func parsePathLineOutput(_ output: String) -> [MeetingQAEvidenceSnippet] {
+        let pattern = #"^(.+?\.md)([:\-])(\d+)(?:[:\-])(.*)$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        return output.split(separator: "\n", omittingEmptySubsequences: false).compactMap { rawLine in
+            let line = String(rawLine)
+            let ns = line as NSString
+            let range = NSRange(location: 0, length: ns.length)
+            guard let match = regex.firstMatch(in: line, range: range),
+                  match.numberOfRanges == 5,
+                  let pathRange = Range(match.range(at: 1), in: line),
+                  let separatorRange = Range(match.range(at: 2), in: line),
+                  let lineRange = Range(match.range(at: 3), in: line),
+                  let textRange = Range(match.range(at: 4), in: line),
+                  let lineNumber = Int(line[lineRange])
+            else { return nil }
+
+            return MeetingQAEvidenceSnippet(
+                path: String(line[pathRange]),
+                line: lineNumber,
+                text: String(line[textRange]).trimmingCharacters(in: .whitespaces),
+                isMatch: String(line[separatorRange]) == ":"
+            )
+        }
+    }
+
+    private static func parseReadFileOutput(path: String, output: String) -> [MeetingQAEvidenceSnippet] {
+        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
+        let pattern = #"^(\d+)\t(.*)$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        return output.split(separator: "\n", omittingEmptySubsequences: false).compactMap { rawLine in
+            let line = String(rawLine)
+            let ns = line as NSString
+            let range = NSRange(location: 0, length: ns.length)
+            guard let match = regex.firstMatch(in: line, range: range),
+                  match.numberOfRanges == 3,
+                  let lineRange = Range(match.range(at: 1), in: line),
+                  let textRange = Range(match.range(at: 2), in: line),
+                  let lineNumber = Int(line[lineRange])
+            else { return nil }
+
+            return MeetingQAEvidenceSnippet(
+                path: path,
+                line: lineNumber,
+                text: String(line[textRange]).trimmingCharacters(in: .whitespaces),
+                isMatch: true
+            )
+        }
+    }
+
+    private static func truncate(_ value: String, maxLength: Int) -> String {
+        guard value.count > maxLength else { return value }
+        return String(value.prefix(maxLength - 1)) + "…"
+    }
+
+    private static func normalizeForQuoteCheck(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "“", with: "\"")
+            .replacingOccurrences(of: "”", with: "\"")
+            .replacingOccurrences(of: "‘", with: "'")
+            .replacingOccurrences(of: "’", with: "'")
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}
+
+struct MeetingQAAnswerVerification {
+    let isValid: Bool
+    let reasons: [String]
+}
+
+enum MeetingQAAnswerVerifier {
+    static func validate(
+        answer: String,
+        question: String,
+        evidence: MeetingQAEvidencePacket,
+        archiveRoot: URL? = nil
+    ) -> MeetingQAAnswerVerification {
+        var reasons: [String] = []
+        let trimmed = answer.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return MeetingQAAnswerVerification(isValid: false, reasons: ["The answer was empty."])
+        }
+
+        let lower = trimmed.lowercased()
+        let planningMarkers = [
+            "okay, so i need",
+            "okay, i need",
+            "i need to figure out",
+            "first, i'll",
+            "i'll start",
+            "i'll run",
+            "let me check",
+            "looking at the source evidence",
+            "source evidence given by the user",
+            "step-by-step explanation",
+            "initial search",
+            "relaxation strategy",
+            "the assistant tried",
+            "i conducted a search",
+            "qmd_search",
+            "perhaps the user wants",
+            "therefore, perhaps",
+            "the best approach is",
+            "use list_dir",
+            "without knowing how",
+            "i can't extract",
+            "i would need to",
+            "i remember",
+            "i recall",
+        ]
+        if let marker = planningMarkers.first(where: { lower.contains($0) }) {
+            reasons.append("The answer exposed tool planning or uncertainty (`\(marker)`).")
+        }
+
+        let citations = extractCitations(from: trimmed)
+        let archiveQuestion = asksArchiveQuestion(question)
+        if archiveQuestion {
+            if containsPlaceholderCitation(trimmed) {
+                reasons.append("The answer used placeholder citations like `path:15` instead of real source paths.")
+            }
+            if !evidence.isEmpty, citations.isEmpty {
+                reasons.append("The answer used archive evidence but did not cite any source file lines.")
+            } else if evidence.isEmpty, makesUnsupportedNoEvidenceClaim(trimmed) {
+                reasons.append("The answer made archive claims even though the tools returned no source evidence.")
+            }
+        }
+
+        let observedPaths = evidence.observedPaths
+        for citation in citations {
+            let citationPath = citation.path
+            let existsOnDisk = archiveRoot.map { FileManager.default.fileExists(atPath: $0.appendingPathComponent(citationPath).path) } ?? false
+            if !observedPaths.contains(citationPath) && !existsOnDisk {
+                reasons.append("The citation \(citation.raw) was not present in the retrieved evidence.")
+            }
+        }
+
+        if !evidence.isEmpty {
+            let missingQuotes = extractDirectQuotes(from: trimmed).filter { !evidence.containsQuote($0) }
+            if let firstMissingQuote = missingQuotes.first {
+                reasons.append("The direct quote \"\(String(firstMissingQuote.prefix(80)))\" was not found in the retrieved evidence.")
+            }
+        }
+
+        if question.lowercased().contains("timeline") {
+            let datedLinesWithoutCitations = trimmed
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init)
+                .filter { containsISODate($0) && extractCitations(from: $0).isEmpty }
+            if !datedLinesWithoutCitations.isEmpty {
+                reasons.append("Timeline date lines need source citations.")
+            }
+        }
+
+        return MeetingQAAnswerVerification(isValid: reasons.isEmpty, reasons: reasons)
+    }
+
+    private static func asksArchiveQuestion(_ question: String) -> Bool {
+        let lower = question.lowercased()
+        return [
+            "meeting", "meetings", "transcript", "timeline", "summarize",
+            "summary", "who", "when", "where", "what did", "with ", "about "
+        ].contains { lower.contains($0) }
+    }
+
+    private static func makesUnsupportedNoEvidenceClaim(_ answer: String) -> Bool {
+        let lower = answer.lowercased()
+        let unsupportedMarkers = [
+            "however",
+            "but wait",
+            "i recall",
+            "i remember",
+            "might be related",
+            "could be related",
+            "maybe",
+            "likely",
+            "around mid",
+            "took place",
+            "participated",
+            "attended",
+            "met ",
+        ]
+        if unsupportedMarkers.contains(where: { lower.contains($0) }) {
+            return true
+        }
+
+        if containsISODate(answer) {
+            return true
+        }
+
+        let noEvidenceMarkers = [
+            "couldn't find",
+            "could not find",
+            "no source evidence",
+            "no matches",
+            "didn't find",
+            "did not find",
+        ]
+        return !noEvidenceMarkers.contains(where: { lower.contains($0) })
+    }
+
+    private static func containsPlaceholderCitation(_ answer: String) -> Bool {
+        let patterns = [
+            #"(?i)\bpath:\d+(?:-\d+)?\b"#,
+            #"(?i)\[`path:\d+(?:-\d+)?`\]"#,
+            #"(?i)\bsource:\s*path:\d+(?:-\d+)?\b"#,
+        ]
+        return patterns.contains { pattern in
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+            let range = NSRange(answer.startIndex..<answer.endIndex, in: answer)
+            return regex.firstMatch(in: answer, range: range) != nil
+        }
+    }
+
+    private static func extractDirectQuotes(from text: String) -> [String] {
+        let patterns = [
+            #""([^"\n]{12,})""#,
+            #"“([^”\n]{12,})”"#,
+        ]
+        return patterns.flatMap { pattern -> [String] in
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+            let ns = text as NSString
+            let range = NSRange(location: 0, length: ns.length)
+            return regex.matches(in: text, range: range).compactMap { match in
+                guard match.numberOfRanges > 1 else { return nil }
+                let value = ns.substring(with: match.range(at: 1)).trimmingCharacters(in: .whitespacesAndNewlines)
+                return value.rangeOfCharacter(from: .letters) == nil ? nil : value
+            }
+        }
+    }
+
+    private struct Citation {
+        let raw: String
+        let path: String
+    }
+
+    private static func extractCitations(from text: String) -> [Citation] {
+        let pattern = #"\b((?:\d{4}-\d{2}-\d{2}|\.indexes|Reads)/[^\s,()\[\]`]+\.md)(?::\d+(?:-\d+)?)?"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let ns = text as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        return regex.matches(in: text, range: range).compactMap { match in
+            guard match.numberOfRanges > 1 else { return nil }
+            return Citation(
+                raw: ns.substring(with: match.range(at: 0)),
+                path: ns.substring(with: match.range(at: 1))
+            )
+        }
+    }
+
+    private static func containsISODate(_ text: String) -> Bool {
+        let pattern = #"\b20\d{2}-\d{2}-\d{2}\b"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.firstMatch(in: text, range: range) != nil
     }
 }

--- a/GhostPepper/QA/MeetingQASystemPrompt.swift
+++ b/GhostPepper/QA/MeetingQASystemPrompt.swift
@@ -13,7 +13,7 @@ enum MeetingQASystemPrompt {
     ) -> String {
         return """
         You are the meeting Q&A assistant for the user's personal meeting archive. \
-        You answer questions about their meetings using three tools: grep, read_file, and list_dir.
+        You answer questions about their meetings using three tools: qmd_search, read_file, and list_dir.
 
         # Archive layout
 
@@ -38,28 +38,42 @@ enum MeetingQASystemPrompt {
            No frontmatter. Starts with an H1 title, then **Date:** line, then ## Notes \
            with free-form content. Generally short.
 
-        Both formats are valid. When grep matches a file, check for `---` on line 1 to know \
+        Both formats are valid. When qmd_search matches a file, check for `---` on line 1 to know \
         which format you're dealing with.
 
         # How to answer
 
         1. Always cite your sources as `path:line` or `path:start-end`. Every factual claim \
            needs a citation. If you can't cite it, don't claim it.
-        2. Prefer grep for names, dates, and exact strings. It's much cheaper than read_file.
-        3. Use read_file with a small offset/limit to confirm context around a grep match. \
+        2. Prefer qmd_search for names, dates, companies, and exact strings. It's much cheaper than read_file.
+        3. Use read_file with a small offset/limit to confirm context around a qmd_search match. \
            Read more (up to 1000 lines) only when you need the full meeting.
         4. Use list_dir to discover meetings on a specific date or to find date-named folders.
         5. Stop searching when you have enough to answer. Don't read every file.
 
+        Never describe a tool-use plan to the user. If you need archive facts, call the tool. \
+        The user should only see the final answer, not your uncertainty or deliberation.
+
+        # Timeline questions
+
+        For "summarize my meetings with PERSON as a timeline" or similar:
+        1. Start with `qmd_search` for the person's full name exactly as written.
+        2. If that returns nothing, search distinctive variants: first name + last name, \
+           middle name, company/affiliation terms, or likely transcript spellings.
+        3. Include only meetings where the search/read evidence connects that person to \
+           the meeting. Do not list every meeting date in the archive.
+        4. Sort the final answer chronologically. Each timeline item needs a citation and, \
+           when useful, a short direct quote from the cited lines.
+
         # When your first search returns one or more hits
 
-        Grep results now include 2 lines of context before and after each match \
+        qmd_search results include nearby context around each match \
         (lines starting with `-` are context; lines with `:` are matches). For \
         most questions, the matched lines plus their context are enough to \
         answer directly — you do NOT need a follow-up read_file. Read the file \
         only if the context lines don't cover what you need.
 
-        Once you have a relevant hit, **stop searching**. Don't run more grep \
+        Once you have a relevant hit, **stop searching**. Don't run more qmd_search \
         variants "just to be sure". The relaxation ladder below is for the \
         empty-result case only.
 
@@ -117,7 +131,7 @@ enum MeetingQASystemPrompt {
         # Iteration budget
 
         You have at most \(maxIterations) tool calls per question. Plan \
-        accordingly. Front-load grep calls (cheap, narrow the search), then \
+        accordingly. Front-load qmd_search calls (cheap, narrow the search), then \
         read selectively.
         \(localAddendum(backend: backend))
         """
@@ -133,9 +147,11 @@ enum MeetingQASystemPrompt {
         You have a tighter budget and slower inference than a cloud model. \
         Skip exploration when you don't need it.
 
-        - As soon as one grep returns a relevant hit, **answer from the \
-          context lines**. Don't run another grep. Don't read_file unless the \
+        - As soon as one qmd_search returns a relevant hit, **answer from the \
+          context lines**. Don't run another qmd_search. Don't read_file unless the \
           context truly doesn't cover the question.
+        - Do not write analysis, uncertainty, or a numbered plan. The first visible \
+          text should be the final answer after tool results.
         - Generic single-word patterns ("Diaz", "the", "gizmo") will time out. \
           Always search for at least two words together, or a distinctive \
           token, when possible.

--- a/GhostPepper/QA/MeetingQATools.swift
+++ b/GhostPepper/QA/MeetingQATools.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum MeetingQAToolError: LocalizedError {
+    case searchFailed(String)
     case grepFailed(String)
     case readFailed(String)
     case writeFailed(String)
@@ -11,6 +12,7 @@ enum MeetingQAToolError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .searchFailed(let m): return "search failed: \(m)"
         case .grepFailed(let m): return "grep failed: \(m)"
         case .readFailed(let m): return "read failed: \(m)"
         case .writeFailed(let m): return "write failed: \(m)"
@@ -30,9 +32,10 @@ struct MeetingQATools {
         self.root = root
     }
 
-    // MARK: - grep
+    // MARK: - qmd_search
 
-    func grep(pattern: String, path: String?, caseInsensitive: Bool, maxResults: Int) async throws -> String {
+    func qmdSearch(query: String, path: String?, caseInsensitive: Bool, maxResults: Int) async throws -> String {
+        let normalizedQuery = Self.normalizedLiteralQuery(query)
         let searchURL: URL
         if let path = path, !path.isEmpty, path != "." {
             searchURL = try PathSandbox.resolveSafe(path, root: root)
@@ -40,18 +43,148 @@ struct MeetingQATools {
             searchURL = root
         }
 
-        let binary = Self.preferredGrepBinary()
+        let relativePath = relativePathInRoot(for: searchURL)
+        if shouldUseQMD(query: normalizedQuery, relativePath: relativePath, caseInsensitive: caseInsensitive),
+           let binary = Self.preferredQMDBinary() {
+            do {
+                let qmdOutput = try await qmdSearchWithBinary(binary, query: normalizedQuery, maxResults: maxResults)
+                if !Self.isNoMatchesOutput(qmdOutput) {
+                    return qmdOutput
+                }
+
+                let textOutput = try await recursiveTextSearch(query: normalizedQuery, searchURL: searchURL, caseInsensitive: caseInsensitive, maxResults: maxResults)
+                if !Self.isNoMatchesOutput(textOutput) {
+                    return textOutput + "\n(qmd returned no matches; used exact text fallback.)"
+                }
+                return qmdOutput
+            } catch {
+                // qmd is an optional local accelerator. If it is missing a
+                // runtime dependency, has a stale index, or otherwise fails,
+                // keep the Q&A flow alive with the legacy text search path.
+            }
+        }
+
+        return try await recursiveTextSearch(query: normalizedQuery, searchURL: searchURL, caseInsensitive: caseInsensitive, maxResults: maxResults)
+    }
+
+    /// Compatibility alias for older prompts/traces and local-model recoveries
+    /// that still emit a `grep` tool call.
+    func grep(pattern: String, path: String?, caseInsensitive: Bool, maxResults: Int) async throws -> String {
+        try await qmdSearch(query: pattern, path: path, caseInsensitive: caseInsensitive, maxResults: maxResults)
+    }
+
+    // MARK: - exact text fallback
+
+    private func recursiveTextSearch(query: String, searchURL: URL, caseInsensitive: Bool, maxResults: Int) async throws -> String {
+        let files = try markdownFiles(in: searchURL)
+        let cap = max(1, min(maxResults, 200))
+        var groups: [[String]] = []
+
+        for file in files {
+            let content: String
+            do {
+                content = try String(contentsOf: file, encoding: .utf8)
+            } catch {
+                continue
+            }
+
+            let lines = content.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            let searchableQuery = caseInsensitive ? query.lowercased() : query
+            for (index, line) in lines.enumerated() {
+                let searchableLine = caseInsensitive ? line.lowercased() : line
+                guard searchableLine.contains(searchableQuery) else { continue }
+
+                let lineNumber = index + 1
+                let start = max(0, index - 2)
+                let end = min(lines.count - 1, index + 2)
+                let relative = relativePathInRoot(for: file) ?? file.lastPathComponent
+                let block = (start...end).map { contextIndex in
+                    let contextLineNumber = contextIndex + 1
+                    let separator = contextLineNumber == lineNumber ? ":" : "-"
+                    return "\(relative)\(separator)\(contextLineNumber)\(separator)\(lines[contextIndex])"
+                }
+                groups.append(block)
+                if groups.count >= cap { break }
+            }
+            if groups.count >= cap { break }
+        }
+
+        guard !groups.isEmpty else {
+            return "No matches found for query: \(query)"
+        }
+
+        var output = groups.map { $0.joined(separator: "\n") }.joined(separator: "\n--\n")
+        if !output.isEmpty { output += "\n" }
+        if groups.count >= cap {
+            output += "\n(Returned \(groups.count) match groups; max_results hit. Increase max_results or narrow the query.)"
+        } else {
+            output += "\n(Returned \(groups.count) of \(groups.count) match groups.)"
+        }
+        return output
+    }
+
+    private func markdownFiles(in searchURL: URL) throws -> [URL] {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: searchURL.path, isDirectory: &isDirectory) else {
+            throw MeetingQAToolError.fileNotFound(relativePathInRoot(for: searchURL) ?? searchURL.path)
+        }
+
+        if !isDirectory.boolValue {
+            return searchURL.pathExtension.lowercased() == "md" ? [searchURL] : []
+        }
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: searchURL,
+            includingPropertiesForKeys: [.isRegularFileKey, .isHiddenKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            throw MeetingQAToolError.notADirectory(relativePathInRoot(for: searchURL) ?? searchURL.path)
+        }
+
+        var files: [URL] = []
+        for case let url as URL in enumerator {
+            if url.lastPathComponent == ".git" {
+                enumerator.skipDescendants()
+                continue
+            }
+            guard url.pathExtension.lowercased() == "md" else { continue }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isHiddenKey])
+            guard values?.isRegularFile == true, values?.isHidden != true else { continue }
+            files.append(url)
+        }
+        return files.sorted { $0.path < $1.path }
+    }
+
+    // MARK: - process text search fallback
+
+    private func recursiveGrep(pattern: String, searchURL: URL, caseInsensitive: Bool, maxResults: Int) async throws -> String {
+        let backend = Self.preferredTextSearchBackend()
         // -B/-A include 2 lines before/after each match so weak local models
         // get context "for free" without needing a follow-up read_file. grep
         // emits "--" separators between non-adjacent match groups; we split
         // on those and cap by group count rather than raw line count.
-        var args: [String] = ["-r", "-n", "--include=*.md", "--exclude-dir=.git", "-B", "2", "-A", "2"]
-        if caseInsensitive { args.append("-i") }
-        args.append("-e")
-        args.append(pattern)
-        args.append(searchURL.path)
+        let binary: String
+        let args: [String]
+        switch backend {
+        case .ripgrep(let path):
+            binary = path
+            var rgArgs: [String] = ["-n", "-g", "*.md", "-g", "!.git/**", "-B", "2", "-A", "2"]
+            if caseInsensitive { rgArgs.append("-i") }
+            rgArgs.append("--")
+            rgArgs.append(pattern)
+            rgArgs.append(searchURL.path)
+            args = rgArgs
+        case .grep(let path):
+            binary = path
+            var grepArgs: [String] = ["-r", "-n", "--include=*.md", "--exclude-dir=.git", "-B", "2", "-A", "2"]
+            if caseInsensitive { grepArgs.append("-i") }
+            grepArgs.append("-e")
+            grepArgs.append(pattern)
+            grepArgs.append(searchURL.path)
+            args = grepArgs
+        }
 
-        let result = try await runProcess(launchPath: binary, arguments: args)
+        let result = try await runProcess(launchPath: binary, arguments: args, timeoutDescription: "grep")
         if result.exitCode > 1 {
             throw MeetingQAToolError.grepFailed(result.stderr.isEmpty ? "exit \(result.exitCode)" : result.stderr)
         }
@@ -85,6 +218,96 @@ struct MeetingQATools {
             output += "\n(Returned \(totalBlocks) of \(totalBlocks) match groups.)"
         }
         return output
+    }
+
+    private func qmdSearchWithBinary(_ binary: String, query: String, maxResults: Int) async throws -> String {
+        try await ensureQMDIndex(binary)
+
+        let cap = max(1, min(maxResults, 200))
+        // Ask qmd for a slightly larger candidate set so filtering and chunk
+        // overlap don't hide useful meeting hits before we apply max_results.
+        let candidateLimit = min(max(cap * 3, cap), 200)
+        let result = try await runProcess(
+            launchPath: binary,
+            arguments: ["search", query, "--json", "--line-numbers", "-n", "\(candidateLimit)", "-c", qmdCollectionName],
+            workingDirectory: root,
+            timeoutDescription: "qmd search"
+        )
+        guard result.exitCode == 0 else {
+            throw MeetingQAToolError.searchFailed(result.stderr.isEmpty ? "qmd search exited \(result.exitCode)" : result.stderr)
+        }
+
+        let matches = Self.parseQMDSearchResults(result.stdout, collectionName: qmdCollectionName)
+            .filter { Self.isMeetingMarkdownPath($0.relativePath) }
+        guard !matches.isEmpty else {
+            return "No matches found for query: \(query)"
+        }
+
+        let limited = Array(matches.prefix(cap))
+        let blocks = try await limited.mapAsync { match in
+            try await qmdContextBlock(binary: binary, match: match)
+        }
+
+        var output = blocks.joined(separator: "\n--\n")
+        if !output.isEmpty { output += "\n" }
+        if matches.count > cap {
+            output += "\n(Returned \(cap) of \(matches.count) qmd search results; max_results hit. Increase max_results or narrow the query.)"
+        } else {
+            output += "\n(Returned \(matches.count) of \(matches.count) qmd search results.)"
+        }
+        return output
+    }
+
+    private func qmdContextBlock(binary: String, match: QMDSearchResult) async throws -> String {
+        let startLine = max(1, match.line - 2)
+        let result = try await runProcess(
+            launchPath: binary,
+            arguments: ["get", "\(match.file):\(startLine)", "-l", "5", "--line-numbers"],
+            workingDirectory: root,
+            timeoutDescription: "qmd get"
+        )
+        guard result.exitCode == 0 else {
+            return "\(match.relativePath):\(match.line):\(match.title)"
+        }
+        return Self.formatQMDContext(
+            result.stdout,
+            relativePath: match.relativePath,
+            matchLine: match.line,
+            fallbackTitle: match.title
+        )
+    }
+
+    private func ensureQMDIndex(_ binary: String) async throws {
+        let initResult = try await runProcess(
+            launchPath: binary,
+            arguments: ["init"],
+            workingDirectory: root,
+            timeoutDescription: "qmd init"
+        )
+        guard initResult.exitCode == 0 else {
+            throw MeetingQAToolError.searchFailed(initResult.stderr.isEmpty ? "qmd init exited \(initResult.exitCode)" : initResult.stderr)
+        }
+
+        let addResult = try await runProcess(
+            launchPath: binary,
+            arguments: ["collection", "add", ".", "--name", qmdCollectionName],
+            workingDirectory: root,
+            timeoutDescription: "qmd collection add"
+        )
+        let addOutput = addResult.stdout + addResult.stderr
+        if addResult.exitCode != 0 && !addOutput.contains("already exists") {
+            throw MeetingQAToolError.searchFailed(addOutput.isEmpty ? "qmd collection add exited \(addResult.exitCode)" : addOutput)
+        }
+
+        let updateResult = try await runProcess(
+            launchPath: binary,
+            arguments: ["update"],
+            workingDirectory: root,
+            timeoutDescription: "qmd update"
+        )
+        guard updateResult.exitCode == 0 else {
+            throw MeetingQAToolError.searchFailed(updateResult.stderr.isEmpty ? "qmd update exited \(updateResult.exitCode)" : updateResult.stderr)
+        }
     }
 
     // MARK: - read_file
@@ -181,11 +404,17 @@ struct MeetingQATools {
         let exitCode: Int32
     }
 
-    private func runProcess(launchPath: String, arguments: [String]) async throws -> ProcessResult {
+    private func runProcess(
+        launchPath: String,
+        arguments: [String],
+        workingDirectory: URL? = nil,
+        timeoutDescription: String
+    ) async throws -> ProcessResult {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ProcessResult, Error>) in
             let process = Process()
             process.executableURL = URL(fileURLWithPath: launchPath)
             process.arguments = arguments
+            process.currentDirectoryURL = workingDirectory
 
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
@@ -206,7 +435,7 @@ struct MeetingQATools {
             timer.setEventHandler {
                 if process.isRunning {
                     process.terminate()
-                    resumeOnce { continuation.resume(throwing: MeetingQAToolError.timedOut("grep")) }
+                    resumeOnce { continuation.resume(throwing: MeetingQAToolError.timedOut(timeoutDescription)) }
                 }
             }
             timer.resume()
@@ -229,11 +458,154 @@ struct MeetingQATools {
         }
     }
 
-    private static func preferredGrepBinary() -> String {
+    private enum TextSearchBackend {
+        case ripgrep(String)
+        case grep(String)
+    }
+
+    private static func preferredTextSearchBackend() -> TextSearchBackend {
         let candidates = ["/opt/homebrew/bin/rg", "/usr/local/bin/rg"]
+        for c in candidates where FileManager.default.isExecutableFile(atPath: c) {
+            return .ripgrep(c)
+        }
+        return .grep("/usr/bin/grep")
+    }
+
+    private static func preferredQMDBinary() -> String? {
+        let candidates = ["/opt/homebrew/bin/qmd", "/usr/local/bin/qmd"]
         for c in candidates where FileManager.default.isExecutableFile(atPath: c) {
             return c
         }
-        return "/usr/bin/grep"
+        return nil
+    }
+
+    private var qmdCollectionName: String {
+        "meetings_\(Self.stableHexHash(root.standardizedFileURL.path))"
+    }
+
+    private struct QMDSearchResult {
+        let file: String
+        let relativePath: String
+        let line: Int
+        let title: String
+    }
+
+    private func relativePathInRoot(for url: URL) -> String? {
+        let rootPath = root.standardizedFileURL.path
+        let targetPath = url.standardizedFileURL.path
+        guard targetPath != rootPath else { return nil }
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+        guard targetPath.hasPrefix(prefix) else { return nil }
+        return String(targetPath.dropFirst(prefix.count))
+    }
+
+    private func shouldUseQMD(query: String, relativePath: String?, caseInsensitive: Bool) -> Bool {
+        guard relativePath == nil else { return false }
+        guard caseInsensitive else { return false }
+        guard !Self.looksLikeRegex(query) else { return false }
+        return true
+    }
+
+    private static func looksLikeRegex(_ query: String) -> Bool {
+        let regexCharacters = CharacterSet(charactersIn: #"[](){}.*+?|^$\"#)
+        return query.rangeOfCharacter(from: regexCharacters) != nil
+    }
+
+    private static func normalizedLiteralQuery(_ query: String) -> String {
+        var trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let quotePairs: [(Character, Character)] = [
+            ("\"", "\""),
+            ("“", "”"),
+            ("'", "'"),
+            ("‘", "’"),
+        ]
+        for (open, close) in quotePairs where trimmed.first == open && trimmed.last == close && trimmed.count >= 2 {
+            trimmed.removeFirst()
+            trimmed.removeLast()
+            return trimmed.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return trimmed
+    }
+
+    static func isNoMatchesOutput(_ output: String) -> Bool {
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed.hasPrefix("no matches found for query:") || trimmed.hasPrefix("no matches found for pattern:")
+    }
+
+    private static func stableHexHash(_ value: String) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        return String(hash, radix: 16)
+    }
+
+    private static func parseQMDSearchResults(_ stdout: String, collectionName: String) -> [QMDSearchResult] {
+        guard let data = stdout.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+        return array.compactMap { item in
+            guard let file = item["file"] as? String,
+                  let relativePath = qmdRelativePath(from: file, collectionName: collectionName) else {
+                return nil
+            }
+            let line = (item["line"] as? Int) ?? 1
+            let title = (item["title"] as? String) ?? relativePath
+            return QMDSearchResult(file: file, relativePath: relativePath, line: max(1, line), title: title)
+        }
+    }
+
+    private static func qmdRelativePath(from file: String, collectionName: String) -> String? {
+        let prefix = "qmd://\(collectionName)/"
+        if file.hasPrefix(prefix) {
+            let raw = String(file.dropFirst(prefix.count))
+            return raw.removingPercentEncoding ?? raw
+        }
+        return nil
+    }
+
+    private static func isMeetingMarkdownPath(_ path: String) -> Bool {
+        guard path.hasSuffix(".md") else { return false }
+        let parts = path.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true)
+        guard let first = parts.first else { return false }
+        return first.range(of: #"^\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) != nil
+    }
+
+    private static func formatQMDContext(
+        _ stdout: String,
+        relativePath: String,
+        matchLine: Int,
+        fallbackTitle: String
+    ) -> String {
+        let lines = stdout.split(separator: "\n", omittingEmptySubsequences: false)
+        let formatted = lines.compactMap { rawLine -> String? in
+            let line = String(rawLine)
+            guard let colon = line.firstIndex(of: ":") else { return nil }
+            let numberText = line[..<colon]
+            guard let lineNumber = Int(numberText.trimmingCharacters(in: .whitespaces)) else { return nil }
+            var content = String(line[line.index(after: colon)...])
+            if content.hasPrefix(" ") { content.removeFirst() }
+            if lineNumber == matchLine {
+                return "\(relativePath):\(lineNumber):\(content)"
+            }
+            return "\(relativePath)-\(lineNumber)-\(content)"
+        }
+        if formatted.isEmpty {
+            return "\(relativePath):\(matchLine):\(fallbackTitle)"
+        }
+        return formatted.joined(separator: "\n")
+    }
+}
+
+private extension Array {
+    func mapAsync<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
+        var values: [T] = []
+        values.reserveCapacity(count)
+        for element in self {
+            values.append(try await transform(element))
+        }
+        return values
     }
 }

--- a/GhostPepper/QA/QwenToolCallParser.swift
+++ b/GhostPepper/QA/QwenToolCallParser.swift
@@ -15,6 +15,11 @@ final class QwenToolCallParser {
     enum Output: Equatable {
         case text(String)
         case toolCall(name: String, input: [String: Any])
+        /// A `<tool_call>` block that could neither be parsed as JSON nor have
+        /// its tool inferred from the argument shape. Carries the raw payload so
+        /// the agent loop can re-prompt the model rather than treating the blob
+        /// as a final answer. See memory note qwen-toolcall-malformed.
+        case malformedToolCall(raw: String)
 
         static func == (lhs: Output, rhs: Output) -> Bool {
             switch (lhs, rhs) {
@@ -22,6 +27,8 @@ final class QwenToolCallParser {
                 return a == b
             case (.toolCall(let na, _), .toolCall(let nb, _)):
                 return na == nb
+            case (.malformedToolCall(let a), .malformedToolCall(let b)):
+                return a == b
             default:
                 return false
             }
@@ -128,8 +135,14 @@ final class QwenToolCallParser {
                         }
                         outputs.append(.toolCall(name: parsed.name, input: parsed.input))
                     } else {
-                        // malformed — surface raw payload as text so the user sees something
-                        textRun.append(Self.openMarker + jsonBuffer + Self.closeMarker)
+                        // Unparseable / uninferable: emit a distinct malformed
+                        // signal so the agent loop can re-prompt instead of
+                        // treating the blob as a final answer.
+                        if !textRun.isEmpty {
+                            outputs.append(.text(textRun))
+                            textRun = ""
+                        }
+                        outputs.append(.malformedToolCall(raw: jsonBuffer))
                     }
                     state = .text
                     jsonBuffer = ""
@@ -161,9 +174,11 @@ final class QwenToolCallParser {
         case .openTag:
             outputs.append(.text(pendingTag))
         case .toolCall:
-            outputs.append(.text(Self.openMarker + jsonBuffer))
+            // Stream ended mid tool_call (never closed) — treat as malformed so
+            // the loop can recover rather than dumping the partial JSON as text.
+            outputs.append(.malformedToolCall(raw: jsonBuffer))
         case .closeTag:
-            outputs.append(.text(Self.openMarker + jsonBuffer + pendingTag))
+            outputs.append(.malformedToolCall(raw: jsonBuffer))
         case .thinkBlock, .thinkCloseTag:
             // unclosed think block — discard, don't surface internal reasoning
             break
@@ -178,8 +193,51 @@ final class QwenToolCallParser {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let data = trimmed.data(using: .utf8) else { return nil }
         guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-        guard let name = obj["name"] as? String else { return nil }
-        let arguments = obj["arguments"] as? [String: Any] ?? [:]
-        return (name, arguments)
+
+        // Arguments may be nested under "arguments"/"parameters", or — when the
+        // model emits a bare call — sit at the top level alongside (or instead
+        // of) "name".
+        let arguments: [String: Any]
+        if let nested = obj["arguments"] as? [String: Any] {
+            arguments = nested
+        } else if let nested = obj["parameters"] as? [String: Any] {
+            arguments = nested
+        } else {
+            arguments = obj.filter { $0.key != "name" }
+        }
+
+        if let name = obj["name"] as? String, !name.isEmpty {
+            return (name, arguments)
+        }
+
+        // Recovery: local Qwen 3.5 (q4) models sometimes emit a tool_call whose
+        // JSON drops the required "name" and carries only the arguments. Rather
+        // than surface it as a dead-end text blob (which the agent treats as a
+        // final answer and stops on), infer the tool from the argument shape —
+        // the agent's tools have distinguishable signatures. See memory note
+        // qwen-toolcall-malformed.
+        if let inferred = inferToolName(fromArguments: arguments) {
+            return (inferred, arguments)
+        }
+        return nil
+    }
+
+    /// Maps a tool_call's argument keys back to a tool name when the model
+    /// omitted it. The meeting-QA / indexing tools (qmd_search, read_file, list_dir,
+    /// write_file) have non-overlapping enough signatures to disambiguate:
+    ///   - `query`/`pattern`    → qmd_search
+    ///   - `content`            → write_file
+    ///   - `offset`/`limit`     → read_file
+    ///   - `path` only          → read_file if it points at a .md file, else list_dir
+    private static func inferToolName(fromArguments args: [String: Any]) -> String? {
+        let keys = Set(args.keys)
+        if keys.contains("query") || keys.contains("pattern") { return "qmd_search" }
+        if keys.contains("content") { return "write_file" }
+        if keys.contains("offset") || keys.contains("limit") { return "read_file" }
+        if keys.contains("path") {
+            if let path = args["path"] as? String, path.hasSuffix(".md") { return "read_file" }
+            return "list_dir"
+        }
+        return nil
     }
 }

--- a/GhostPepper/UI/BuildIndexSheet.swift
+++ b/GhostPepper/UI/BuildIndexSheet.swift
@@ -7,7 +7,7 @@ struct BuildIndexSheet: View {
     let fetchBuilder: () -> IndexBuilder?
     let onClose: () -> Void
 
-    @AppStorage("claudeAPIModel") private var storedModel: String = ClaudeAPIModel.sonnet.rawValue
+    @AppStorage("agentBackend") private var storedBackend: String = "claude:\(ClaudeAPIModel.sonnet.rawValue)"
     @State private var phase: Phase = .estimating
     @State private var estimate: IndexBuildEstimate?
     @State private var statusLine: String = ""
@@ -18,8 +18,12 @@ struct BuildIndexSheet: View {
     @State private var errorMessage: String?
     @State private var buildTask: Task<Void, Never>?
 
-    private var selectedModel: ClaudeAPIModel {
-        ClaudeAPIModel(rawValue: storedModel) ?? .sonnet
+    private var selectedBackend: AgentBackend {
+        AgentBackend.decode(storedBackend) ?? .claude(.sonnet)
+    }
+
+    private func localLabel(for kind: LocalCleanupModelKind) -> String {
+        AgentBackend.local(kind).shortDisplayName + " (local)"
     }
 
     enum Phase {
@@ -100,22 +104,38 @@ struct BuildIndexSheet: View {
                     HStack(spacing: 8) {
                         Text("**\(estimate.unprocessedCount)** meetings to process using")
                             .font(.system(size: 13))
-                        Picker("", selection: $storedModel) {
-                            ForEach(ClaudeAPIModel.allCases) { model in
-                                Text(model.shortDisplayName).tag(model.rawValue)
+                        Picker("", selection: $storedBackend) {
+                            Section("Cloud") {
+                                ForEach(ClaudeAPIModel.allCases) { model in
+                                    Text(model.shortDisplayName).tag("claude:\(model.rawValue)")
+                                }
+                            }
+                            Section("Local") {
+                                ForEach(LocalCleanupModelKind.allCases) { kind in
+                                    Text(localLabel(for: kind)).tag("local:\(kind.rawValue)")
+                                }
                             }
                         }
                         .labelsHidden()
-                        .frame(maxWidth: 160)
+                        .pickerStyle(.menu)
+                        .frame(maxWidth: 180)
                     }
 
-                    let range = ClaudePricing.estimateBuildCostRange(model: selectedModel, meetingCount: estimate.unprocessedCount)
-                    Text("Likely cost: \(formatCost(range.low)) – \(formatCost(range.high))")
-                        .font(.system(size: 13, weight: .medium))
-
-                    Text("Estimate is order-of-magnitude; running cost is shown during the build, and you can hit Stop at any time.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
+                    switch selectedBackend {
+                    case .claude(let model):
+                        let range = ClaudePricing.estimateBuildCostRange(model: model, meetingCount: estimate.unprocessedCount)
+                        Text("Likely cost: \(formatCost(range.low)) – \(formatCost(range.high))")
+                            .font(.system(size: 13, weight: .medium))
+                        Text("Estimate is order-of-magnitude; running cost is shown during the build, and you can hit Stop at any time.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    case .local:
+                        Text("Free — runs on-device")
+                            .font(.system(size: 13, weight: .medium))
+                        Text("Local models are slower and less reliable for a long multi-step build than Claude — best on a 9B+ model. You can hit Stop at any time.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 HStack {

--- a/GhostPepper/UI/IndexEntryView.swift
+++ b/GhostPepper/UI/IndexEntryView.swift
@@ -3,9 +3,9 @@ import AppKit
 
 /// Renders a single dossier entry. The body is parsed as markdown blocks
 /// (headers, paragraphs, bullet lists) and rendered with appropriate styles.
-/// `[[Wikilinks]]` are rewritten as `wikilink://<slug>` links so SwiftUI's
-/// AttributedString link rendering keeps them tappable inside flowing text;
-/// taps are intercepted via `.environment(\.openURL, ...)`.
+/// `[[Wikilinks]]` and meeting-path mentions are rewritten as custom links so
+/// SwiftUI's AttributedString link rendering keeps them tappable inside flowing
+/// text; taps are intercepted via `.environment(\.openURL, ...)`.
 struct IndexEntryView: View {
     let entry: IndexEntry
     let saveDir: URL
@@ -47,6 +47,12 @@ struct IndexEntryView: View {
                 } else {
                     onOpenEntry(entry.kind, slug)
                 }
+                return .handled
+            }
+            if url.scheme == "gp", url.host == "meeting" {
+                let relativePath = url.path.hasPrefix("/") ? String(url.path.dropFirst()) : url.path
+                guard !relativePath.isEmpty else { return .discarded }
+                onOpenMeetingInNewTab(relativePath)
                 return .handled
             }
             return .systemAction
@@ -143,13 +149,11 @@ struct IndexEntryView: View {
                 .font(headingFont(for: level))
                 .padding(.top, level <= 2 ? 8 : 2)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .textSelection(.enabled)
         case .paragraph(let text):
             inlineText(text)
                 .font(.system(size: 14))
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
-                .textSelection(.enabled)
         case .bulletList(let items):
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(Array(items.enumerated()), id: \.offset) { _, item in
@@ -161,7 +165,6 @@ struct IndexEntryView: View {
                             .font(.system(size: 14))
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .fixedSize(horizontal: false, vertical: true)
-                            .textSelection(.enabled)
                     }
                 }
             }
@@ -176,12 +179,11 @@ struct IndexEntryView: View {
         }
     }
 
-    /// Renders inline markdown with `[[Wikilink]]` rewritten as
-    /// `[Wikilink](wikilink://slug)` so SwiftUI's AttributedString link parser
-    /// keeps the link tappable inside flowing text. Taps are routed via the
-    /// openURL environment override at the view root.
+    /// Renders inline markdown after rewriting dossier wikilinks and meeting
+    /// path mentions into custom URLs. Taps are routed via the openURL
+    /// environment override at the view root.
     private func inlineText(_ text: String) -> Text {
-        let transformed = Self.transformWikilinks(text)
+        let transformed = IndexEntryInlineLinks.preprocess(text)
         if let attributed = try? AttributedString(
             markdown: transformed,
             options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -197,23 +199,6 @@ struct IndexEntryView: View {
         case 2: return .system(size: 16, weight: .semibold)
         default: return .system(size: 14, weight: .semibold)
         }
-    }
-
-    private static func transformWikilinks(_ text: String) -> String {
-        let pattern = #"\[\[([^\]]+)\]\]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
-        let range = NSRange(text.startIndex..., in: text)
-        let matches = regex.matches(in: text, range: range)
-        guard !matches.isEmpty else { return text }
-        var result = text
-        for match in matches.reversed() {
-            guard let nameRange = Range(match.range(at: 1), in: result),
-                  let fullRange = Range(match.range, in: result) else { continue }
-            let name = String(result[nameRange])
-            let slug = MarkdownArchivePaths.slugForIndexEntry(name)
-            result.replaceSubrange(fullRange, with: "[\(name)](wikilink://\(slug))")
-        }
-        return result
     }
 
     private var sourcesSection: some View {
@@ -249,6 +234,55 @@ struct IndexEntryView: View {
         return f.string(from: date)
     }
 
+}
+
+enum IndexEntryInlineLinks {
+    static func preprocess(_ source: String) -> String {
+        var text = transformMeetingPaths(source)
+        text = transformWikilinks(text)
+        return text
+    }
+
+    private static func transformMeetingPaths(_ text: String) -> String {
+        let pattern = #"`?(\d{4}-\d{2}-\d{2}/[A-Za-z0-9_\-\.]+\.md)`?(?::(\d+(?:-\d+)?))?"#
+        return replaceMatches(in: text, pattern: pattern) { groups in
+            let path = groups[1]
+            let lineSpec = groups[2]
+            let label = lineSpec.isEmpty ? path : "\(path):\(lineSpec)"
+            let firstLine = lineSpec.split(separator: "-").first.map(String.init) ?? ""
+            let query = firstLine.isEmpty ? "" : "?line=\(firstLine)"
+            return "[\(label)](gp://meeting/\(path)\(query))"
+        }
+    }
+
+    private static func transformWikilinks(_ text: String) -> String {
+        let pattern = #"\[\[([^\]]+)\]\]"#
+        return replaceMatches(in: text, pattern: pattern) { groups in
+            let name = groups[1]
+            let slug = MarkdownArchivePaths.slugForIndexEntry(name)
+            return "[\(name)](wikilink://\(slug))"
+        }
+    }
+
+    private static func replaceMatches(in source: String, pattern: String, transform: ([String]) -> String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return source }
+        let ns = source as NSString
+        var result = ""
+        var lastEnd = 0
+        regex.enumerateMatches(in: source, range: NSRange(location: 0, length: ns.length)) { match, _, _ in
+            guard let match else { return }
+            result += ns.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+            var groups: [String] = []
+            for idx in 0..<match.numberOfRanges {
+                let range = match.range(at: idx)
+                groups.append(range.location == NSNotFound ? "" : ns.substring(with: range))
+            }
+            result += transform(groups)
+            lastEnd = match.range.location + match.range.length
+        }
+        result += ns.substring(from: lastEnd)
+        return result
+    }
 }
 
 // MARK: - Markdown block parser

--- a/GhostPepper/UI/MeetingTranscriptWindow.swift
+++ b/GhostPepper/UI/MeetingTranscriptWindow.swift
@@ -640,6 +640,7 @@ struct MeetingRootView: View {
     @StateObject private var qaTranscript: QATranscript = QATranscript()
     @State private var currentQATask: Task<Void, Never>? = nil
     @State private var isApplyingDossier: Bool = false
+    @State private var copiedQATurnID: UUID? = nil
     @AppStorage("agentBackend") private var qaAgentBackendStorage: String = "claude:\(ClaudeAPIModel.sonnet.rawValue)"
     @State private var showCommandKSearch: Bool = false
     @State private var showQAMentionSheet: Bool = false
@@ -1110,14 +1111,37 @@ struct MeetingRootView: View {
                         .foregroundStyle(.secondary)
                 }
             } else if !turn.answer.isEmpty {
-                QAAnswerView(source: turn.answer, onLink: handleAnswerLink)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                HStack(alignment: .top, spacing: 6) {
+                    QAAnswerView(source: turn.answer, onLink: handleAnswerLink)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button(action: { copyQAAnswer(turn) }) {
+                        Image(systemName: copiedQATurnID == turn.id ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(copiedQATurnID == turn.id ? .green : .secondary)
+                            .frame(width: 22, height: 22)
+                    }
+                    .buttonStyle(.plain)
+                    .help(copiedQATurnID == turn.id ? "Copied" : "Copy full answer")
+                    .disabled(turn.answer.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
                 if let usage = turn.usage {
                     Text(usageFooterText(usage))
                         .font(.system(size: 10))
                         .foregroundStyle(.secondary)
                 }
+            }
+        }
+    }
+
+    private func copyQAAnswer(_ turn: QATurn) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(turn.answer, forType: .string)
+        copiedQATurnID = turn.id
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_200_000_000)
+            if copiedQATurnID == turn.id {
+                copiedQATurnID = nil
             }
         }
     }
@@ -1180,12 +1204,7 @@ struct MeetingRootView: View {
     }
 
     private func localPickerLabel(for kind: LocalCleanupModelKind) -> String {
-        switch kind {
-        case .qwen35_0_8b_q4_k_m: return "Qwen 3.5 0.8B (local)"
-        case .qwen35_2b_q4_k_m: return "Qwen 3.5 2B (local)"
-        case .qwen35_4b_q4_k_m: return "Qwen 3.5 4B (local)"
-        case .deepseek_r1_qwen_7b_q4_k_m: return "DeepSeek R1 7B (local)"
-        }
+        "\(kind.qaPickerDisplayName) local"
     }
 
     private func formatTraceLine(_ event: QAEvent) -> String {
@@ -1208,7 +1227,7 @@ struct MeetingRootView: View {
 
     private func formatToolStatusLine(name: String, summary: String) -> String {
         switch name {
-        case "grep": return "Searching: \(summary)"
+        case "qmd_search", "grep": return "Searching: \(summary)"
         case "read_file": return "Reading \(summary)"
         case "list_dir": return "Listing \(summary)"
         default: return "\(name): \(summary)"

--- a/GhostPepper/UI/ModelsSidebarView.swift
+++ b/GhostPepper/UI/ModelsSidebarView.swift
@@ -168,7 +168,7 @@ struct ModelsSidebarView: View {
                 LocalModelRow(
                     title: desc.displayName,
                     subtitle: desc.sizeDescription,
-                    capabilities: ["cleanup", "meeting summary"],
+                    capabilities: ["cleanup", "Q&A \(desc.kind.qaProfileLabel.lowercased())"],
                     isDownloaded: downloaded,
                     isActive: isActive,
                     progress: progress,
@@ -291,12 +291,7 @@ struct ModelsSidebarView: View {
     private var agentBackendIsLocal: Bool { agentBackend.isLocal }
 
     private func localAgentLabel(for kind: LocalCleanupModelKind) -> String {
-        switch kind {
-        case .qwen35_0_8b_q4_k_m: return "Qwen 3.5 0.8B (local)"
-        case .qwen35_2b_q4_k_m: return "Qwen 3.5 2B (local)"
-        case .qwen35_4b_q4_k_m: return "Qwen 3.5 4B (local)"
-        case .deepseek_r1_qwen_7b_q4_k_m: return "DeepSeek R1 7B (local)"
-        }
+        "\(kind.qaPickerDisplayName) local"
     }
 
     private var diarizationLabel: String {

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -160,6 +160,7 @@ struct RecordingSpeakerFilteringToggleState {
 
 struct SettingsView: View {
     @ObservedObject var appState: AppState
+    @AppStorage("agentBackend") private var agentBackendStorage: String = "claude:\(ClaudeAPIModel.sonnet.rawValue)"
     @State private var inputDevices: [AudioInputDevice] = []
     @State private var selectedDeviceID: AudioDeviceID = 0
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
@@ -1823,46 +1824,66 @@ struct SettingsView: View {
     private var crossMeetingQACard: some View {
         SettingsCard("Cross-Meeting Q&A") {
             VStack(alignment: .leading, spacing: 14) {
-                Text("Ask questions across all meeting transcripts. The assistant searches your archive with grep / read_file / list_dir and cites sources.")
+                Text("Ask questions across all meeting transcripts. The assistant searches locally with qmd, reads exact source lines, and verifies local-model answers before showing them.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                Picker("Provider", selection: .constant(LLMProviderKind.anthropic)) {
-                    ForEach(LLMProviderKind.allCases) { provider in
-                        Text(provider.displayName).tag(provider)
+                Picker("Q&A model", selection: $agentBackendStorage) {
+                    Section("Cloud") {
+                        ForEach(ClaudeAPIModel.allCases) { model in
+                            Text(model.displayName).tag("claude:\(model.rawValue)")
+                        }
+                    }
+                    Section("Local") {
+                        ForEach(LocalCleanupModelKind.allCases) { kind in
+                            Text(kind.qaPickerDisplayName).tag("local:\(kind.rawValue)")
+                        }
+                    }
+                }
+                .onChange(of: agentBackendStorage) { _, newValue in
+                    if case .claude(let model) = AgentBackend.decode(newValue) {
+                        appState.claudeAPIModel = model.rawValue
                     }
                 }
 
-                Picker("Model", selection: $appState.claudeAPIModel) {
-                    ForEach(ClaudeAPIModel.allCases) { model in
-                        Text(model.displayName).tag(model.rawValue)
-                    }
-                }
-
-                HStack(spacing: 8) {
-                    SecureField("sk-ant-...", text: $claudeAPIKeyInput)
-                        .textFieldStyle(.roundedBorder)
-                        .onChange(of: claudeAPIKeyInput) { _, _ in
+                switch selectedQABackend {
+                case .claude:
+                    HStack(spacing: 8) {
+                        SecureField("sk-ant-...", text: $claudeAPIKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .onChange(of: claudeAPIKeyInput) { _, _ in
+                                claudeAPIKeySaved = false
+                            }
+                        Button(claudeAPIKeySaved ? "Saved" : "Save") {
+                            _ = KeychainHelper.set(claudeAPIKeyInput, for: AnthropicProvider.keychainKey)
+                            claudeAPIKeySaved = true
+                        }
+                        .disabled(claudeAPIKeyInput.isEmpty)
+                        Button("Clear") {
+                            KeychainHelper.delete(AnthropicProvider.keychainKey)
+                            claudeAPIKeyInput = ""
                             claudeAPIKeySaved = false
                         }
-                    Button(claudeAPIKeySaved ? "Saved" : "Save") {
-                        _ = KeychainHelper.set(claudeAPIKeyInput, for: AnthropicProvider.keychainKey)
-                        claudeAPIKeySaved = true
+                        .disabled(claudeAPIKeyInput.isEmpty && !claudeAPIKeySaved)
                     }
-                    .disabled(claudeAPIKeyInput.isEmpty)
-                    Button("Clear") {
-                        KeychainHelper.delete(AnthropicProvider.keychainKey)
-                        claudeAPIKeyInput = ""
-                        claudeAPIKeySaved = false
-                    }
-                    .disabled(claudeAPIKeyInput.isEmpty && !claudeAPIKeySaved)
-                }
 
-                Text("API key is stored in your macOS Keychain. Get one at [console.anthropic.com](https://console.anthropic.com/settings/keys). Cost is shown after each answer; prompt caching keeps follow-up questions cheap.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    Text("API key is stored in your macOS Keychain. Get one at [console.anthropic.com](https://console.anthropic.com/settings/keys). Cost is shown after each answer; prompt caching keeps follow-up questions cheap.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                case .local(let kind):
+                    Text(kind.qaProfileDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Local Q&A runs on-device. For citation-heavy answers, 9B or larger models are the better starting point.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
+    }
+
+    private var selectedQABackend: AgentBackend {
+        AgentBackend.decode(agentBackendStorage) ?? .claude(.sonnet)
     }
 
     private var meetingTranscriptSection: some View {

--- a/GhostPepper/UpdaterController.swift
+++ b/GhostPepper/UpdaterController.swift
@@ -1,16 +1,79 @@
+import AppKit
+import Combine
 import Sparkle
 
-final class UpdaterController: ObservableObject {
-    let updater: SPUUpdater
+struct UpdateSurveyPromptPolicy {
+    static let lastLaunchedVersionKey = "updateSurveyLastLaunchedVersion"
+    static let lastPromptedVersionKey = "updateSurveyLastPromptedVersion"
+    static let pendingUpdatedVersionKey = "updateSurveyPendingVersion"
+
+    let defaults: UserDefaults
+
+    func shouldPromptAfterLaunch(currentVersion rawCurrentVersion: String?) -> Bool {
+        guard let currentVersion = rawCurrentVersion?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !currentVersion.isEmpty else {
+            return false
+        }
+
+        let lastLaunchedVersion = defaults.string(forKey: Self.lastLaunchedVersionKey)
+        let lastPromptedVersion = defaults.string(forKey: Self.lastPromptedVersionKey)
+        let pendingUpdatedVersion = defaults.string(forKey: Self.pendingUpdatedVersionKey)
+        let launchedAfterKnownUpdate = pendingUpdatedVersion == currentVersion
+        let launchedAfterVersionChange = lastLaunchedVersion != nil && lastLaunchedVersion != currentVersion
+
+        defaults.set(currentVersion, forKey: Self.lastLaunchedVersionKey)
+
+        guard (launchedAfterKnownUpdate || launchedAfterVersionChange),
+              lastPromptedVersion != currentVersion else {
+            return false
+        }
+
+        defaults.set(currentVersion, forKey: Self.lastPromptedVersionKey)
+        if pendingUpdatedVersion == currentVersion {
+            defaults.removeObject(forKey: Self.pendingUpdatedVersionKey)
+        }
+        return true
+    }
+
+    func markPendingSurveyPrompt(forVersion rawVersion: String?) {
+        guard let version = rawVersion?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !version.isEmpty else {
+            return
+        }
+
+        defaults.set(version, forKey: Self.pendingUpdatedVersionKey)
+    }
+}
+
+final class UpdaterController: NSObject, ObservableObject, SPUUpdaterDelegate {
+    private static let surveyURL = URL(string: "https://forms.gle/WEGksMfvAgQojdG49")!
+
+    private lazy var standardUpdaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: self,
+        userDriverDelegate: nil
+    )
+
+    var updater: SPUUpdater {
+        standardUpdaterController.updater
+    }
+
     @Published var updateAvailable = false
 
-    init() {
-        let controller = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
-            userDriverDelegate: nil
-        )
-        updater = controller.updater
+    private let defaults: UserDefaults
+    private let currentVersionProvider: () -> String?
+
+    init(
+        defaults: UserDefaults = .standard,
+        currentVersionProvider: @escaping () -> String? = {
+            Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+        }
+    ) {
+        self.defaults = defaults
+        self.currentVersionProvider = currentVersionProvider
+        super.init()
+
+        let updater = self.updater
         updater.automaticallyChecksForUpdates = true
         updater.updateCheckInterval = 86400
 
@@ -22,6 +85,28 @@ final class UpdaterController: ObservableObject {
 
     func checkForUpdates() {
         updater.checkForUpdates()
+    }
+
+    func askForSurveyAfterUpdateIfNeeded() {
+        let policy = UpdateSurveyPromptPolicy(defaults: defaults)
+        guard policy.shouldPromptAfterLaunch(currentVersion: currentVersionProvider()) else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            self?.showUpdateSurveyPrompt()
+        }
+    }
+
+    func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+        markPendingSurveyPrompt(for: item)
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        willInstallUpdateOnQuit item: SUAppcastItem,
+        immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
+    ) -> Bool {
+        markPendingSurveyPrompt(for: item)
+        return false
     }
 
     /// Check the appcast XML to see if a newer version exists.
@@ -41,6 +126,26 @@ final class UpdaterController: ObservableObject {
             await MainActor.run {
                 self.updateAvailable = isNewer
             }
+        }
+    }
+
+    private func markPendingSurveyPrompt(for item: SUAppcastItem) {
+        UpdateSurveyPromptPolicy(defaults: defaults)
+            .markPendingSurveyPrompt(forVersion: item.displayVersionString)
+    }
+
+    private func showUpdateSurveyPrompt() {
+        let alert = NSAlert()
+        alert.messageText = "Thanks for updating Ghost Pepper"
+        alert.informativeText = "Would you be willing to complete a quick survey? It helps shape what gets better next."
+        alert.alertStyle = .informational
+        alert.icon = NSImage(named: "AppIcon")
+        alert.addButton(withTitle: "Take Survey")
+        alert.addButton(withTitle: "Not Now")
+
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            NSWorkspace.shared.open(Self.surveyURL)
         }
     }
 }

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -151,6 +151,49 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(AppStatus.error.rawValue, "Error")
     }
 
+    func testUpdateSurveyPromptSkipsFirstLaunchButRecordsVersion() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let policy = UpdateSurveyPromptPolicy(defaults: defaults)
+
+        XCTAssertFalse(policy.shouldPromptAfterLaunch(currentVersion: "2.4.0"))
+        XCTAssertEqual(
+            defaults.string(forKey: UpdateSurveyPromptPolicy.lastLaunchedVersionKey),
+            "2.4.0"
+        )
+        XCTAssertNil(defaults.string(forKey: UpdateSurveyPromptPolicy.lastPromptedVersionKey))
+    }
+
+    func testUpdateSurveyPromptShowsOnceAfterVersionChange() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        defaults.set("2.3.0", forKey: UpdateSurveyPromptPolicy.lastLaunchedVersionKey)
+        let policy = UpdateSurveyPromptPolicy(defaults: defaults)
+
+        XCTAssertTrue(policy.shouldPromptAfterLaunch(currentVersion: "2.4.0"))
+        XCTAssertEqual(
+            defaults.string(forKey: UpdateSurveyPromptPolicy.lastPromptedVersionKey),
+            "2.4.0"
+        )
+        XCTAssertFalse(policy.shouldPromptAfterLaunch(currentVersion: "2.4.0"))
+    }
+
+    func testUpdateSurveyPromptUsesPendingSparkleInstallVersion() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let policy = UpdateSurveyPromptPolicy(defaults: defaults)
+        policy.markPendingSurveyPrompt(forVersion: "2.4.0")
+
+        XCTAssertTrue(policy.shouldPromptAfterLaunch(currentVersion: "2.4.0"))
+        XCTAssertNil(defaults.string(forKey: UpdateSurveyPromptPolicy.pendingUpdatedVersionKey))
+    }
+
     func testEmptyTranscriptionDispositionCancelsSubThresholdRecordings() {
         XCTAssertEqual(
             AppState.emptyTranscriptionDisposition(forAudioSampleCount: 7_999),

--- a/GhostPepperTests/IndexBuilderHelpersTests.swift
+++ b/GhostPepperTests/IndexBuilderHelpersTests.swift
@@ -41,6 +41,6 @@ final class IndexBuilderHelpersTests: XCTestCase {
     func testIndexingToolDefinitionsContainsAllFour() {
         let tools = IndexBuilder.indexingToolDefinitions()
         let names = Set(tools.map { $0.name })
-        XCTAssertEqual(names, Set(["grep", "read_file", "list_dir", "write_file"]))
+        XCTAssertEqual(names, Set(["qmd_search", "read_file", "list_dir", "write_file"]))
     }
 }

--- a/GhostPepperTests/IndexEntryFileTests.swift
+++ b/GhostPepperTests/IndexEntryFileTests.swift
@@ -103,3 +103,35 @@ final class IndexEntryFileTests: XCTestCase {
         XCTAssertEqual(parsed.canonicalName, "Dr. Foo: The Sequel")
     }
 }
+
+final class IndexEntryInlineLinksTests: XCTestCase {
+    func testPreprocessLinksBacktickedMeetingMentions() {
+        let source = "In `2026-04-28/standup.md`: introduced the deploy pipeline."
+        let processed = IndexEntryInlineLinks.preprocess(source)
+
+        XCTAssertEqual(
+            processed,
+            "In [2026-04-28/standup.md](gp://meeting/2026-04-28/standup.md): introduced the deploy pipeline."
+        )
+    }
+
+    func testPreprocessPreservesLineSpecInMeetingMentionLabel() {
+        let source = "See 2026-04-28/standup.md:71-72 for the original context."
+        let processed = IndexEntryInlineLinks.preprocess(source)
+
+        XCTAssertEqual(
+            processed,
+            "See [2026-04-28/standup.md:71-72](gp://meeting/2026-04-28/standup.md?line=71) for the original context."
+        )
+    }
+
+    func testPreprocessKeepsPersonWikilinksTappable() {
+        let source = "Often works with [[Lara Chen]]."
+        let processed = IndexEntryInlineLinks.preprocess(source)
+
+        XCTAssertEqual(
+            processed,
+            "Often works with [Lara Chen](wikilink://lara-chen)."
+        )
+    }
+}

--- a/GhostPepperTests/IndexSystemPromptTests.swift
+++ b/GhostPepperTests/IndexSystemPromptTests.swift
@@ -14,7 +14,7 @@ final class IndexSystemPromptTests: XCTestCase {
     func testFullBuildPromptDescribesAllFourTools() {
         let prompt = IndexSystemPrompt.buildPeopleIndexFullBuild(archiveRootPath: "/a", indexRootPath: "/i")
         XCTAssertTrue(prompt.contains("list_dir"))
-        XCTAssertTrue(prompt.contains("grep"))
+        XCTAssertTrue(prompt.contains("qmd_search"))
         XCTAssertTrue(prompt.contains("read_file"))
         XCTAssertTrue(prompt.contains("write_file"))
     }

--- a/GhostPepperTests/MeetingQAAgentTests.swift
+++ b/GhostPepperTests/MeetingQAAgentTests.swift
@@ -31,6 +31,17 @@ final class MeetingQAAgentTests: XCTestCase {
         try FileManager.default.createDirectory(at: rootDir, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: rootDir.appendingPathComponent("2025-01-29"), withIntermediateDirectories: true)
         try "Quinn Adler".write(to: rootDir.appendingPathComponent("2025-01-29/dana-matt.md"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: rootDir.appendingPathComponent("2025-02-06"), withIntermediateDirectories: true)
+        try """
+        # Owen Blake Carter sync
+        Owen Blake Carter said: We should ship this.
+        We agreed to follow up next week.
+        """.write(to: rootDir.appendingPathComponent("2025-02-06/owen.md"), atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: rootDir.appendingPathComponent("2024-03-20"), withIntermediateDirectories: true)
+        try """
+        # Mira planning
+        Mira said: The second brain should stay local.
+        """.write(to: rootDir.appendingPathComponent("2024-03-20/mira.md"), atomically: true, encoding: .utf8)
     }
 
     override func tearDownWithError() throws {
@@ -62,7 +73,7 @@ final class MeetingQAAgentTests: XCTestCase {
     func testExecutesToolCallAndContinuesLoop() async throws {
         let provider = MockProvider(scripts: [
             [
-                .toolUse(id: "tu_1", name: "grep", input: ["pattern": "Quinn", "case_insensitive": true, "max_results": 50]),
+                .toolUse(id: "tu_1", name: "qmd_search", input: ["query": "Quinn", "case_insensitive": true, "max_results": 50]),
                 .stop(reason: .toolUse, usage: ProviderUsage(inputTokens: 50, outputTokens: 10, cacheReadTokens: 0, cacheWriteTokens: 0)),
             ],
             [
@@ -91,7 +102,7 @@ final class MeetingQAAgentTests: XCTestCase {
 
     func testHonorsIterationCap() async throws {
         let infiniteToolUse: [ProviderEvent] = [
-            .toolUse(id: "tu_x", name: "grep", input: ["pattern": "anything", "case_insensitive": true, "max_results": 10]),
+            .toolUse(id: "tu_x", name: "qmd_search", input: ["query": "anything", "case_insensitive": true, "max_results": 10]),
             .stop(reason: .toolUse, usage: ProviderUsage(inputTokens: 10, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0)),
         ]
         let provider = MockProvider(scripts: Array(repeating: infiniteToolUse, count: 20))
@@ -103,6 +114,411 @@ final class MeetingQAAgentTests: XCTestCase {
         }
         XCTAssertTrue(statuses.contains(where: { $0.contains("iteration cap") }), "Expected iteration-cap status, got \(statuses)")
         XCTAssertEqual(provider.calls.count, 3)
+    }
+
+    func testLocalModelRetriesToollessArchivePlanWithoutStreamingIt() async throws {
+        let provider = MockProvider(scripts: [
+            [
+                .textDelta("Therefore, perhaps the best approach is to use list_dir and compile dates."),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+            [
+                .textDelta("Timeline:\n- 2025-02-06: Owen said \"We should ship this.\" 2025-02-06/owen.md:2"),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+        ])
+        let agent = MeetingQAAgent(provider: provider, backend: .local(.deepseek_r1_qwen_7b_q4_k_m), archiveRoot: rootDir, maxIterations: 15)
+
+        var text = ""
+        var statuses: [String] = []
+        for try await event in agent.ask("summarize my meetings with Owen Blake Carter as a timeline") {
+            switch event {
+            case .text(let t): text += t
+            case .status(let s): statuses.append(s)
+            default: break
+            }
+        }
+
+        XCTAssertFalse(text.contains("Therefore, perhaps"), "Toolless planning text should not be shown: \(text)")
+        XCTAssertTrue(text.contains("Timeline:"), "Expected final answer text after retry: \(text)")
+        XCTAssertTrue(statuses.contains { $0.contains("Searching archive before local answer") }, "Expected deterministic search status, got \(statuses)")
+        XCTAssertEqual(provider.calls.count, 2)
+
+        let secondCallText = provider.calls[1].messages.flatMap { $0.content }.compactMap { block -> String? in
+            if case .text(let t) = block { return t } else { return nil }
+        }.joined(separator: "\n")
+        let secondCallToolResults = provider.calls[1].messages.flatMap { $0.content }.compactMap { block -> String? in
+            if case .toolResult(_, let content, _) = block { return content } else { return nil }
+        }.joined(separator: "\n")
+        XCTAssertFalse(secondCallText.contains("You answered without searching the archive"), "Expected deterministic search instead of a text-only retry")
+        XCTAssertTrue(secondCallToolResults.contains("2025-02-06/owen.md"), "Expected qmd evidence in second call")
+    }
+
+    func testLocalModelSuppressesFakeSearchAnswerAfterNoToolRetry() async throws {
+        let fakeSearchAnswer = """
+        Okay, I need to figure out how to answer the user's question about prior meetings with Mira Vale. \
+        The user is asking for a timeline of their meetings, so I should start by searching using "Mira Vale" as the query.
+
+        To provide an accurate timeline of prior meetings with Mira Vale, I conducted a search using qmd_search for "Mira Vale." Here are the results:
+
+        1. Meeting on March 20, 2024
+        2. Meeting on January 15, 2024
+        3. Meeting on October 10, 2023
+        """
+        let provider = MockProvider(scripts: [
+            [
+                .textDelta("I should use qmd_search for Mira Vale before answering."),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+            [
+                .textDelta(fakeSearchAnswer),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+            [
+                .textDelta("Mira said \"The second brain should stay local.\" 2024-03-20/mira.md:2"),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+        ])
+        let agent = MeetingQAAgent(provider: provider, backend: .local(.deepseek_r1_qwen_7b_q4_k_m), archiveRoot: rootDir, maxIterations: 15)
+
+        var text = ""
+        var statuses: [String] = []
+        for try await event in agent.ask("can you tell me about prior meetings with Mira Vale?") {
+            switch event {
+            case .text(let t): text += t
+            case .status(let s): statuses.append(s)
+            default: break
+            }
+        }
+
+        XCTAssertFalse(text.contains("Meeting on March 20, 2024"), "Fake qmd_search prose should not be shown: \(text)")
+        XCTAssertTrue(text.contains("The second brain should stay local."), text)
+        XCTAssertTrue(text.contains("2024-03-20/mira.md:2"), text)
+        XCTAssertTrue(statuses.contains { $0.contains("Searching archive before local answer") }, "Expected deterministic search status, got \(statuses)")
+        XCTAssertTrue(statuses.contains { $0.contains("Checking answer against source evidence") }, "Expected verification status, got \(statuses)")
+        XCTAssertEqual(provider.calls.count, 3)
+    }
+
+    func testLocalArchiveSearchQueryExtractsPersonFromQuestion() {
+        XCTAssertEqual(
+            MeetingQAAgent.localArchiveSearchQuery(for: "can you tell me about prior meetings with Mira Vale?"),
+            "Mira Vale"
+        )
+        XCTAssertEqual(
+            MeetingQAAgent.localArchiveSearchQueries(for: "can you tell me about prior meetings with Mira Vale?"),
+            ["Mira Vale", "Mira", "Vale"]
+        )
+        XCTAssertEqual(
+            MeetingQAAgent.localArchiveSearchQuery(for: "summarize my meetings with Owen Blake Carter as a timeline"),
+            "Owen Blake Carter"
+        )
+    }
+
+    func testLocalModelAllowsCitedAnswerWithoutRetry() async throws {
+        let provider = MockProvider(scripts: [
+            [
+                .textDelta("Owen appears in the archive at 2025-01-29/dana-matt.md:1."),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+        ])
+        let agent = MeetingQAAgent(provider: provider, backend: .local(.qwen35_9b_q4_k_m), archiveRoot: rootDir, maxIterations: 15)
+
+        var text = ""
+        var statuses: [String] = []
+        for try await event in agent.ask("What did I discuss with Owen?") {
+            switch event {
+            case .text(let t): text += t
+            case .status(let s): statuses.append(s)
+            default: break
+            }
+        }
+
+        XCTAssertEqual(provider.calls.count, 1)
+        XCTAssertEqual(text, "Owen appears in the archive at 2025-01-29/dana-matt.md:1.")
+        XCTAssertFalse(statuses.contains { $0.contains("Retrying with archive search") }, "Cited local answers should not be retried")
+    }
+
+    func testLocalSynthesisFallbackSuppressesToolsForFinalAnswer() async throws {
+        let provider = MockProvider(scripts: [
+            [
+                .toolUse(id: "tu_1", name: "qmd_search", input: ["query": "Owen Blake Carter", "case_insensitive": true, "max_results": 50]),
+                .stop(reason: .toolUse, usage: .zero),
+            ],
+            [
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+            [
+                .textDelta("Owen Blake Carter appears in the archive at 2025-02-06/owen.md:2."),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+        ])
+        let agent = MeetingQAAgent(provider: provider, backend: .local(.qwen35_9b_q4_k_m), archiveRoot: rootDir, maxIterations: 15)
+
+        var text = ""
+        var statuses: [String] = []
+        for try await event in agent.ask("summarize my meetings with Owen Blake Carter as a timeline") {
+            switch event {
+            case .text(let t): text += t
+            case .status(let s): statuses.append(s)
+            default: break
+            }
+        }
+
+        XCTAssertEqual(provider.calls.count, 3)
+        XCTAssertTrue(statuses.contains { $0.contains("Synthesizing answer") }, "Expected synthesis fallback status, got \(statuses)")
+        XCTAssertEqual(provider.calls[2].tools.count, 0, "Final synthesis turn should not expose tools to the local model")
+        XCTAssertTrue(text.contains("Owen Blake Carter appears"), text)
+    }
+
+    func testLocalModelRewritesUncitedTimelineAgainstEvidenceBeforeStreaming() async throws {
+        let provider = MockProvider(scripts: [
+            [
+                .toolUse(id: "tu_1", name: "qmd_search", input: ["query": "Owen Blake Carter", "case_insensitive": true, "max_results": 50]),
+                .stop(reason: .toolUse, usage: .zero),
+            ],
+            [
+                .textDelta("Timeline:\n- 2025-02-06: Owen discussed the project."),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+            [
+                .textDelta("Timeline:\n- 2025-02-06: Owen said \"We should ship this.\" 2025-02-06/owen.md:2"),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+        ])
+        let agent = MeetingQAAgent(provider: provider, backend: .local(.qwen35_9b_q4_k_m), archiveRoot: rootDir, maxIterations: 15)
+
+        var text = ""
+        var statuses: [String] = []
+        for try await event in agent.ask("summarize my meetings with Owen Blake Carter as a timeline") {
+            switch event {
+            case .text(let t): text += t
+            case .status(let s): statuses.append(s)
+            default: break
+            }
+        }
+
+        XCTAssertFalse(text.contains("Owen discussed the project."), "Uncited draft should not be streamed: \(text)")
+        XCTAssertTrue(text.contains("We should ship this."), text)
+        XCTAssertTrue(text.contains("2025-02-06/owen.md:2"), text)
+        XCTAssertTrue(statuses.contains { $0.contains("Checking answer against source evidence") }, "Expected verification status, got \(statuses)")
+        XCTAssertEqual(provider.calls.count, 3)
+        XCTAssertEqual(provider.calls[2].tools.count, 0, "Verification recovery should force a plain-text final answer")
+
+        let recoveryPrompt = provider.calls[2].messages.flatMap { $0.content }.compactMap { block -> String? in
+            if case .text(let t) = block { return t } else { return nil }
+        }.joined(separator: "\n")
+        XCTAssertTrue(recoveryPrompt.contains("Direct quotes must match the source text exactly"), recoveryPrompt)
+        XCTAssertTrue(recoveryPrompt.contains("2025-02-06/owen.md:2"), recoveryPrompt)
+    }
+
+    func testLocalModelFallsBackToEvidenceWhenVerificationRecoveryStillFails() async throws {
+        let badDraft = "Timeline:\n- 2025-02-06: Owen discussed the project."
+        let provider = MockProvider(scripts: [
+            [
+                .toolUse(id: "tu_1", name: "qmd_search", input: ["query": "Owen Blake Carter", "case_insensitive": true, "max_results": 50]),
+                .stop(reason: .toolUse, usage: .zero),
+            ],
+            [
+                .textDelta(badDraft),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+            [
+                .textDelta(badDraft),
+                .stop(reason: .endTurn, usage: .zero),
+            ],
+        ])
+        let agent = MeetingQAAgent(provider: provider, backend: .local(.qwen35_9b_q4_k_m), archiveRoot: rootDir, maxIterations: 15)
+
+        var text = ""
+        for try await event in agent.ask("summarize my meetings with Owen Blake Carter as a timeline") {
+            if case .text(let t) = event { text += t }
+        }
+
+        XCTAssertTrue(text.contains("local model did not produce a fully verified answer"), text)
+        XCTAssertTrue(text.contains("2025-02-06/owen.md:2"), text)
+        XCTAssertTrue(text.contains("We should ship this."), text)
+        XCTAssertEqual(provider.calls.count, 3)
+    }
+
+    func testEvidencePacketParsesQMDAndReadFileLines() {
+        let packet = MeetingQAEvidencePacket(observations: [
+            MeetingQAToolObservation(
+                name: "qmd_search",
+                input: ["query": "Owen Blake Carter"],
+                output: """
+                2025-02-06/owen.md-1-# Owen Blake Carter sync
+                2025-02-06/owen.md:2:Owen Blake Carter said: We should ship this.
+                --
+                (Returned 1 of 1 qmd search results.)
+                """,
+                isError: false
+            ),
+            MeetingQAToolObservation(
+                name: "read_file",
+                input: ["path": "2025-02-06/owen.md"],
+                output: """
+                2\tOwen Blake Carter said: We should ship this.
+
+                (End of file at line 3.)
+                """,
+                isError: false
+            ),
+        ])
+
+        XCTAssertEqual(packet.snippets.count, 3)
+        XCTAssertTrue(packet.observedPaths.contains("2025-02-06/owen.md"))
+        XCTAssertTrue(packet.containsQuote("We should ship this."))
+        XCTAssertTrue(packet.compactSummary().contains("2025-02-06/owen.md:2"))
+    }
+
+    func testAnswerVerifierRejectsMissingQuotesAndUncitedTimelineDates() {
+        let packet = MeetingQAEvidencePacket(observations: [
+            MeetingQAToolObservation(
+                name: "qmd_search",
+                input: ["query": "Owen Blake Carter"],
+                output: "2025-02-06/owen.md:2:Owen Blake Carter said: We should ship this.\n",
+                isError: false
+            )
+        ])
+
+        let result = MeetingQAAnswerVerifier.validate(
+            answer: "Timeline:\n- 2025-02-06: Owen said \"We should launch today.\"",
+            question: "summarize my meetings with Owen Blake Carter as a timeline",
+            evidence: packet
+        )
+
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.reasons.contains { $0.contains("direct quote") }, "\(result.reasons)")
+        XCTAssertTrue(result.reasons.contains { $0.contains("Timeline date lines") }, "\(result.reasons)")
+    }
+
+    func testAnswerVerifierRejectsPlaceholderPathCitations() {
+        let packet = MeetingQAEvidencePacket(observations: [
+            MeetingQAToolObservation(
+                name: "qmd_search",
+                input: ["query": "Mira"],
+                output: """
+                2026-04-21/intro-call-matt-mira-northwind.md:9:Intro Call: Matt & Mira (Northwind)
+                2026-04-21/intro-call-matt-mira-northwind.md:15:Mira founded Northwind.
+                """,
+                isError: false
+            )
+        ])
+
+        let result = MeetingQAAnswerVerifier.validate(
+            answer: "Mira founded Northwind [`path:15`]. 2026-04-21/intro-call-matt-mira-northwind.md:9",
+            question: "can you tell me about prior meetings with Mira?",
+            evidence: packet
+        )
+
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.reasons.contains { $0.contains("placeholder citations") }, "\(result.reasons)")
+    }
+
+    func testAnswerVerifierRejectsVisibleDeepSeekPlanningEvenWithCitations() {
+        let packet = MeetingQAEvidencePacket(observations: [
+            MeetingQAToolObservation(
+                name: "qmd_search",
+                input: ["query": "Mira"],
+                output: """
+                2026-04-21/intro-call-matt-mira-northwind.md-7-
+                2026-04-21/intro-call-matt-mira-northwind.md-8-# Intro Call
+                2026-04-21/intro-call-matt-mira-northwind.md:9:Intro Call: Matt & Mira (Northwind)
+                """,
+                isError: false
+            )
+        ])
+
+        let result = MeetingQAAnswerVerifier.validate(
+            answer: """
+            Okay, so I need to figure out how to answer the user's question about prior meetings with Mira. \
+            First, I'll start by using the qmd_search tool.
+
+            Mira met Matt at an intro call on 2026-04-21 titled "Intro Call: Matt & Mira (Northwind)". \
+            2026-04-21/intro-call-matt-mira-northwind.md:9
+            """,
+            question: "can you tell me about prior meetings with Mira?",
+            evidence: packet
+        )
+
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.reasons.contains { $0.contains("tool planning") }, "\(result.reasons)")
+    }
+
+    func testAnswerVerifierRejectsNoEvidenceRecallHallucination() {
+        let packet = MeetingQAEvidencePacket(observations: [
+            MeetingQAToolObservation(
+                name: "qmd_search",
+                input: ["query": "Mira Vale"],
+                output: "No matches found for query: Mira Vale",
+                isError: false
+            )
+        ])
+
+        let result = MeetingQAAnswerVerifier.validate(
+            answer: """
+            I couldn't find any direct matches for "Mira Vale" in the meeting archive. \
+            However, I recall a meeting titled "AI in Healthcare" that might be related to her work.
+            """,
+            question: "can you tell me about prior meetings with Mira Vale?",
+            evidence: packet
+        )
+
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.reasons.contains { $0.contains("no source evidence") }, "\(result.reasons)")
+    }
+
+    // MARK: - Malformed tool-call recovery (memory: qwen-toolcall-malformed)
+
+    func testRecoversFromMalformedToolCallByReprompting() async throws {
+        let provider = MockProvider(scripts: [
+            [
+                .malformedToolCall(raw: #"{"arguments":{"unknown_key":"x"}}"#),
+                .stop(reason: .endTurn, usage: ProviderUsage(inputTokens: 40, outputTokens: 4, cacheReadTokens: 0, cacheWriteTokens: 0)),
+            ],
+            [
+                .textDelta("Recovered answer."),
+                .stop(reason: .endTurn, usage: ProviderUsage(inputTokens: 50, outputTokens: 5, cacheReadTokens: 0, cacheWriteTokens: 0)),
+            ],
+        ])
+        let agent = MeetingQAAgent(provider: provider, backend: .local(.qwen35_4b_q4_k_m), archiveRoot: rootDir, maxIterations: 15)
+
+        var text = ""
+        var statuses: [String] = []
+        for try await event in agent.ask("anything") {
+            switch event {
+            case .text(let t): text += t
+            case .status(let s): statuses.append(s)
+            default: break
+            }
+        }
+        // The malformed blob must NOT leak into the answer; the loop re-prompts
+        // and surfaces only the recovered turn's text.
+        XCTAssertEqual(text, "Recovered answer.")
+        XCTAssertEqual(provider.calls.count, 2)
+        XCTAssertTrue(statuses.contains { $0.contains("malformed") }, "Expected a recovery status, got \(statuses)")
+        // The re-prompt must reach the model on the second call.
+        let secondCallText = provider.calls[1].messages.flatMap { $0.content }.compactMap { block -> String? in
+            if case .text(let t) = block { return t } else { return nil }
+        }.joined(separator: "\n")
+        XCTAssertTrue(secondCallText.contains("could not be parsed"), "Expected recovery prompt in second call")
+    }
+
+    func testGivesUpAfterRepeatedMalformedToolCalls() async throws {
+        let malformedTurn: [ProviderEvent] = [
+            .malformedToolCall(raw: #"{"arguments":{"unknown_key":"x"}}"#),
+            .stop(reason: .endTurn, usage: ProviderUsage(inputTokens: 10, outputTokens: 1, cacheReadTokens: 0, cacheWriteTokens: 0)),
+        ]
+        let provider = MockProvider(scripts: [malformedTurn, malformedTurn, malformedTurn])
+        let agent = MeetingQAAgent(provider: provider, backend: .local(.qwen35_4b_q4_k_m), archiveRoot: rootDir, maxIterations: 15)
+
+        var sawError = false
+        for try await event in agent.ask("anything") {
+            if case .error = event { sawError = true }
+        }
+        XCTAssertTrue(sawError, "Expected an error after repeated malformed tool calls")
+        // One retry only: initial + one re-prompt, then give up (no infinite loop).
+        XCTAssertEqual(provider.calls.count, 2)
     }
 
     func testToolErrorReportedToProviderAsIsError() async throws {

--- a/GhostPepperTests/MeetingQASystemPromptTests.swift
+++ b/GhostPepperTests/MeetingQASystemPromptTests.swift
@@ -26,6 +26,28 @@ final class MeetingQASystemPromptTests: XCTestCase {
         XCTAssertTrue(prompt.contains("path:line"), prompt)
     }
 
+    func testPromptUsesQMDSearchAsPrimarySearchTool() {
+        let prompt = MeetingQASystemPrompt.build(archiveRootPath: "/tmp/Meetings", backend: .claude(.sonnet), maxIterations: 15)
+        XCTAssertTrue(prompt.contains("qmd_search"), prompt)
+        XCTAssertTrue(prompt.contains("Prefer qmd_search"), prompt)
+        XCTAssertFalse(prompt.contains("Prefer grep"), prompt)
+    }
+
+    func testPromptGivesPersonTimelineRules() {
+        let prompt = MeetingQASystemPrompt.build(archiveRootPath: "/tmp/Meetings", backend: .claude(.sonnet), maxIterations: 15)
+        XCTAssertTrue(prompt.contains("Timeline questions"), prompt)
+        XCTAssertTrue(prompt.contains("person's full name"), prompt)
+        XCTAssertTrue(prompt.contains("Do not list every meeting date"), prompt)
+        XCTAssertTrue(prompt.contains("Sort the final answer chronologically"), prompt)
+    }
+
+    func testPromptTellsModelNotToExposeToolPlans() {
+        let prompt = MeetingQASystemPrompt.build(archiveRootPath: "/tmp/Meetings", backend: .local(.deepseek_r1_qwen_7b_q4_k_m), maxIterations: 15)
+        XCTAssertTrue(prompt.contains("Never describe a tool-use plan"), prompt)
+        XCTAssertTrue(prompt.contains("Do not write analysis"), prompt)
+        XCTAssertTrue(prompt.contains("first visible"), prompt)
+    }
+
     func testPromptHasVoiceToTextGuidance() {
         let prompt = MeetingQASystemPrompt.build(archiveRootPath: "/tmp/Meetings", backend: .claude(.sonnet), maxIterations: 15)
         XCTAssertTrue(prompt.contains("voice-to-text") || prompt.contains("Voice-to-text"), prompt)
@@ -40,5 +62,17 @@ final class MeetingQASystemPromptTests: XCTestCase {
     func testPromptDescribesIterationBudget() {
         let prompt = MeetingQASystemPrompt.build(archiveRootPath: "/tmp/Meetings", backend: .claude(.sonnet), maxIterations: 15)
         XCTAssertTrue(prompt.contains("15"), "Iteration cap should be visible to the model")
+    }
+
+    func testLocalProviderPromptForcesArchiveToolCallFirst() {
+        let tool = MeetingQAAgent.qaToolDefinitions().first { $0.name == "qmd_search" }!
+        let prompt = LocalLLMProvider.buildPrompt(
+            system: "System instructions",
+            messages: [LLMMessage(role: .user, content: [.text("summarize my meetings with Owen Blake Carter as a timeline")])],
+            tools: [tool]
+        )
+        XCTAssertTrue(prompt.contains("Emit a tool_call first"), prompt)
+        XCTAssertTrue(prompt.contains(#""name":"qmd_search""#), prompt)
+        XCTAssertTrue(prompt.contains("no hidden analysis"), prompt)
     }
 }

--- a/GhostPepperTests/MeetingQAToolsTests.swift
+++ b/GhostPepperTests/MeetingQAToolsTests.swift
@@ -34,33 +34,54 @@ final class MeetingQAToolsTests: XCTestCase {
         try? FileManager.default.removeItem(at: rootDir)
     }
 
-    // MARK: - grep
+    // MARK: - qmd_search
 
-    func testGrepFindsMatchAcrossArchive() async throws {
+    func testQMDSearchFindsMatchAcrossArchive() async throws {
         let tools = MeetingQATools(root: rootDir)
-        let result = try await tools.grep(pattern: "Quinn", path: nil, caseInsensitive: true, maxResults: 50)
+        let result = try await tools.qmdSearch(query: "Quinn", path: nil, caseInsensitive: true, maxResults: 50)
         XCTAssertTrue(result.contains("2025-01-29/dana-matt.md:"), "Expected file:line match in output: \(result)")
         XCTAssertTrue(result.contains("2026-01-07/team-standup.md:"), "Expected second-file match in output: \(result)")
     }
 
-    func testGrepRespectsMaxResults() async throws {
+    func testQMDSearchOutputContainsCitationReadyContext() async throws {
         let tools = MeetingQATools(root: rootDir)
-        let result = try await tools.grep(pattern: "Quinn", path: nil, caseInsensitive: true, maxResults: 1)
-        let matchLines = result.split(separator: "\n").filter { $0.contains(".md:") }
-        XCTAssertEqual(matchLines.count, 1, "Expected exactly 1 match line, got: \(result)")
-        XCTAssertTrue(result.contains("max_results was 1"), "Expected hit-cap meta line: \(result)")
+        let result = try await tools.qmdSearch(query: "Sam Rivers", path: nil, caseInsensitive: true, maxResults: 10)
+        XCTAssertTrue(result.contains("2026-01-07/team-standup.md:"), "Expected cited match line: \(result)")
+        XCTAssertTrue(result.contains("Sam Rivers"), "Expected matched text in output: \(result)")
+        XCTAssertFalse(result.contains("2025-01-30: 4,000+ lines"), "Search should return source context, not a generic date-only timeline: \(result)")
     }
 
-    func testGrepReturnsNoMatchesMessage() async throws {
+    func testQMDSearchStillFindsExactTextWhenQMDIsBypassed() async throws {
         let tools = MeetingQATools(root: rootDir)
-        let result = try await tools.grep(pattern: "definitelynotinanyfile", path: nil, caseInsensitive: false, maxResults: 50)
+        let result = try await tools.qmdSearch(query: "\"Sam Rivers\"", path: nil, caseInsensitive: false, maxResults: 10)
+        XCTAssertTrue(result.contains("2026-01-07/team-standup.md:"), "Expected pure Swift fallback cited match line: \(result)")
+        XCTAssertTrue(result.contains("Sam Rivers"), "Expected matched text in fallback output: \(result)")
+    }
+
+    func testLegacyGrepToolAliasStillSearchesArchive() async throws {
+        let tools = MeetingQATools(root: rootDir)
+        let result = try await tools.grep(pattern: "Quinn Adler", path: nil, caseInsensitive: true, maxResults: 10)
+        XCTAssertTrue(result.contains("2025-01-29/dana-matt.md:"), "Expected legacy grep alias to return qmd/search-style citations: \(result)")
+    }
+
+    func testQMDSearchRespectsMaxResults() async throws {
+        let tools = MeetingQATools(root: rootDir)
+        let result = try await tools.qmdSearch(query: "Quinn", path: nil, caseInsensitive: true, maxResults: 1)
+        let matchLines = result.split(separator: "\n").filter { $0.contains(".md:") }
+        XCTAssertEqual(matchLines.count, 1, "Expected exactly 1 match line, got: \(result)")
+        XCTAssertTrue(result.contains("max_results hit"), "Expected hit-cap meta line: \(result)")
+    }
+
+    func testQMDSearchReturnsNoMatchesMessage() async throws {
+        let tools = MeetingQATools(root: rootDir)
+        let result = try await tools.qmdSearch(query: "definitelynotinanyfile", path: nil, caseInsensitive: false, maxResults: 50)
         XCTAssertTrue(result.contains("No matches found"), result)
     }
 
-    func testGrepRejectsPathOutsideRoot() async {
+    func testQMDSearchRejectsPathOutsideRoot() async {
         let tools = MeetingQATools(root: rootDir)
         do {
-            _ = try await tools.grep(pattern: "anything", path: "../outside", caseInsensitive: true, maxResults: 10)
+            _ = try await tools.qmdSearch(query: "anything", path: "../outside", caseInsensitive: true, maxResults: 10)
             XCTFail("Expected pathOutsideRoot error")
         } catch let error as PathSandboxError {
             guard case .pathOutsideRoot = error else { XCTFail("Wrong error: \(error)"); return }

--- a/GhostPepperTests/MeetingTranscriptWindowPresentationTests.swift
+++ b/GhostPepperTests/MeetingTranscriptWindowPresentationTests.swift
@@ -33,3 +33,73 @@ final class MeetingTranscriptWindowPresentationTests: XCTestCase {
         )
     }
 }
+
+@MainActor
+final class QAAnswerCitationsTests: XCTestCase {
+    func testPreprocessLinksMeetingLineCitations() {
+        let processed = QAAnswerCitations.preprocess(
+            "See 2026-04-28/standup.md:71-72 for the original quote."
+        )
+        XCTAssertTrue(
+            processed.contains("[2026-04-28/standup.md:71-72](gp://meeting/2026-04-28/standup.md?line=71)"),
+            processed
+        )
+    }
+
+    func testPreprocessLinksPersonWikilinks() {
+        let processed = QAAnswerCitations.preprocess("Follow up with [[Owen Blake Carter]].")
+        XCTAssertTrue(
+            processed.contains("[Owen Blake Carter](gp://person/people/owen-blake-carter)"),
+            processed
+        )
+    }
+}
+
+@MainActor
+final class MeetingMarkdownWriterTests: XCTestCase {
+    func testGranolaImportRoundTripPreservesFrontmatterDateAndRawTranscript() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let fileURL = directory.appendingPathComponent("jay-taylor-navan-chauhan-matt-hartman.md")
+        let original = """
+        ---
+        title: "Jay Taylor & Navan Chauhan <> Matt Hartman"
+        date: "2026-05-26T20:01:18.803Z"
+        granola_id: "not_FTrJiW1VXfbWSj"
+        source_type: meeting
+        imported_from: granola
+        ---
+
+        # Jay Taylor & Navan Chauhan <> Matt Hartman
+
+        ## Summary
+
+        ### Company Background
+
+        - Started July 2025
+
+        ## Transcript
+
+        Chat with meeting transcript: [https://notes.granola.ai/t/example](https://notes.granola.ai/t/example)
+
+        Hello from the raw Granola transcript.
+        """
+        try original.write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let transcript = try MeetingMarkdownWriter.parse(from: fileURL)
+        transcript.summary = transcript.summary?.replacingOccurrences(of: "Started", with: "Began")
+
+        let rendered = MeetingMarkdownWriter.renderMarkdown(transcript: transcript)
+
+        XCTAssertTrue(rendered.contains("granola_id: \"not_FTrJiW1VXfbWSj\""))
+        XCTAssertTrue(rendered.contains("date: \"2026-05-26T20:01:18.803Z\""))
+        XCTAssertTrue(rendered.contains("imported_from: granola"))
+        XCTAssertTrue(rendered.contains("Hello from the raw Granola transcript."))
+        XCTAssertTrue(rendered.contains("- Began July 2025"))
+        XCTAssertFalse(rendered.contains("*No transcript yet.*"))
+        XCTAssertFalse(rendered.contains("**Date:**"))
+    }
+}

--- a/GhostPepperTests/QwenToolCallParserTests.swift
+++ b/GhostPepperTests/QwenToolCallParserTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import GhostPepper
+
+final class QwenToolCallParserTests: XCTestCase {
+    /// Drives a full tool_call through the parser (open tag + JSON + close tag)
+    /// and returns the single resolved output.
+    private func parseSingle(_ payload: String) -> QwenToolCallParser.Output? {
+        let parser = QwenToolCallParser()
+        var outputs = parser.consume("<tool_call>\(payload)</tool_call>")
+        outputs += parser.finish()
+        return outputs.first(where: {
+            if case .toolCall = $0 { return true }
+            if case .text = $0 { return true }
+            return false
+        })
+    }
+
+    private func toolCall(_ output: QwenToolCallParser.Output?) -> (name: String, input: [String: Any])? {
+        guard case .toolCall(let name, let input)? = output else { return nil }
+        return (name, input)
+    }
+
+    func testWellFormedToolCallParses() {
+        let out = parseSingle(#"{"name": "qmd_search", "arguments": {"query": "Essex"}}"#)
+        let call = toolCall(out)
+        XCTAssertEqual(call?.name, "qmd_search")
+        XCTAssertEqual(call?.input["query"] as? String, "Essex")
+    }
+
+    // MARK: - Recovery: local Qwen drops "name" (memory: qwen-toolcall-malformed)
+
+    func testMissingNameInfersQMDSearchFromPattern() {
+        let out = parseSingle(#"{"arguments": {"pattern": "Essex Labs", "max_results": 50}}"#)
+        let call = toolCall(out)
+        XCTAssertEqual(call?.name, "qmd_search")
+        XCTAssertEqual(call?.input["pattern"] as? String, "Essex Labs")
+    }
+
+    func testMissingNameInfersQMDSearchFromQuery() {
+        let out = parseSingle(#"{"arguments": {"query": "Essex Labs", "max_results": 50}}"#)
+        let call = toolCall(out)
+        XCTAssertEqual(call?.name, "qmd_search")
+        XCTAssertEqual(call?.input["query"] as? String, "Essex Labs")
+    }
+
+    func testMissingNameInfersWriteFileFromContent() {
+        let out = parseSingle(#"{"arguments": {"path": "jane-doe.md", "content": "Jane Doe"}}"#)
+        XCTAssertEqual(toolCall(out)?.name, "write_file")
+    }
+
+    func testMissingNameInfersReadFileFromOffset() {
+        let out = parseSingle(#"{"arguments": {"path": "2026-01-07/standup.md", "offset": 10}}"#)
+        XCTAssertEqual(toolCall(out)?.name, "read_file")
+    }
+
+    func testMissingNameInfersReadFileFromMdPath() {
+        let out = parseSingle(#"{"arguments": {"path": "2026-01-07/standup.md"}}"#)
+        XCTAssertEqual(toolCall(out)?.name, "read_file")
+    }
+
+    func testMissingNameInfersListDirFromBarePath() {
+        let out = parseSingle(#"{"arguments": {"path": "2026-01-07"}}"#)
+        XCTAssertEqual(toolCall(out)?.name, "list_dir")
+    }
+
+    func testBareTopLevelArgumentsWithoutWrapper() {
+        // Some emissions drop both "name" and the "arguments" wrapper.
+        let out = parseSingle(#"{"pattern": "Quinn"}"#)
+        let call = toolCall(out)
+        XCTAssertEqual(call?.name, "qmd_search")
+        XCTAssertEqual(call?.input["pattern"] as? String, "Quinn")
+    }
+
+    func testUninferableMalformedEmitsMalformedSignal() {
+        // No recognizable argument keys → can't infer. Don't fabricate a tool;
+        // emit a distinct malformed signal so the agent loop can re-prompt
+        // (rather than treating the blob as a final answer).
+        let parser = QwenToolCallParser()
+        var outputs = parser.consume(#"<tool_call>{"foo": "bar"}</tool_call>"#)
+        outputs += parser.finish()
+        XCTAssertFalse(outputs.contains { if case .toolCall = $0 { return true } else { return false } },
+                       "should not infer a tool from unknown keys")
+        XCTAssertTrue(outputs.contains { if case .malformedToolCall = $0 { return true } else { return false } },
+                      "expected a malformed-tool-call signal")
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,10 +3,10 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Ghost Pepper — 100% local voice dictation & meeting transcription for macOS</title>
-<meta name="description" content="Voice dictation and meeting transcription without data ever leaving your machine. 100% local models, 100% privacy. Free and open source.">
+<title>Ghost Pepper — 100% local voice-to-text, meeting transcription, and 2nd brain for macOS</title>
+<meta name="description" content="Voice-to-text, meeting transcription, and a 2nd brain without data ever leaving your machine. 100% local models, 100% privacy. Free and open source.">
 <meta property="og:title" content="Ghost Pepper">
-<meta property="og:description" content="Voice dictation and meeting transcription without data ever leaving your machine. 100% local models = 100% privacy.">
+<meta property="og:description" content="Voice-to-text, meeting transcription, and a 2nd brain without data ever leaving your machine. 100% local models = 100% privacy.">
 <meta property="og:image" content="https://raw.githubusercontent.com/matthartman/ghost-pepper/main/app-icon.png">
 <meta property="og:url" content="https://matthartman.github.io/ghost-pepper">
 <meta name="twitter:card" content="summary">
@@ -276,8 +276,8 @@
 
 <div class="hero">
   <img src="https://raw.githubusercontent.com/matthartman/ghost-pepper/main/app-icon.png" alt="Ghost Pepper" class="hero-logo">
-  <h1>Ghost Pepper: Meet</h1>
-  <p class="tagline">Voice dictation and meeting transcription<br>without data ever leaving your machine.</p>
+  <h1>Ghost Pepper</h1>
+  <p class="tagline">Voice-to-text, meeting transcription, and a 2nd brain<br>without data ever leaving your machine.</p>
   <p class="subtagline">100% local models = 100% privacy</p>
 
   <a href="https://github.com/matthartman/ghost-pepper/releases/latest/download/GhostPepper.dmg" class="download-btn">Download for Mac</a>

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+DERIVED_DATA="${DERIVED_DATA:-$ROOT/build/DerivedData}"
+SOURCE_PACKAGES="${SOURCE_PACKAGES:-$DERIVED_DATA/SourcePackages}"
+MODULE_CACHE="${MODULE_CACHE:-$ROOT/build/ModuleCache.noindex}"
+SWIFTPM_MODULE_CACHE="${SWIFTPM_MODULE_CACHE:-$ROOT/build/swiftpm-module-cache}"
+RESULT_BUNDLE="${RESULT_BUNDLE:-$ROOT/build/ResultBundles/xcode-test.xcresult}"
+
+mkdir -p "$DERIVED_DATA" "$SOURCE_PACKAGES" "$MODULE_CACHE" "$SWIFTPM_MODULE_CACHE" "$(dirname "$RESULT_BUNDLE")"
+rm -rf "$RESULT_BUNDLE"
+
+package_resolution_flags=()
+if [[ "${ALLOW_PACKAGE_RESOLUTION:-0}" != "1" ]]; then
+    package_resolution_flags=(-disableAutomaticPackageResolution)
+fi
+
+export SWIFTPM_MODULECACHE_OVERRIDE="$SWIFTPM_MODULE_CACHE"
+export CLANG_MODULE_CACHE_PATH="$MODULE_CACHE"
+
+xcodebuild \
+    -project GhostPepper.xcodeproj \
+    -scheme GhostPepper \
+    -destination "platform=macOS" \
+    -derivedDataPath "$DERIVED_DATA" \
+    -clonedSourcePackagesDirPath "$SOURCE_PACKAGES" \
+    "${package_resolution_flags[@]}" \
+    -resultBundlePath "$RESULT_BUNDLE" \
+    CODE_SIGNING_ALLOWED=NO \
+    MODULE_CACHE_DIR="$MODULE_CACHE" \
+    -skipMacroValidation \
+    "$@" \
+    test


### PR DESCRIPTION
## Summary
Hardens local meeting Q&A so it no longer depends on external `qmd`/`rg`/`grep` for correctness, and tightens how weak local models are kept source-grounded.

- **MeetingQATools**: in-process Swift exact-text search fallback; unique qmd collection name per archive root. `qmd` remains an optional accelerator (not bundled, not required).
- **MeetingQAAgent**: malformed tool-call recovery; deterministic archive search when a local model answers without searching; answer verification against retrieved evidence before streaming.
- **QwenToolCallParser**: extracted with dedicated tests (`QwenToolCallParserTests`).
- Granola import roundtrip fixes, indexing/UI tweaks.
- Tooling: committed shared `GhostPepper` scheme; `scripts/xcode-test.sh` for hermetic local test runs. Local agent/skill config and the generated `.qmd` index are gitignored.

## Testing
- `MeetingQAAgentTests` — 17/17 passing
- `MeetingQAToolsTests` — 16/16 passing
- Full Debug build succeeds; app launches.

## Notes
Bundling `qmd` for semantic search was considered and deferred — it's a ~187 MB Node package + Node runtime + ~2 GB of GGUF models + notarization work. The in-process fallback is the shipping default; qmd is an opt-in accelerator for machines that have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)