### PR TITLE
Add menu actions for last vocal recording and history

### DIFF
--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -90,6 +90,13 @@ class AppState: ObservableObject {
     @Published private(set) var pushToTalkChord: KeyChord
     @Published private(set) var toggleToTalkChord: KeyChord
     @Published private(set) var pepperChatChord: KeyChord
+    /// Configurable global hotkeys for the menu affordances. Unset by default so a
+    /// system-wide chord is opt-in rather than clobbering an existing shortcut.
+    @Published private(set) var copyLastTranscriptionChord: KeyChord?
+    @Published private(set) var openHistoryChord: KeyChord?
+    /// Most recent dictation result (push-to-talk) — cleaned if cleanup ran, else raw;
+    /// not meeting text. Backs "Copy Last Transcription"; nil until the first dictation.
+    @Published private(set) var lastTranscription: String?
     @Published var postPasteLearningEnabled: Bool {
         didSet {
             cleanupSettingsDefaults.set(
@@ -243,6 +250,8 @@ class AppState: ObservableObject {
         self.pushToTalkChord = chordBindingStore.binding(for: .pushToTalk) ?? AppState.defaultPushToTalkChord
         self.toggleToTalkChord = chordBindingStore.binding(for: .toggleToTalk) ?? AppState.defaultToggleToTalkChord
         self.pepperChatChord = chordBindingStore.binding(for: .pepperChat) ?? AppState.defaultPepperChatChord
+        self.copyLastTranscriptionChord = chordBindingStore.binding(for: .copyLastTranscription)
+        self.openHistoryChord = chordBindingStore.binding(for: .openHistory)
         self.textCleanupManager = textCleanupManager ?? TextCleanupManager(defaults: cleanupSettingsDefaults)
         self.frontmostWindowOCRService = frontmostWindowOCRService
         self.recordingOCRPrefetch = RecordingOCRPrefetch { [frontmostWindowOCRService] customWords in
@@ -622,6 +631,12 @@ class AppState: ObservableObject {
             // No-op on key release — toggle mode handles everything on key down
         }
 
+        hotkeyMonitor.onSimpleAction = { [weak self] action in
+            Task { @MainActor in
+                self?.performSimpleHotkeyAction(action)
+            }
+        }
+
         hotkeyMonitor.updateBindings(shortcutBindings)
 
         if hotkeyMonitorStarted {
@@ -902,6 +917,10 @@ class AppState: ObservableObject {
 
         let cleanupResult = await cleanedTranscriptionResult(text, windowContext: windowContext)
         let finalText = cleanupResult.text
+        // Single dictation funnel — the only write site for "Copy Last Transcription".
+        if !finalText.isEmpty {
+            lastTranscription = finalText
+        }
         activeCleanupAttempted = cleanupResult.attemptedCleanup
         if cleanupResult.attemptedCleanup {
             activePerformanceTrace?.cleanupEndAt = Date()
@@ -1162,6 +1181,23 @@ class AppState: ObservableObject {
 
     func showSettings(section: SettingsSection? = nil) {
         settingsController.show(appState: self, section: section)
+    }
+
+    func copyLastTranscriptionToPasteboard() {
+        guard let lastTranscription else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(lastTranscription, forType: .string)
+    }
+
+    private func performSimpleHotkeyAction(_ action: ChordAction) {
+        switch action {
+        case .copyLastTranscription:
+            copyLastTranscriptionToPasteboard()
+        case .openHistory:
+            showSettings(section: .transcriptionLab)
+        case .pushToTalk, .toggleToTalk, .pepperChat:
+            break
+        }
     }
 
     func showPromptEditor() {
@@ -1499,6 +1535,14 @@ class AppState: ObservableObject {
             bindings[.pepperChat] = pepperChatChord
         }
 
+        if let copyLastTranscriptionChord {
+            bindings[.copyLastTranscription] = copyLastTranscriptionChord
+        }
+
+        if let openHistoryChord {
+            bindings[.openHistory] = openHistoryChord
+        }
+
         return bindings
     }
 
@@ -1506,6 +1550,8 @@ class AppState: ObservableObject {
         try? chordBindingStore.setBinding(pushToTalkChord, for: .pushToTalk)
         try? chordBindingStore.setBinding(toggleToTalkChord, for: .toggleToTalk)
         try? chordBindingStore.setBinding(pepperChatChord, for: .pepperChat)
+        try? chordBindingStore.setBinding(copyLastTranscriptionChord, for: .copyLastTranscription)
+        try? chordBindingStore.setBinding(openHistoryChord, for: .openHistory)
     }
 
     private var canAttemptCleanup: Bool {
@@ -1816,6 +1862,8 @@ class AppState: ObservableObject {
         let previousPushChord = pushToTalkChord
         let previousToggleChord = toggleToTalkChord
         let previousPepperChatChord = pepperChatChord
+        let previousCopyLastChord = copyLastTranscriptionChord
+        let previousOpenHistoryChord = openHistoryChord
 
         do {
             try chordBindingStore.setBinding(chord, for: action)
@@ -1828,6 +1876,10 @@ class AppState: ObservableObject {
                 toggleToTalkChord = chord
             case .pepperChat:
                 pepperChatChord = chord
+            case .copyLastTranscription:
+                copyLastTranscriptionChord = chord
+            case .openHistory:
+                openHistoryChord = chord
             }
 
             hotkeyMonitor.updateBindings(shortcutBindings)
@@ -1835,6 +1887,8 @@ class AppState: ObservableObject {
             pushToTalkChord = previousPushChord
             toggleToTalkChord = previousToggleChord
             pepperChatChord = previousPepperChatChord
+            copyLastTranscriptionChord = previousCopyLastChord
+            openHistoryChord = previousOpenHistoryChord
             shortcutErrorMessage = "That shortcut is already in use."
         }
     }

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -95,7 +95,7 @@ class AppState: ObservableObject {
     @Published private(set) var copyLastTranscriptionChord: KeyChord?
     @Published private(set) var openHistoryChord: KeyChord?
     /// Most recent dictation result (push-to-talk) — cleaned if cleanup ran, else raw;
-    /// not meeting text. Backs "Copy Last Transcription"; nil until the first dictation.
+    /// not meeting text. Backs "Copy Last Transcription".
     @Published private(set) var lastTranscription: String?
     @Published var postPasteLearningEnabled: Bool {
         didSet {
@@ -917,7 +917,7 @@ class AppState: ObservableObject {
 
         let cleanupResult = await cleanedTranscriptionResult(text, windowContext: windowContext)
         let finalText = cleanupResult.text
-        // Single dictation funnel — the only write site for "Copy Last Transcription".
+        // An empty cleanup result keeps the prior value rather than clearing the menu item.
         if !finalText.isEmpty {
             lastTranscription = finalText
         }

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -92,11 +92,11 @@ class AppState: ObservableObject {
     @Published private(set) var pepperChatChord: KeyChord
     /// Configurable global hotkeys for the menu affordances. Unset by default so a
     /// system-wide chord is opt-in rather than clobbering an existing shortcut.
-    @Published private(set) var copyLastTranscriptionChord: KeyChord?
+    @Published private(set) var copyLastVocalRecordingChord: KeyChord?
     @Published private(set) var openHistoryChord: KeyChord?
     /// Most recent dictation result (push-to-talk) — cleaned if cleanup ran, else raw;
-    /// not meeting text. Backs "Copy Last Transcription".
-    @Published private(set) var lastTranscription: String?
+    /// not meeting text. Backs "Copy Last Vocal Recording".
+    @Published private(set) var lastVocalRecording: String?
     @Published var postPasteLearningEnabled: Bool {
         didSet {
             cleanupSettingsDefaults.set(
@@ -250,7 +250,7 @@ class AppState: ObservableObject {
         self.pushToTalkChord = chordBindingStore.binding(for: .pushToTalk) ?? AppState.defaultPushToTalkChord
         self.toggleToTalkChord = chordBindingStore.binding(for: .toggleToTalk) ?? AppState.defaultToggleToTalkChord
         self.pepperChatChord = chordBindingStore.binding(for: .pepperChat) ?? AppState.defaultPepperChatChord
-        self.copyLastTranscriptionChord = chordBindingStore.binding(for: .copyLastTranscription)
+        self.copyLastVocalRecordingChord = chordBindingStore.binding(for: .copyLastVocalRecording)
         self.openHistoryChord = chordBindingStore.binding(for: .openHistory)
         self.textCleanupManager = textCleanupManager ?? TextCleanupManager(defaults: cleanupSettingsDefaults)
         self.frontmostWindowOCRService = frontmostWindowOCRService
@@ -878,6 +878,7 @@ class AppState: ObservableObject {
         )
 
         guard let text = transcriptionResult.rawTranscription else {
+            lastVocalRecording = nil
             recordingOCRPrefetch.cancel()
             await archiveRecordingForLab(
                 audioBuffer: audioBuffer,
@@ -917,10 +918,8 @@ class AppState: ObservableObject {
 
         let cleanupResult = await cleanedTranscriptionResult(text, windowContext: windowContext)
         let finalText = cleanupResult.text
-        // An empty cleanup result keeps the prior value rather than clearing the menu item.
-        if !finalText.isEmpty {
-            lastTranscription = finalText
-        }
+        let vocalRecordingText = finalText.isEmpty ? text : finalText
+        lastVocalRecording = vocalRecordingText.isEmpty ? nil : vocalRecordingText
         activeCleanupAttempted = cleanupResult.attemptedCleanup
         if cleanupResult.attemptedCleanup {
             activePerformanceTrace?.cleanupEndAt = Date()
@@ -1183,16 +1182,16 @@ class AppState: ObservableObject {
         settingsController.show(appState: self, section: section)
     }
 
-    func copyLastTranscriptionToPasteboard() {
-        guard let lastTranscription else { return }
+    func copyLastVocalRecordingToPasteboard() {
+        guard let lastVocalRecording else { return }
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(lastTranscription, forType: .string)
+        NSPasteboard.general.setString(lastVocalRecording, forType: .string)
     }
 
     private func performSimpleHotkeyAction(_ action: ChordAction) {
         switch action {
-        case .copyLastTranscription:
-            copyLastTranscriptionToPasteboard()
+        case .copyLastVocalRecording:
+            copyLastVocalRecordingToPasteboard()
         case .openHistory:
             showSettings(section: .transcriptionLab)
         case .pushToTalk, .toggleToTalk, .pepperChat:
@@ -1535,8 +1534,8 @@ class AppState: ObservableObject {
             bindings[.pepperChat] = pepperChatChord
         }
 
-        if let copyLastTranscriptionChord {
-            bindings[.copyLastTranscription] = copyLastTranscriptionChord
+        if let copyLastVocalRecordingChord {
+            bindings[.copyLastVocalRecording] = copyLastVocalRecordingChord
         }
 
         if let openHistoryChord {
@@ -1550,7 +1549,7 @@ class AppState: ObservableObject {
         try? chordBindingStore.setBinding(pushToTalkChord, for: .pushToTalk)
         try? chordBindingStore.setBinding(toggleToTalkChord, for: .toggleToTalk)
         try? chordBindingStore.setBinding(pepperChatChord, for: .pepperChat)
-        try? chordBindingStore.setBinding(copyLastTranscriptionChord, for: .copyLastTranscription)
+        try? chordBindingStore.setBinding(copyLastVocalRecordingChord, for: .copyLastVocalRecording)
         try? chordBindingStore.setBinding(openHistoryChord, for: .openHistory)
     }
 
@@ -1862,7 +1861,7 @@ class AppState: ObservableObject {
         let previousPushChord = pushToTalkChord
         let previousToggleChord = toggleToTalkChord
         let previousPepperChatChord = pepperChatChord
-        let previousCopyLastChord = copyLastTranscriptionChord
+        let previousCopyLastChord = copyLastVocalRecordingChord
         let previousOpenHistoryChord = openHistoryChord
 
         do {
@@ -1876,8 +1875,8 @@ class AppState: ObservableObject {
                 toggleToTalkChord = chord
             case .pepperChat:
                 pepperChatChord = chord
-            case .copyLastTranscription:
-                copyLastTranscriptionChord = chord
+            case .copyLastVocalRecording:
+                copyLastVocalRecordingChord = chord
             case .openHistory:
                 openHistoryChord = chord
             }
@@ -1887,10 +1886,25 @@ class AppState: ObservableObject {
             pushToTalkChord = previousPushChord
             toggleToTalkChord = previousToggleChord
             pepperChatChord = previousPepperChatChord
-            copyLastTranscriptionChord = previousCopyLastChord
+            copyLastVocalRecordingChord = previousCopyLastChord
             openHistoryChord = previousOpenHistoryChord
             shortcutErrorMessage = "That shortcut is already in use."
         }
+    }
+
+    func clearShortcut(for action: ChordAction) {
+        switch action {
+        case .copyLastVocalRecording:
+            copyLastVocalRecordingChord = nil
+        case .openHistory:
+            openHistoryChord = nil
+        case .pushToTalk, .toggleToTalk, .pepperChat:
+            return
+        }
+
+        try? chordBindingStore.setBinding(nil, for: action)
+        shortcutErrorMessage = nil
+        hotkeyMonitor.updateBindings(shortcutBindings)
     }
 
     func setShortcutCaptureActive(_ isActive: Bool) {

--- a/GhostPepper/Input/ChordAction.swift
+++ b/GhostPepper/Input/ChordAction.swift
@@ -4,13 +4,13 @@ enum ChordAction: String, CaseIterable, Codable {
     case pushToTalk
     case toggleToTalk
     case pepperChat
-    case copyLastTranscription
+    case copyLastVocalRecording
     case openHistory
 
     /// One-shot actions fire once on key-down rather than tracking a hold (start/stop).
     var isSimpleAction: Bool {
         switch self {
-        case .copyLastTranscription, .openHistory:
+        case .copyLastVocalRecording, .openHistory:
             return true
         case .pushToTalk, .toggleToTalk, .pepperChat:
             return false

--- a/GhostPepper/Input/ChordAction.swift
+++ b/GhostPepper/Input/ChordAction.swift
@@ -4,4 +4,16 @@ enum ChordAction: String, CaseIterable, Codable {
     case pushToTalk
     case toggleToTalk
     case pepperChat
+    case copyLastTranscription
+    case openHistory
+
+    /// One-shot actions fire once on key-down rather than tracking a hold (start/stop).
+    var isSimpleAction: Bool {
+        switch self {
+        case .copyLastTranscription, .openHistory:
+            return true
+        case .pushToTalk, .toggleToTalk, .pepperChat:
+            return false
+        }
+    }
 }

--- a/GhostPepper/Input/ChordEngine.swift
+++ b/GhostPepper/Input/ChordEngine.swift
@@ -74,7 +74,7 @@ struct ChordEngine {
 
             return []
 
-        case .copyLastTranscription, .openHistory:
+        case .copyLastVocalRecording, .openHistory:
             // Unreachable: simple actions never become the active recording action.
             return []
 

--- a/GhostPepper/Input/ChordEngine.swift
+++ b/GhostPepper/Input/ChordEngine.swift
@@ -9,11 +9,15 @@ struct ChordEngine {
         case startRecording
         case stopRecording
         case restartRecording
+        case fireSimpleAction(ChordAction)
     }
 
     private let bindings: [ChordAction: KeyChord]
     private(set) var pressedKeys: Set<PhysicalKey> = []
     private(set) var activeRecordingAction: ChordAction?
+    /// Latches the simple action that fired for the current press so it cannot fire
+    /// again while its chord stays held; cleared once a chord key is released.
+    private var firedSimpleAction: ChordAction?
 
     init(bindings: [ChordAction: KeyChord]) {
         self.bindings = bindings
@@ -31,7 +35,13 @@ struct ChordEngine {
     }
 
     private mutating func evaluateStateTransition() -> [Effect] {
-        
+        // Release the simple-action latch once its chord is no longer fully held.
+        if let firedSimpleAction,
+           let chord = bindings[firedSimpleAction],
+           !pressedKeys.isSuperset(of: chord.keys) {
+            self.firedSimpleAction = nil
+        }
+
         switch activeRecordingAction {
         case .pushToTalk:
             if matchResult() == .exact(.toggleToTalk) {
@@ -72,8 +82,20 @@ struct ChordEngine {
 
             return []
 
+        case .copyLastTranscription, .openHistory:
+            // One-shot actions never hold.
+            activeRecordingAction = nil
+            return []
+
         case nil:
             switch matchResult() {
+            case .exact(let action) where action.isSimpleAction:
+                // Edge-triggered: fire once per press. The latch suppresses re-fires while
+                // the chord stays held (auto-repeat key-downs, or a superset collapsing back
+                // to exact); it clears when a chord key lifts.
+                guard firedSimpleAction != action else { return [] }
+                firedSimpleAction = action
+                return [.fireSimpleAction(action)]
             case .exact(let action):
                 activeRecordingAction = action
                 return [.startRecording]
@@ -86,6 +108,7 @@ struct ChordEngine {
     mutating func reset() {
         pressedKeys.removeAll()
         activeRecordingAction = nil
+        firedSimpleAction = nil
     }
 
     func matchResult() -> ChordMatchResult {

--- a/GhostPepper/Input/ChordEngine.swift
+++ b/GhostPepper/Input/ChordEngine.swift
@@ -15,33 +15,25 @@ struct ChordEngine {
     private let bindings: [ChordAction: KeyChord]
     private(set) var pressedKeys: Set<PhysicalKey> = []
     private(set) var activeRecordingAction: ChordAction?
-    /// Latches the simple action that fired for the current press so it cannot fire
-    /// again while its chord stays held; cleared once a chord key is released.
-    private var firedSimpleAction: ChordAction?
 
     init(bindings: [ChordAction: KeyChord]) {
         self.bindings = bindings
     }
 
     mutating func handle(_ inputEvent: InputEvent) -> [Effect] {
+        let previousPressedKeys = pressedKeys
         guard updatePressedKeys(for: inputEvent) else { return [] }
-        return evaluateStateTransition()
+        return evaluateStateTransition(previousPressedKeys: previousPressedKeys)
     }
 
     mutating func syncPressedKeys(_ pressedKeys: Set<PhysicalKey>) -> [Effect] {
         guard self.pressedKeys != pressedKeys else { return [] }
+        let previousPressedKeys = self.pressedKeys
         self.pressedKeys = pressedKeys
-        return evaluateStateTransition()
+        return evaluateStateTransition(previousPressedKeys: previousPressedKeys)
     }
 
-    private mutating func evaluateStateTransition() -> [Effect] {
-        // Release the simple-action latch once its chord is no longer fully held.
-        if let firedSimpleAction,
-           let chord = bindings[firedSimpleAction],
-           !pressedKeys.isSuperset(of: chord.keys) {
-            self.firedSimpleAction = nil
-        }
-
+    private mutating func evaluateStateTransition(previousPressedKeys: Set<PhysicalKey>) -> [Effect] {
         switch activeRecordingAction {
         case .pushToTalk:
             if matchResult() == .exact(.toggleToTalk) {
@@ -83,18 +75,16 @@ struct ChordEngine {
             return []
 
         case .copyLastTranscription, .openHistory:
-            // One-shot actions never hold.
-            activeRecordingAction = nil
+            // Unreachable: simple actions never become the active recording action.
             return []
 
         case nil:
             switch matchResult() {
             case .exact(let action) where action.isSimpleAction:
-                // Edge-triggered: fire once per press. The latch suppresses re-fires while
-                // the chord stays held (auto-repeat key-downs, or a superset collapsing back
-                // to exact); it clears when a chord key lifts.
-                guard firedSimpleAction != action else { return [] }
-                firedSimpleAction = action
+                // Fire only when the chord is completed by adding a key, not when a larger
+                // held set collapses back down onto it (which would re-fire on key release).
+                guard let chord = bindings[action],
+                      !previousPressedKeys.isSuperset(of: chord.keys) else { return [] }
                 return [.fireSimpleAction(action)]
             case .exact(let action):
                 activeRecordingAction = action
@@ -108,7 +98,6 @@ struct ChordEngine {
     mutating func reset() {
         pressedKeys.removeAll()
         activeRecordingAction = nil
-        firedSimpleAction = nil
     }
 
     func matchResult() -> ChordMatchResult {

--- a/GhostPepper/Input/HotkeyMonitor.swift
+++ b/GhostPepper/Input/HotkeyMonitor.swift
@@ -12,6 +12,7 @@ protocol HotkeyMonitoring: AnyObject {
     var onToggleToTalkStop: (() -> Void)? { get set }
     var onPepperChatStart: (() -> Void)? { get set }
     var onPepperChatStop: (() -> Void)? { get set }
+    var onSimpleAction: ((ChordAction) -> Void)? { get set }
 
     func start() -> Bool
     func stop()
@@ -29,12 +30,14 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
         let startAction: ChordAction?
         let stopAction: ChordAction?
         let restartAction: ChordAction?
+        let simpleAction: ChordAction?
 
-        init(logMessage: String?, startAction: ChordAction? = nil, stopAction: ChordAction? = nil, restartAction: ChordAction? = nil) {
+        init(logMessage: String?, startAction: ChordAction? = nil, stopAction: ChordAction? = nil, restartAction: ChordAction? = nil, simpleAction: ChordAction? = nil) {
             self.logMessage = logMessage
             self.startAction = startAction
             self.stopAction = stopAction
             self.restartAction = restartAction
+            self.simpleAction = simpleAction
         }
     }
 
@@ -55,6 +58,7 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
     var onToggleToTalkStop: (() -> Void)?
     var onPepperChatStart: (() -> Void)?
     var onPepperChatStop: (() -> Void)?
+    var onSimpleAction: ((ChordAction) -> Void)?
 
     // MARK: - State
 
@@ -310,6 +314,8 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
                 "stop"
             case .restartRecording:
                 "restart"
+            case .fireSimpleAction(let action):
+                "fire(\(action.rawValue))"
             }
         }.joined(separator: ", ")
         let actionDescription = currentAction?.rawValue ?? "none"
@@ -319,7 +325,11 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
         let startAction = effects.contains(.startRecording) ? currentAction : nil
         let stopAction = effects.contains(.stopRecording) ? previousAction : nil
         let restartAction = effects.contains(.restartRecording) ? currentAction : nil
-        return HandlingResult(logMessage: logMessage, startAction: startAction, stopAction: stopAction, restartAction: restartAction)
+        var simpleAction: ChordAction?
+        for case .fireSimpleAction(let action) in effects {
+            simpleAction = action
+        }
+        return HandlingResult(logMessage: logMessage, startAction: startAction, stopAction: stopAction, restartAction: restartAction, simpleAction: simpleAction)
     }
 
     private func currentPressedKeys() -> Set<PhysicalKey> {
@@ -385,6 +395,10 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
             debugLogger?(.hotkey, logMessage)
         }
 
+        if let simpleAction = result.simpleAction {
+            onSimpleAction?(simpleAction)
+        }
+
         if let startAction = result.startAction {
             switch startAction {
             case .pushToTalk:
@@ -401,6 +415,8 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
                 }
             case .pepperChat:
                 onPepperChatStart?()
+            case .copyLastTranscription, .openHistory:
+                break
             }
         }
 
@@ -409,7 +425,7 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
             switch restartAction {
             case .pushToTalk, .toggleToTalk:
                 onRecordingRestart?()
-            case .pepperChat:
+            case .pepperChat, .copyLastTranscription, .openHistory:
                 break
             }
         }
@@ -430,6 +446,8 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
                 }
             case .pepperChat:
                 onPepperChatStop?()
+            case .copyLastTranscription, .openHistory:
+                break
             }
         }
     }

--- a/GhostPepper/Input/HotkeyMonitor.swift
+++ b/GhostPepper/Input/HotkeyMonitor.swift
@@ -415,7 +415,7 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
                 }
             case .pepperChat:
                 onPepperChatStart?()
-            case .copyLastTranscription, .openHistory:
+            case .copyLastVocalRecording, .openHistory:
                 break
             }
         }
@@ -425,7 +425,7 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
             switch restartAction {
             case .pushToTalk, .toggleToTalk:
                 onRecordingRestart?()
-            case .pepperChat, .copyLastTranscription, .openHistory:
+            case .pepperChat, .copyLastVocalRecording, .openHistory:
                 break
             }
         }
@@ -446,7 +446,7 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
                 }
             case .pepperChat:
                 onPepperChatStop?()
-            case .copyLastTranscription, .openHistory:
+            case .copyLastVocalRecording, .openHistory:
                 break
             }
         }

--- a/GhostPepper/UI/MenuBarView.swift
+++ b/GhostPepper/UI/MenuBarView.swift
@@ -16,10 +16,10 @@ struct MenuBarView: View {
                 appState.showSettings(section: .transcriptionLab)
             }
 
-            Button("Copy Last Transcription") {
-                appState.copyLastTranscriptionToPasteboard()
+            Button("Copy Last Vocal Recording") {
+                appState.copyLastVocalRecordingToPasteboard()
             }
-            .disabled(appState.lastTranscription == nil)
+            .disabled(appState.lastVocalRecording == nil)
 
             Divider()
 

--- a/GhostPepper/UI/MenuBarView.swift
+++ b/GhostPepper/UI/MenuBarView.swift
@@ -12,6 +12,17 @@ struct MenuBarView: View {
                 appState.showSettings()
             }
 
+            Button("History...") {
+                appState.showSettings(section: .transcriptionLab)
+            }
+
+            Button("Copy Last Transcription") {
+                appState.copyLastTranscriptionToPasteboard()
+            }
+            .disabled(appState.lastTranscription == nil)
+
+            Divider()
+
             if appState.pepperChatEnabled {
                 Button("Context Bundler...") {
                     appState.showPepperChat()

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -597,13 +597,29 @@ struct SettingsView: View {
                         appState.updateShortcut(chord, for: .toggleToTalk)
                     }
 
+                    ShortcutRecorderView(
+                        title: "Copy Last Transcription",
+                        chord: appState.copyLastTranscriptionChord,
+                        onRecordingStateChange: appState.setShortcutCaptureActive
+                    ) { chord in
+                        appState.updateShortcut(chord, for: .copyLastTranscription)
+                    }
+
+                    ShortcutRecorderView(
+                        title: "Open History",
+                        chord: appState.openHistoryChord,
+                        onRecordingStateChange: appState.setShortcutCaptureActive
+                    ) { chord in
+                        appState.updateShortcut(chord, for: .openHistory)
+                    }
+
                     if let shortcutErrorMessage = appState.shortcutErrorMessage {
                         Text(shortcutErrorMessage)
                             .font(.caption)
                             .foregroundStyle(.red)
                     }
 
-                    Text("Push to talk records while the hold chord stays down. Toggle recording starts and stops when you press the full toggle chord.")
+                    Text("Push to talk records while the hold chord stays down. Toggle recording starts and stops when you press the full toggle chord. Copy Last Transcription and Open History are unset by default — record a chord to enable each as a global shortcut.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -598,17 +598,23 @@ struct SettingsView: View {
                     }
 
                     ShortcutRecorderView(
-                        title: "Copy Last Transcription",
-                        chord: appState.copyLastTranscriptionChord,
-                        onRecordingStateChange: appState.setShortcutCaptureActive
+                        title: "Copy Last Vocal Recording",
+                        chord: appState.copyLastVocalRecordingChord,
+                        onRecordingStateChange: appState.setShortcutCaptureActive,
+                        onClear: {
+                            appState.clearShortcut(for: .copyLastVocalRecording)
+                        }
                     ) { chord in
-                        appState.updateShortcut(chord, for: .copyLastTranscription)
+                        appState.updateShortcut(chord, for: .copyLastVocalRecording)
                     }
 
                     ShortcutRecorderView(
                         title: "Open History",
                         chord: appState.openHistoryChord,
-                        onRecordingStateChange: appState.setShortcutCaptureActive
+                        onRecordingStateChange: appState.setShortcutCaptureActive,
+                        onClear: {
+                            appState.clearShortcut(for: .openHistory)
+                        }
                     ) { chord in
                         appState.updateShortcut(chord, for: .openHistory)
                     }
@@ -619,7 +625,7 @@ struct SettingsView: View {
                             .foregroundStyle(.red)
                     }
 
-                    Text("Push to talk records while the hold chord stays down. Toggle recording starts and stops when you press the full toggle chord. Copy Last Transcription and Open History are unset by default — record a chord to enable each as a global shortcut.")
+                    Text("Push to talk records while the hold chord stays down. Toggle recording starts and stops when you press the full toggle chord. Copy Last Vocal Recording and Open History are unset by default — record a chord to enable each as a global shortcut.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/GhostPepper/UI/ShortcutRecorderView.swift
+++ b/GhostPepper/UI/ShortcutRecorderView.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 
 struct ShortcutRecorderView: View {
     let title: String
-    let chord: KeyChord
+    let chord: KeyChord?
     let onRecordingStateChange: (Bool) -> Void
     let onChange: (KeyChord) -> Void
 
@@ -54,7 +54,7 @@ struct ShortcutRecorderView: View {
             return "Press Shortcut"
         }
 
-        return chord.shortcutRecorderDisplayString
+        return chord?.shortcutRecorderDisplayString ?? "Record Shortcut"
     }
 
     private func toggleRecording() {

--- a/GhostPepper/UI/ShortcutRecorderView.swift
+++ b/GhostPepper/UI/ShortcutRecorderView.swift
@@ -6,17 +6,36 @@ struct ShortcutRecorderView: View {
     let title: String
     let chord: KeyChord?
     let onRecordingStateChange: (Bool) -> Void
+    let onClear: (() -> Void)?
     let onChange: (KeyChord) -> Void
 
     @State private var isRecording = false
     @State private var captureState = ShortcutCaptureState()
     @State private var localMonitor: Any?
 
+    init(
+        title: String,
+        chord: KeyChord?,
+        onRecordingStateChange: @escaping (Bool) -> Void,
+        onClear: (() -> Void)? = nil,
+        onChange: @escaping (KeyChord) -> Void
+    ) {
+        self.title = title
+        self.chord = chord
+        self.onRecordingStateChange = onRecordingStateChange
+        self.onClear = onClear
+        self.onChange = onChange
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Text(title)
                 Spacer()
+                if !isRecording, chord != nil, let onClear {
+                    Button("Clear", action: onClear)
+                        .buttonStyle(.borderless)
+                }
                 if isRecording {
                     Button(action: toggleRecording) {
                         Text(buttonLabel)

--- a/GhostPepperTests/ChordEngineTests.swift
+++ b/GhostPepperTests/ChordEngineTests.swift
@@ -73,6 +73,51 @@ final class ChordEngineTests: XCTestCase {
         XCTAssertNil(engine.activeRecordingAction)
     }
 
+    func testSimpleActionFiresOnceOnKeyDownEdgeAndSuppressesRepeat() throws {
+        var engine = ChordEngine(bindings: [
+            .copyLastTranscription: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
+        XCTAssertNil(engine.activeRecordingAction)
+
+        XCTAssertEqual(engine.handle(.keyDown(space)), [])
+        XCTAssertEqual(engine.handle(.keyUp(space)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+    }
+
+    func testSimpleActionDoesNotRefireWhenChordIsReenteredFromASuperset() throws {
+        let extra = PhysicalKey(keyCode: 4) // H
+        var engine = ChordEngine(bindings: [
+            .copyLastTranscription: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
+
+        // Extend past the chord, then collapse back to the exact set — must not re-fire.
+        XCTAssertEqual(engine.handle(.keyDown(extra)), [])
+        XCTAssertEqual(engine.handle(.keyUp(extra)), [])
+
+        // Releasing a chord key clears the latch, so a fresh press fires again.
+        XCTAssertEqual(engine.handle(.keyUp(space)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
+    }
+
+    func testRecordingChordStillStartsWhenASimpleActionIsAlsoBound() throws {
+        var engine = ChordEngine(bindings: [
+            .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption]))),
+            .openHistory: try XCTUnwrap(KeyChord(keys: Set([leftCommand, space])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.flagsChanged(rightOption)), [.startRecording])
+        XCTAssertEqual(engine.activeRecordingAction, .pushToTalk)
+    }
+
     func testPushToTalkStopsWhenAnyRequiredKeyReleases() throws {
         var engine = ChordEngine(bindings: [
             .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption]))),

--- a/GhostPepperTests/ChordEngineTests.swift
+++ b/GhostPepperTests/ChordEngineTests.swift
@@ -75,11 +75,11 @@ final class ChordEngineTests: XCTestCase {
 
     func testSimpleActionFiresOnceOnKeyDownEdgeAndSuppressesRepeat() throws {
         var engine = ChordEngine(bindings: [
-            .copyLastTranscription: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space])))
+            .copyLastVocalRecording: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space])))
         ])
 
         XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
-        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastVocalRecording)])
         XCTAssertNil(engine.activeRecordingAction)
 
         XCTAssertEqual(engine.handle(.keyDown(space)), [])
@@ -90,11 +90,11 @@ final class ChordEngineTests: XCTestCase {
     func testSimpleActionDoesNotRefireWhenChordIsReenteredFromASuperset() throws {
         let extra = PhysicalKey(keyCode: 4) // H
         var engine = ChordEngine(bindings: [
-            .copyLastTranscription: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space])))
+            .copyLastVocalRecording: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space])))
         ])
 
         XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
-        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastVocalRecording)])
 
         // Extend past the chord, then collapse back to the exact set — must not re-fire.
         XCTAssertEqual(engine.handle(.keyDown(extra)), [])
@@ -104,18 +104,18 @@ final class ChordEngineTests: XCTestCase {
         XCTAssertEqual(engine.handle(.keyUp(space)), [])
         XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
         XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
-        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastVocalRecording)])
     }
 
     func testOverlappingSimpleActionDoesNotRefireWhenSupersetCollapses() throws {
         let extra = PhysicalKey(keyCode: 4) // H
         var engine = ChordEngine(bindings: [
-            .copyLastTranscription: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space]))),
+            .copyLastVocalRecording: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space]))),
             .openHistory: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space, extra])))
         ])
 
         XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
-        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastVocalRecording)])
         XCTAssertEqual(engine.handle(.keyDown(extra)), [.fireSimpleAction(.openHistory)])
 
         // Collapsing the superset back to the smaller chord must not re-fire it.

--- a/GhostPepperTests/ChordEngineTests.swift
+++ b/GhostPepperTests/ChordEngineTests.swift
@@ -100,7 +100,7 @@ final class ChordEngineTests: XCTestCase {
         XCTAssertEqual(engine.handle(.keyDown(extra)), [])
         XCTAssertEqual(engine.handle(.keyUp(extra)), [])
 
-        // Releasing a chord key clears the latch, so a fresh press fires again.
+        // Releasing a chord key breaks the superset, so a fresh press fires again.
         XCTAssertEqual(engine.handle(.keyUp(space)), [])
         XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
         XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])

--- a/GhostPepperTests/ChordEngineTests.swift
+++ b/GhostPepperTests/ChordEngineTests.swift
@@ -107,6 +107,21 @@ final class ChordEngineTests: XCTestCase {
         XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
     }
 
+    func testOverlappingSimpleActionDoesNotRefireWhenSupersetCollapses() throws {
+        let extra = PhysicalKey(keyCode: 4) // H
+        var engine = ChordEngine(bindings: [
+            .copyLastTranscription: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space]))),
+            .openHistory: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space, extra])))
+        ])
+
+        XCTAssertEqual(engine.handle(.flagsChanged(rightCommand)), [])
+        XCTAssertEqual(engine.handle(.keyDown(space)), [.fireSimpleAction(.copyLastTranscription)])
+        XCTAssertEqual(engine.handle(.keyDown(extra)), [.fireSimpleAction(.openHistory)])
+
+        // Collapsing the superset back to the smaller chord must not re-fire it.
+        XCTAssertEqual(engine.handle(.keyUp(extra)), [])
+    }
+
     func testRecordingChordStillStartsWhenASimpleActionIsAlsoBound() throws {
         var engine = ChordEngine(bindings: [
             .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([rightCommand, rightOption]))),

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -315,9 +315,9 @@ final class GhostPepperTests: XCTestCase {
 
         await appState.startHotkeyMonitor()
 
-        XCTAssertNil(appState.copyLastTranscriptionChord)
+        XCTAssertNil(appState.copyLastVocalRecordingChord)
         XCTAssertNil(appState.openHistoryChord)
-        XCTAssertNil(monitor.updatedBindings[.copyLastTranscription])
+        XCTAssertNil(monitor.updatedBindings[.copyLastVocalRecording])
         XCTAssertNil(monitor.updatedBindings[.openHistory])
         XCTAssertNotNil(monitor.onSimpleAction)
     }
@@ -332,13 +332,32 @@ final class GhostPepperTests: XCTestCase {
             PhysicalKey(keyCode: 4)
         ])))
 
-        appState.updateShortcut(chord, for: .copyLastTranscription)
+        appState.updateShortcut(chord, for: .copyLastVocalRecording)
 
-        XCTAssertEqual(appState.copyLastTranscriptionChord, chord)
-        XCTAssertEqual(monitor.updatedBindings[.copyLastTranscription], chord)
+        XCTAssertEqual(appState.copyLastVocalRecordingChord, chord)
+        XCTAssertEqual(monitor.updatedBindings[.copyLastVocalRecording], chord)
     }
 
-    func testAppStateRecordsLastTranscriptionAtDictationFunnel() async throws {
+    func testAppStateClearShortcutUnbindsOptionalMenuAction() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let store = ChordBindingStore(defaults: defaults)
+        let appState = AppState(hotkeyMonitor: monitor, chordBindingStore: store)
+        let chord = try XCTUnwrap(KeyChord(keys: Set([
+            PhysicalKey(keyCode: 54),
+            PhysicalKey(keyCode: 4)
+        ])))
+
+        appState.updateShortcut(chord, for: .copyLastVocalRecording)
+        appState.clearShortcut(for: .copyLastVocalRecording)
+
+        XCTAssertNil(appState.copyLastVocalRecordingChord)
+        XCTAssertNil(store.binding(for: .copyLastVocalRecording))
+        XCTAssertNil(monitor.updatedBindings[.copyLastVocalRecording])
+    }
+
+    func testAppStateRecordsLastVocalRecordingAtDictationFunnel() async throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)
         let appState = AppState(
@@ -346,7 +365,7 @@ final class GhostPepperTests: XCTestCase {
             chordBindingStore: ChordBindingStore(defaults: defaults),
             cleanupSettingsDefaults: defaults
         )
-        XCTAssertNil(appState.lastTranscription)
+        XCTAssertNil(appState.lastVocalRecording)
 
         appState.transcribeAudioBufferOverride = { _ in "raw transcript" }
         appState.cleanedTranscriptionResultOverride = { _, _ in
@@ -360,10 +379,67 @@ final class GhostPepperTests: XCTestCase {
             archivedWindowContext: nil
         )
 
-        XCTAssertEqual(appState.lastTranscription, "cleaned transcript")
+        XCTAssertEqual(appState.lastVocalRecording, "cleaned transcript")
     }
 
-    func testCopyLastTranscriptionToPasteboardNoOpsWhenEmpty() throws {
+    func testAppStateFallsBackToRawVocalRecordingWhenCleanupReturnsEmpty() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.transcribeAudioBufferOverride = { _ in "raw transcript" }
+        appState.cleanedTranscriptionResultOverride = { _, _ in
+            (text: "", prompt: "", attemptedCleanup: true, cleanupUsedFallback: false)
+        }
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: nil,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertEqual(appState.lastVocalRecording, "raw transcript")
+    }
+
+    func testAppStateClearsLastVocalRecordingWhenRecordingHasNoTranscription() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+
+        appState.transcribeAudioBufferOverride = { _ in "previous transcript" }
+        appState.cleanedTranscriptionResultOverride = { text, _ in
+            (text: text, prompt: "", attemptedCleanup: false, cleanupUsedFallback: false)
+        }
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: nil,
+            archivedWindowContext: nil
+        )
+
+        appState.transcribeAudioBufferOverride = { _ in nil }
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: nil,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertNil(appState.lastVocalRecording)
+    }
+
+    func testCopyLastVocalRecordingToPasteboardNoOpsWhenEmpty() throws {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
         defaults.removePersistentDomain(forName: #function)
         let appState = AppState(
@@ -374,7 +450,7 @@ final class GhostPepperTests: XCTestCase {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString("sentinel", forType: .string)
 
-        appState.copyLastTranscriptionToPasteboard()
+        appState.copyLastVocalRecordingToPasteboard()
 
         XCTAssertEqual(NSPasteboard.general.string(forType: .string), "sentinel")
     }

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -12,6 +12,7 @@ private final class FakeHotkeyMonitor: HotkeyMonitoring {
     var onToggleToTalkStop: (() -> Void)?
     var onPepperChatStart: (() -> Void)?
     var onPepperChatStop: (() -> Void)?
+    var onSimpleAction: ((ChordAction) -> Void)?
     var onRecordingRestart: (() -> Void)?
 
     var updatedBindings: [ChordAction: KeyChord] = [:]
@@ -304,6 +305,78 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertEqual(appState.toggleToTalkChord, originalToggleChord)
         XCTAssertEqual(monitor.updatedBindings[.toggleToTalk], originalToggleChord)
         XCTAssertEqual(appState.shortcutErrorMessage, "That shortcut is already in use.")
+    }
+
+    func testAppStateLeavesMenuShortcutsUnsetByDefault() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let appState = AppState(hotkeyMonitor: monitor, chordBindingStore: ChordBindingStore(defaults: defaults))
+
+        await appState.startHotkeyMonitor()
+
+        XCTAssertNil(appState.copyLastTranscriptionChord)
+        XCTAssertNil(appState.openHistoryChord)
+        XCTAssertNil(monitor.updatedBindings[.copyLastTranscription])
+        XCTAssertNil(monitor.updatedBindings[.openHistory])
+        XCTAssertNotNil(monitor.onSimpleAction)
+    }
+
+    func testAppStateUpdateShortcutBindsMenuActionGlobally() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let monitor = FakeHotkeyMonitor()
+        let appState = AppState(hotkeyMonitor: monitor, chordBindingStore: ChordBindingStore(defaults: defaults))
+        let chord = try XCTUnwrap(KeyChord(keys: Set([
+            PhysicalKey(keyCode: 54),
+            PhysicalKey(keyCode: 4)
+        ])))
+
+        appState.updateShortcut(chord, for: .copyLastTranscription)
+
+        XCTAssertEqual(appState.copyLastTranscriptionChord, chord)
+        XCTAssertEqual(monitor.updatedBindings[.copyLastTranscription], chord)
+    }
+
+    func testAppStateRecordsLastTranscriptionAtDictationFunnel() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        XCTAssertNil(appState.lastTranscription)
+
+        appState.transcribeAudioBufferOverride = { _ in "raw transcript" }
+        appState.cleanedTranscriptionResultOverride = { _, _ in
+            (text: "cleaned transcript", prompt: "", attemptedCleanup: true, cleanupUsedFallback: false)
+        }
+
+        await appState.finishRecordingForTesting(
+            audioBuffer: [1, 2, 3, 4, 5, 6],
+            recordingSessionCoordinator: nil,
+            recordingTranscriptionSession: nil,
+            archivedWindowContext: nil
+        )
+
+        XCTAssertEqual(appState.lastTranscription, "cleaned transcript")
+    }
+
+    func testCopyLastTranscriptionToPasteboardNoOpsWhenEmpty() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults
+        )
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("sentinel", forType: .string)
+
+        appState.copyLastTranscriptionToPasteboard()
+
+        XCTAssertEqual(NSPasteboard.general.string(forType: .string), "sentinel")
     }
 
     func testAppStateLoadsPersistedCleanupBackendSelection() throws {

--- a/GhostPepperTests/HotkeyMonitorTests.swift
+++ b/GhostPepperTests/HotkeyMonitorTests.swift
@@ -75,6 +75,35 @@ final class HotkeyMonitorTests: XCTestCase {
         XCTAssertEqual(events, ["start", "stop"])
     }
 
+    func testSimpleActionTriggersCallbackOnceOnKeyDownEdge() throws {
+        var keyStates: [PhysicalKey: Bool] = [:]
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .copyLastVocalRecording: try XCTUnwrap(KeyChord(keys: Set([rightCommand, space])))
+            ],
+            keyStateProvider: { keyStates[$0] ?? false }
+        )
+        var actions: [ChordAction] = []
+
+        monitor.onSimpleAction = { action in
+            actions.append(action)
+        }
+
+        keyStates[rightCommand] = true
+        monitor.handleInput(.flagsChanged(rightCommand))
+        keyStates[space] = true
+        monitor.handleInput(.keyDown(space))
+        monitor.handleInput(.keyDown(space))
+        keyStates[a] = true
+        monitor.handleInput(.keyDown(a))
+        keyStates[a] = false
+        monitor.handleInput(.keyUp(a))
+        keyStates[space] = false
+        monitor.handleInput(.keyUp(space))
+
+        XCTAssertEqual(actions, [.copyLastVocalRecording])
+    }
+
     func testPushChordStartsWhenCurrentKeyStateLagsBehindModifierEvents() throws {
         var keyStates: [PhysicalKey: Bool] = [:]
         let monitor = HotkeyMonitor(


### PR DESCRIPTION
Closes #140.

## Summary

Adds two menu bar actions:

- Copy Last Vocal Recording copies the latest completed vocal dictation.
- History opens the History view in Settings.

Both actions can be assigned global shortcuts from Settings > General > Shortcuts. They are unset by default, and optional shortcuts can be cleared.

## Notes

Copy Last Vocal Recording uses the cleaned dictation text when available, falls back to the raw dictation text, and clears when a recording produces no transcript. Meeting transcripts stay in History.

## Test Plan

- Focused macOS test run for:
  - ChordEngine simple actions
  - AppState shortcut binding and clearing
  - Last vocal recording capture, fallback, and clearing
  - HotkeyMonitor simple action callback
- `git diff --check`