### PR TITLE
Add ghostpepper:// URL and App Intents automation

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		04654E621041E2A81CC2CFC7 /* MeetingQAToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785F5D6EDD25D78F6220268E /* MeetingQAToolsTests.swift */; };
 		056C454F3BD1A9795C6775A5 /* ScreenRecordingPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4B61BA7270EEC11A8AC69 /* ScreenRecordingPermissionController.swift */; };
 		0606E11E6F102BBB44ED08B6 /* ScreenRecordingPermissionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9ECBFE04804AA79262A07B /* ScreenRecordingPermissionControllerTests.swift */; };
+		095051A93AE669587DBA043B /* MeetingSessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51E5C765BF88E2010E8F07B /* MeetingSessionIndexTests.swift */; };
 		09DA02222FFAFD8F32DB0212 /* TranscriptionLabStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */; };
 		0A1823314AE4FF4E17DCF627 /* sprite_frame_0.png in Resources */ = {isa = PBXBuildFile; fileRef = 2AF744C59EEAE51FC81BE6D6 /* sprite_frame_0.png */; };
 		0B50B23BDEAFA03CE3FFA368 /* Secrets.example in Resources */ = {isa = PBXBuildFile; fileRef = 84630A373DA596D94B45E867 /* Secrets.example */; };
@@ -59,11 +60,13 @@
 		408C8D6C7BE897429324F4F1 /* PerformanceTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016C38149DDDAA03B88E35C0 /* PerformanceTrace.swift */; };
 		41585ECBAFB5534CB6AE4FC5 /* GranolaImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9452C09EB8A7AC2E5E69A502 /* GranolaImporter.swift */; };
 		41C94A48B97D3A6861EA1E92 /* PostPasteLearningCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */; };
+		431919591B7D5593849B22A8 /* AppState+Automation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1352060EF22E0C0F9A90D4 /* AppState+Automation.swift */; };
 		44E13DF256A7BE7761A7C540 /* HighlightedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864660499212282B8ADC1AA7 /* HighlightedTextView.swift */; };
 		4698737CA099EE331A50CB77 /* TrelloCommandParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5A9294BC5DAF7D7ED625ECD /* TrelloCommandParser.swift */; };
 		47212FA484A38B3ABB2D679A /* MeetingWindowHeuristics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440454805353FB26F7C77E12 /* MeetingWindowHeuristics.swift */; };
 		478299189CD80630739E9150 /* MeetingQASystemPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87733132E66F36BCE7103250 /* MeetingQASystemPrompt.swift */; };
 		47B377ADA2B2F12226744122 /* MeetingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE672F443903BF4B47EF96EF /* MeetingDetector.swift */; };
+		47D1BBEA4D447A4A68F5C3E7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70DA33A8C71CFB79A4C50D3C /* AppDelegate.swift */; };
 		4961DAF729CE58AAAACBC1AC /* MeetingQAAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFEA05207B7965A3D44D000 /* MeetingQAAgentTests.swift */; };
 		4CFBE4928A2B811D649B4140 /* TextCleanupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C0D4F04FFD2C13DEACA238 /* TextCleanupManager.swift */; };
 		4DD74E9C222518EEB0DA2A9B /* RecordingOCRPrefetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */; };
@@ -112,6 +115,7 @@
 		8323B1A2E48B64B493939727 /* GranolaImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89E71C9D2C08957AB78FA5E /* GranolaImportView.swift */; };
 		8990B2F77435E351A458EDD9 /* DebugLogWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2715D9117D8664700616D95A /* DebugLogWindow.swift */; };
 		8BCB1AE8A984462B0635BA09 /* SystemAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BBAF87158BF49AB528B979 /* SystemAudioRecorder.swift */; };
+		8D953CB311DD3E4AF973B4FE /* URLActionHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C78B4783C66EE2E76879B9B5 /* URLActionHandlerTests.swift */; };
 		8F4C6360C1304C4A145DC34F /* LocalLLMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5336D97A974B974B025ED4 /* LocalLLMProvider.swift */; };
 		8F72E86B5335738940C35A67 /* MeetingWindowHeuristicsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */; };
 		90F411F8E3564F1C5DDD1A5F /* TextPasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */; };
@@ -147,7 +151,9 @@
 		B48B6FC5DEAB303E1A2DE5DC /* PathSandboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64F59E7884CF5A1ABFB3C387 /* PathSandboxTests.swift */; };
 		B4F9DA24EDE1C2CCDDC80AE5 /* AppRelauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECE990F52DED36EC4C5458D /* AppRelauncher.swift */; };
 		B648FDD8AE7E12040DF33CCA /* TranscriptionLabController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E1E5A0F12FE2B2FB5CD874 /* TranscriptionLabController.swift */; };
+		B86BDA3895A07B331025B36B /* GhostPepperAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE008237D4CEF3A478B59CD0 /* GhostPepperAppIntents.swift */; };
 		B8877739DF84D885A825C19F /* LLMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB9204EC17BB248E71D930A /* LLMProvider.swift */; };
+		BE21847998169864A2E6B9C0 /* GhostPepperAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0F15B8EE202259618F435F /* GhostPepperAction.swift */; };
 		BE7701382D2CC62C1CEBF29C /* ShortcutCaptureStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 231812B1BF8E3F2D5E0209F3 /* ShortcutCaptureStateTests.swift */; };
 		BEC965DB305742A9F42897F8 /* SpeechTranscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B1A6E1B8F3D8C8F234BD408 /* SpeechTranscriberTests.swift */; };
 		BF329CF451CC34A3B74348CC /* HotkeyMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF88392E6B9F0168E43B8C51 /* HotkeyMonitor.swift */; };
@@ -160,6 +166,7 @@
 		C5D011A82469050DF1E7F462 /* IndexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8311B6325214FE6B40CDE /* IndexBuilder.swift */; };
 		C6EDBC09902D8470DBFD5255 /* IndexSystemPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D736758B588185CCE102504 /* IndexSystemPrompt.swift */; };
 		C6F4C6C95E2835A2EEB58861 /* MeetingHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648497BCB18036D3B10EADD2 /* MeetingHistory.swift */; };
+		C9913C4ECA529A0655D9A2EE /* URLActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7995F6E1E0239797A4899616 /* URLActionHandler.swift */; };
 		CB39E9A8C16C4704B087F40C /* PathSandbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659E43C6D2C350FE7DB967A3 /* PathSandbox.swift */; };
 		CBDE26BEEBD0419A73D09DFC /* OCRRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45DE13042196F9DF2445E66 /* OCRRequestFactory.swift */; };
 		CC795C47BAF8CEF62790BAFF /* LocalLLMCleanupBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE96F13974B4DC0EEB3C17E /* LocalLLMCleanupBackend.swift */; };
@@ -297,14 +304,17 @@
 		6BF767CF1AA15DB2C2B82A1C /* ChordBindingStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordBindingStoreTests.swift; sourceTree = "<group>"; };
 		6CAEC58BA358D8ED4206D550 /* ChunkedTranscriptionPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkedTranscriptionPipeline.swift; sourceTree = "<group>"; };
 		6D736758B588185CCE102504 /* IndexSystemPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSystemPrompt.swift; sourceTree = "<group>"; };
+		6F0F15B8EE202259618F435F /* GhostPepperAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostPepperAction.swift; sourceTree = "<group>"; };
 		6F3496D74914A4B865A1A0DF /* TranscriptionLabSpeakerProfileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabSpeakerProfileStoreTests.swift; sourceTree = "<group>"; };
 		6FEC2E37841B0CF1F320F326 /* ZoBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoBackend.swift; sourceTree = "<group>"; };
+		70DA33A8C71CFB79A4C50D3C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7201BD31C20BC2B1D0E51DB6 /* CleanupModelProbeRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupModelProbeRunner.swift; sourceTree = "<group>"; };
 		74815C21991689C25D83ACE9 /* SpeakerIdentityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerIdentityResolverTests.swift; sourceTree = "<group>"; };
 		770403076BA384F3E35AA7A1 /* TextCleanupManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanupManagerTests.swift; sourceTree = "<group>"; };
 		777FDA0FC9C05B5D278C6C3E /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		785F5D6EDD25D78F6220268E /* MeetingQAToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingQAToolsTests.swift; sourceTree = "<group>"; };
 		79231C6829FD88741536FF4A /* sprite_frame_0@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_0@2x.png"; sourceTree = "<group>"; };
+		7995F6E1E0239797A4899616 /* URLActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActionHandler.swift; sourceTree = "<group>"; };
 		7ECFAFC0144B6B9203BF4EE0 /* RecognizedVoiceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizedVoiceStoreTests.swift; sourceTree = "<group>"; };
 		7FC3D36DE7AC456246062883 /* IndexListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexListView.swift; sourceTree = "<group>"; };
 		80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOCRPrefetchTests.swift; sourceTree = "<group>"; };
@@ -333,6 +343,7 @@
 		9A3540C6212101C885EA22CD /* RecordingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOverlay.swift; sourceTree = "<group>"; };
 		9A54422D17879836781B7F71 /* KeyChord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChord.swift; sourceTree = "<group>"; };
 		9AA71CE818E7248813A08248 /* SpeakerIdentityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerIdentityResolver.swift; sourceTree = "<group>"; };
+		9C1352060EF22E0C0F9A90D4 /* AppState+Automation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppState+Automation.swift"; sourceTree = "<group>"; };
 		9C9ECBFE04804AA79262A07B /* ScreenRecordingPermissionControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordingPermissionControllerTests.swift; sourceTree = "<group>"; };
 		9CA473A11BE2285D5F27714C /* ClaudeAPIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeAPIModel.swift; sourceTree = "<group>"; };
 		9E3575D1B5EA81CBB2CD1C2B /* FocusedElementLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedElementLocator.swift; sourceTree = "<group>"; };
@@ -354,6 +365,7 @@
 		B112C736F05F0A7CFA7784A2 /* MeetingTranscriptWindowPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingTranscriptWindowPresentationTests.swift; sourceTree = "<group>"; };
 		B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingWindowHeuristicsTests.swift; sourceTree = "<group>"; };
 		B219A1BCAC2EBC64DDAE6960 /* UsageStatsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageStatsStore.swift; sourceTree = "<group>"; };
+		B51E5C765BF88E2010E8F07B /* MeetingSessionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSessionIndexTests.swift; sourceTree = "<group>"; };
 		B7327B46CAF5B3DDE5325601 /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPasterTests.swift; sourceTree = "<group>"; };
 		B89E71C9D2C08957AB78FA5E /* GranolaImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GranolaImportView.swift; sourceTree = "<group>"; };
@@ -367,6 +379,7 @@
 		C1855FD74C5B66BEFC6A9F06 /* GoogleCalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleCalendarService.swift; sourceTree = "<group>"; };
 		C297C5F9DF753732CD01C5B1 /* MediaPlaybackController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackController.swift; sourceTree = "<group>"; };
 		C3172F66BB9EF510F4E17D76 /* MeetingTranscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingTranscript.swift; sourceTree = "<group>"; };
+		C78B4783C66EE2E76879B9B5 /* URLActionHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLActionHandlerTests.swift; sourceTree = "<group>"; };
 		CA0C0CBEADEB8791C4D738B1 /* ModelsSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsSidebarView.swift; sourceTree = "<group>"; };
 		CC0F71B32FF6973FD42639C7 /* ModelInventory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelInventory.swift; sourceTree = "<group>"; };
 		CCE81899A3B0F5CB9777BD6A /* TextCleanupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanupManager.swift; sourceTree = "<group>"; };
@@ -392,6 +405,7 @@
 		E9369F8E6A32A99F693A5DF3 /* QAEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAEvent.swift; sourceTree = "<group>"; };
 		EAF6390CFE5F526DD23C316D /* AudioDeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDeviceManager.swift; sourceTree = "<group>"; };
 		EBAB39218D09F11336C4F684 /* TextCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleaner.swift; sourceTree = "<group>"; };
+		EE008237D4CEF3A478B59CD0 /* GhostPepperAppIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostPepperAppIntents.swift; sourceTree = "<group>"; };
 		F0EBA7ECAEFCAC714F83C2C5 /* OnboardingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindow.swift; sourceTree = "<group>"; };
 		F14601041CEB40DAB3828382 /* IndexBuildEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexBuildEvent.swift; sourceTree = "<group>"; };
 		F2387F1E285001F18E98F967 /* QATranscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QATranscript.swift; sourceTree = "<group>"; };
@@ -479,6 +493,7 @@
 				B7327B46CAF5B3DDE5325601 /* Secrets.swift */,
 				5F85AD0262D40047E6FCA3D8 /* UpdaterController.swift */,
 				BD13B12B603D3A9D89A5F2C4 /* Audio */,
+				AFDBB85A11F8E96C8FF6AC73 /* Automation */,
 				3F87A3BF3E682C1FA96DE9AC /* Calendar */,
 				6A2ED16C65A7A2047D1F84F6 /* Cleanup */,
 				D5A9C7455B7D779E3D316BB3 /* Context */,
@@ -726,6 +741,18 @@
 			);
 			sourceTree = "<group>";
 		};
+		AFDBB85A11F8E96C8FF6AC73 /* Automation */ = {
+			isa = PBXGroup;
+			children = (
+				70DA33A8C71CFB79A4C50D3C /* AppDelegate.swift */,
+				9C1352060EF22E0C0F9A90D4 /* AppState+Automation.swift */,
+				6F0F15B8EE202259618F435F /* GhostPepperAction.swift */,
+				EE008237D4CEF3A478B59CD0 /* GhostPepperAppIntents.swift */,
+				7995F6E1E0239797A4899616 /* URLActionHandler.swift */,
+			);
+			path = Automation;
+			sourceTree = "<group>";
+		};
 		B242BF76D6E42784C2A05EB5 /* Transcription */ = {
 			isa = PBXGroup;
 			children = (
@@ -822,6 +849,7 @@
 				35A699887678B31BAF27498A /* MeetingQASystemPromptTests.swift */,
 				785F5D6EDD25D78F6220268E /* MeetingQAToolsTests.swift */,
 				8DE1C89364E34D2A8758EB96 /* MeetingQAToolsWriteFileTests.swift */,
+				B51E5C765BF88E2010E8F07B /* MeetingSessionIndexTests.swift */,
 				B112C736F05F0A7CFA7784A2 /* MeetingTranscriptWindowPresentationTests.swift */,
 				B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */,
 				D6A098A2516C7563B1E4FDD3 /* ModelManagerTests.swift */,
@@ -844,6 +872,7 @@
 				48FD8FBD546233B0547BB89D /* TranscriptionLabRunnerTests.swift */,
 				6F3496D74914A4B865A1A0DF /* TranscriptionLabSpeakerProfileStoreTests.swift */,
 				D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */,
+				C78B4783C66EE2E76879B9B5 /* URLActionHandlerTests.swift */,
 			);
 			path = GhostPepperTests;
 			sourceTree = "<group>";
@@ -927,7 +956,6 @@
 				};
 			};
 			buildConfigurationList = 4DD304029FEB6147483470FD /* Build configuration list for PBXProject "GhostPepper" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -943,6 +971,7 @@
 				E56E28037799FE95D6CB5F71 /* XCRemoteSwiftPackageReference "WhisperKit" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 3705D6F7BCD01CB7D37DF812 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -984,7 +1013,9 @@
 				9702D125E2DECC58D973E80F /* AccessibilityWindowTitles.swift in Sources */,
 				124405C2042DC7A4D8C3BCBC /* AgentBackend.swift in Sources */,
 				117E06290C6E2BB843E9BEBF /* AnthropicProvider.swift in Sources */,
+				47D1BBEA4D447A4A68F5C3E7 /* AppDelegate.swift in Sources */,
 				B4F9DA24EDE1C2CCDDC80AE5 /* AppRelauncher.swift in Sources */,
+				431919591B7D5593849B22A8 /* AppState+Automation.swift in Sources */,
 				A9E5AB4DC4D58FB4C50A1B23 /* AppState.swift in Sources */,
 				780CB9207962633AEE3E69BD /* AudioDeviceManager.swift in Sources */,
 				4EAE492B8F7F4CB18D2E0FE9 /* AudioRecorder.swift in Sources */,
@@ -1010,7 +1041,9 @@
 				761730C7D555A5E165541B02 /* FluidAudioSpeechSession.swift in Sources */,
 				58786AC40C6823691E15369C /* FocusedElementLocator.swift in Sources */,
 				2911F1771ED7BA232F973EC1 /* FrontmostWindowOCRService.swift in Sources */,
+				BE21847998169864A2E6B9C0 /* GhostPepperAction.swift in Sources */,
 				31E37E3EDDB8A0E5011BCA54 /* GhostPepperApp.swift in Sources */,
+				B86BDA3895A07B331025B36B /* GhostPepperAppIntents.swift in Sources */,
 				B3DB833B0C853CCB9A2C52ED /* GoogleCalendarService.swift in Sources */,
 				8323B1A2E48B64B493939727 /* GranolaImportView.swift in Sources */,
 				41585ECBAFB5534CB6AE4FC5 /* GranolaImporter.swift in Sources */,
@@ -1093,6 +1126,7 @@
 				DFAB770908C43B46C21F6986 /* TranscriptionLabStore.swift in Sources */,
 				660FCA13EFCA0BC0B8A1FA8E /* TrelloBackend.swift in Sources */,
 				4698737CA099EE331A50CB77 /* TrelloCommandParser.swift in Sources */,
+				C9913C4ECA529A0655D9A2EE /* URLActionHandler.swift in Sources */,
 				829C83DF25112D375A8DB767 /* UpdaterController.swift in Sources */,
 				3867702A684F28E1B31A4440 /* UsageReportView.swift in Sources */,
 				9114B9CC3A96A49F51A622A8 /* UsageStatsStore.swift in Sources */,
@@ -1148,6 +1182,7 @@
 				190EA523BC8AAF93599DD038 /* MeetingQASystemPromptTests.swift in Sources */,
 				04654E621041E2A81CC2CFC7 /* MeetingQAToolsTests.swift in Sources */,
 				DC6FA0D74F38335D52B5DFA2 /* MeetingQAToolsWriteFileTests.swift in Sources */,
+				095051A93AE669587DBA043B /* MeetingSessionIndexTests.swift in Sources */,
 				D647909F8F2D5C2046352750 /* MeetingTranscriptWindowPresentationTests.swift in Sources */,
 				8F72E86B5335738940C35A67 /* MeetingWindowHeuristicsTests.swift in Sources */,
 				1A9C394F69A8A0E9DCA48219 /* ModelManagerTests.swift in Sources */,
@@ -1170,6 +1205,7 @@
 				950E9B7AB1223E2B2D679B71 /* TranscriptionLabRunnerTests.swift in Sources */,
 				37669DE8B07FA0D5E77661ED /* TranscriptionLabSpeakerProfileStoreTests.swift in Sources */,
 				09DA02222FFAFD8F32DB0212 /* TranscriptionLabStoreTests.swift in Sources */,
+				8D953CB311DD3E4AF973B4FE /* URLActionHandlerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -81,6 +81,11 @@ class AppState: ObservableObject {
     @AppStorage("trelloDefaultListId") var trelloDefaultListId: String = ""
     @Published var trelloBoards: [TrelloBoard] = []
     @AppStorage("meetingTranscriptEnabled") var meetingTranscriptEnabled: Bool = false
+    /// Opt-in for the `ghostpepper://` URL scheme and App Intents. Off by default:
+    /// a custom URL scheme is unauthenticated and web-reachable, so state-changing
+    /// and value-returning automation is refused until the user enables this. See
+    /// `AppState.perform(_:)`.
+    @AppStorage("allowAutomation") var allowAutomation: Bool = false
     @Published var showWhatsNew = false
     @AppStorage("meetingAutoDetectEnabled") var meetingAutoDetectEnabled: Bool = true
     @AppStorage("meetingWindowFloatsWhileRecording") var meetingWindowFloatsWhileRecording: Bool = true
@@ -432,6 +437,10 @@ class AppState: ObservableObject {
         self.textCleaner.sensitiveDebugLogger = sensitiveComponentDebugLogger
         self.postPasteLearningCoordinator.debugLogger = componentDebugLogger
         self.modelManager.debugLogger = componentDebugLogger
+
+        // Publish this instance for automation front-ends (URL scheme / App Intents),
+        // which can be invoked before SwiftUI finishes building the scene.
+        AppState.registerShared(self)
     }
 
     func initialize(skipPermissionPrompts: Bool = false) async {
@@ -1130,6 +1139,9 @@ class AppState: ObservableObject {
     }()
     private let meetingDetector = MeetingDetector()
     @Published var activeMeetingSession: MeetingSession?
+
+    /// Resolves `open-meeting?id=…` to a saved file. Built off-main, updated on save.
+    let meetingSessionIndex = MeetingSessionIndex()
     private(set) lazy var pepperChatSession: PepperChatSession = {
         let session = PepperChatSession(transcriber: transcriber)
         session.debugLogger = debugLogStore.record
@@ -1360,6 +1372,12 @@ class AppState: ObservableObject {
         meetingTranscriptWindowController.show()
     }
 
+    /// Used by automation, which can't reach the private window controller directly.
+    func openSavedMeeting(at url: URL) {
+        meetingTranscriptWindowController.show()
+        meetingTranscriptWindowController.windowState?.openFile(url)
+    }
+
     func showOrCreateMeetingWindow() {
         meetingTranscriptWindowController.show()
     }
@@ -1432,6 +1450,8 @@ class AppState: ObservableObject {
         NotificationCenter.default.post(name: .meetingRecordingStopped, object: savedURL)
         if let savedURL = savedURL {
             triggerIndexUpdates(for: savedURL)
+            let sessionID = session.transcript.sessionID
+            Task { await meetingSessionIndex.register(sessionID: sessionID, url: savedURL) }
         }
     }
 

--- a/GhostPepper/Automation/AppDelegate.swift
+++ b/GhostPepper/Automation/AppDelegate.swift
@@ -1,0 +1,61 @@
+import AppKit
+
+/// Handles `ghostpepper://` URLs. `.onOpenURL` is unreliable in a `MenuBarExtra`-only
+/// app, so we register a delegate via `@NSApplicationDelegateAdaptor` and implement
+/// `application(_:open:)`.
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private let processor = AutomationURLProcessor()
+
+    func application(_ application: NSApplication, open urls: [URL]) {
+        for url in urls where url.scheme?.lowercased() == URLActionHandler.scheme {
+            processor.enqueue(url)
+        }
+    }
+}
+
+/// Runs inbound automation URLs one at a time so a slow `summarize-meeting` can't race
+/// a later URL, and waits for AppState before dispatching (cold-launch buffering).
+@MainActor
+private final class AutomationURLProcessor {
+    private var tail: Task<Void, Never>?
+
+    func enqueue(_ url: URL) {
+        let previous = tail
+        tail = Task { @MainActor in
+            await previous?.value
+            await Self.handle(url)
+        }
+    }
+
+    private static func handle(_ url: URL) async {
+        guard let request = URLActionHandler.parse(url) else {
+            NSLog("GhostPepper automation: ignoring malformed URL %@", url.absoluteString)
+            return
+        }
+
+        let appState = await AppState.ready()
+        let result: Result<GhostPepperActionResult, GhostPepperActionError>
+        if let appState {
+            switch URLActionHandler.action(for: request) {
+            case .success(let action):
+                result = await appState.perform(action)
+            case .failure(let error):
+                result = .failure(error)
+            }
+        } else {
+            result = .failure(.notReady("Ghost Pepper is still launching."))
+        }
+
+        if let callback = URLActionHandler.callbackURL(for: request, result: result) {
+            NSWorkspace.shared.open(callback)
+        } else if case .failure(let error) = result {
+            let message = "automation \(request.action) failed (\(error.code.rawValue)) — \(error.message)"
+            if let appState {
+                appState.debugLogStore.record(category: .model, message: message)
+            } else {
+                NSLog("GhostPepper %@", message)
+            }
+        }
+    }
+}

--- a/GhostPepper/Automation/AppState+Automation.swift
+++ b/GhostPepper/Automation/AppState+Automation.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+// MARK: - Shared instance + readiness gate
+
+extension AppState {
+    private static var sharedInstance: AppState?
+
+    /// The live AppState once SwiftUI has constructed it. `nil` during cold launch,
+    /// before the scene's `@StateObject` is built.
+    static var shared: AppState? { sharedInstance }
+
+    static func registerShared(_ instance: AppState) {
+        sharedInstance = instance
+    }
+
+    /// Suspend until AppState exists, or give up after `timeout`. A URL or App Intent
+    /// can launch the app before the scene is built; front-ends use this to map that
+    /// race to `NOT_READY` rather than crash on a missing instance.
+    static func ready(timeout: Duration = .seconds(8)) async -> AppState? {
+        await poll(timeout: timeout, interval: .milliseconds(50)) { sharedInstance }
+    }
+
+    /// Sleeping suspends (does not block) the main actor.
+    static func poll<T>(timeout: Duration, interval: Duration, _ predicate: () -> T?) async -> T? {
+        let deadline = ContinuousClock.now + timeout
+        while true {
+            if let value = predicate() { return value }
+            if ContinuousClock.now >= deadline { return nil }
+            try? await Task.sleep(for: interval)
+        }
+    }
+}
+
+// MARK: - Dispatcher
+
+extension AppState {
+    /// The single automation boundary. The menu, configurable hotkeys, the
+    /// `ghostpepper://` URL scheme, and App Intents all cross into the app here.
+    func perform(_ action: GhostPepperAction) async -> Result<GhostPepperActionResult, GhostPepperActionError> {
+        if action.requiresAutomationConsent, !allowAutomation {
+            return .failure(.forbidden("Automation is disabled. Enable \u{201C}Allow automation\u{201D} in Settings."))
+        }
+
+        switch action {
+        case .startMeeting(let name):
+            return await startMeetingAction(name: name)
+        case .stopMeeting:
+            return stopMeetingAction()
+        case .getLastTranscription:
+            return await getLastTranscriptionAction()
+        case .getStatus:
+            return .success(statusSnapshot())
+        case .summarizeMeeting(let ref):
+            return await summarizeMeetingAction(ref)
+        case .openMeeting(let ref):
+            return await openMeetingAction(ref)
+        }
+    }
+
+    // MARK: Start / stop
+
+    private func startMeetingAction(name: String?) async -> Result<GhostPepperActionResult, GhostPepperActionError> {
+        guard activeMeetingSession == nil else {
+            return .failure(.conflict("A meeting is already being recorded."))
+        }
+
+        let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let meetingName = (trimmed?.isEmpty == false) ? trimmed! : Self.generatedMeetingName()
+
+        // Route through the existing consent path: this prompts unless the
+        // user opted out globally, so a URL/Shortcut can't silently record.
+        startMeetingTranscription(meetingName: meetingName)
+
+        // Wait until the session exists and its first autosave has written the
+        // `id:` frontmatter, so the returned viewURL resolves by-id. The wait is
+        // bounded so a pending consent dialog can't block the URL queue indefinitely;
+        // on timeout the meeting may still start, so report NOT_READY (retryable),
+        // not FORBIDDEN.
+        guard let session = await awaitMeetingFileReady(timeout: .seconds(30)) else {
+            return .failure(.notReady("Recording did not start in time. If a consent prompt is open, approve it and retry."))
+        }
+
+        let id = session.transcript.sessionID.uuidString
+        return .success(.meetingStarted(id: id, viewURL: URLActionHandler.viewURL(forMeetingID: id)))
+    }
+
+    private func stopMeetingAction() -> Result<GhostPepperActionResult, GhostPepperActionError> {
+        guard activeMeetingSession != nil else {
+            return .failure(.notFound("No meeting is currently being recorded."))
+        }
+        stopMeetingTranscription()
+        return .success(.ok)
+    }
+
+    // MARK: Queries
+
+    private func statusSnapshot() -> GhostPepperActionResult {
+        // Ungated read-only snapshot. It includes the meeting name (can be sensitive),
+        // but the web-scheme guard keeps it off http/https callbacks.
+        let meeting = activeMeetingSession
+        let recording = isRecording || (meeting?.isActive == true)
+        return .status(
+            recording: recording,
+            appStatus: publicAppStatus,
+            meetingID: meeting?.transcript.sessionID.uuidString,
+            meetingName: meeting?.transcript.meetingName
+        )
+    }
+
+    /// Internal `AppStatus` mapped to a small, frozen public vocabulary. Never
+    /// expose the internal `rawValue` (Hyrum: don't freeze a UI string into the contract).
+    private var publicAppStatus: String {
+        if activeMeetingSession?.isActive == true { return "recording" }
+        switch status {
+        case .ready: return "idle"
+        case .recording: return "recording"
+        case .transcribing, .cleaningUp: return "transcribing"
+        case .loading, .error: return "busy"
+        }
+    }
+
+    private func getLastTranscriptionAction() async -> Result<GhostPepperActionResult, GhostPepperActionError> {
+        if let active = activeMeetingSession, !active.transcript.segments.isEmpty {
+            return .success(.transcription(text: active.transcript.plainText))
+        }
+
+        // Newest saved file that actually holds a transcript. Reader/article entries
+        // share the archive but have no segments, so skip them. Directory scan runs
+        // off the main actor; parsing builds a @MainActor transcript here.
+        let saveDir = MeetingTranscriptSettings.effectiveSaveDirectory()
+        let files = await Task.detached(operation: { Self.meetingFilesNewestFirst(in: saveDir) }).value
+        for url in files {
+            if let transcript = try? MeetingMarkdownWriter.parse(from: url), !transcript.segments.isEmpty {
+                return .success(.transcription(text: transcript.plainText))
+            }
+        }
+        return .failure(.notFound("No transcription available."))
+    }
+
+    // MARK: Summarize
+
+    private func summarizeMeetingAction(_ ref: MeetingRef?) async -> Result<GhostPepperActionResult, GhostPepperActionError> {
+        let transcript: MeetingTranscript
+        if let ref {
+            switch await resolveMeetingURL(for: ref) {
+            case .success(let url):
+                guard let parsed = try? MeetingMarkdownWriter.parse(from: url) else {
+                    return .failure(.notFound("Could not read the meeting file."))
+                }
+                transcript = parsed
+            case .failure(let error):
+                return .failure(error)
+            }
+        } else {
+            guard let active = activeMeetingSession else {
+                return .failure(.notFound("No active meeting to summarize."))
+            }
+            transcript = active.transcript
+        }
+
+        guard !transcript.segments.isEmpty else {
+            return .failure(.notFound("The meeting has no transcript to summarize."))
+        }
+        // Pre-check readiness: the generator swallows a not-loaded model into a nil
+        // result, so map NOT_READY here before dispatching.
+        guard textCleanupManager.isReady else {
+            return .failure(.notReady("The summary model is not loaded yet."))
+        }
+
+        await generateMeetingSummary(for: transcript)
+        return .success(.ok)
+    }
+
+    // MARK: Open
+
+    /// Not gated by the opt-in: opening only navigates the local UI (no payload is
+    /// returned), and `resolveMeetingURL` confines paths to the archive. `get-status`
+    /// is likewise ungated; its payload still can't reach a web callback (see
+    /// `URLActionHandler.dataCallback`).
+    private func openMeetingAction(_ ref: MeetingRef) async -> Result<GhostPepperActionResult, GhostPepperActionError> {
+        switch await resolveMeetingURL(for: ref) {
+        case .success(let url):
+            openSavedMeeting(at: url)
+            return .success(.ok)
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+
+    // MARK: Resolution
+
+    /// Resolve a `MeetingRef` to a file URL, rejecting path traversal and
+    /// resolving ids via the active session, then the on-disk index.
+    private func resolveMeetingURL(for ref: MeetingRef) async -> Result<URL, GhostPepperActionError> {
+        let saveDir = MeetingTranscriptSettings.effectiveSaveDirectory()
+        switch ref {
+        case .path(let raw):
+            guard raw.hasSuffix(".md") else {
+                return .failure(.badRequest("Meeting path must end in .md"))
+            }
+            let url: URL
+            do {
+                url = try PathSandbox.resolveSafe(raw, root: saveDir)
+            } catch {
+                return .failure(.badRequest("Path is outside the meeting archive."))
+            }
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                return .failure(.notFound("No meeting at \(raw)"))
+            }
+            return .success(url)
+
+        case .id(let raw):
+            guard let uuid = UUID(uuidString: raw) else {
+                return .failure(.badRequest("Invalid meeting id."))
+            }
+            if let active = activeMeetingSession, active.transcript.sessionID == uuid, let url = active.fileURL {
+                return .success(url)
+            }
+            await meetingSessionIndex.ensureBuilt(from: saveDir)
+            if let url = await meetingSessionIndex.resolve(uuid) {
+                return .success(url)
+            }
+            return .failure(.notFound("No meeting with id \(raw)"))
+        }
+    }
+
+    // MARK: Helpers
+
+    private static func generatedMeetingName() -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return "Meeting \u{2014} \(formatter.string(from: Date()))"
+    }
+
+    /// Safe to call off the main actor. Each file is stat'd once (decorate-sort).
+    nonisolated private static func meetingFilesNewestFirst(in baseDirectory: URL) -> [URL] {
+        MeetingHistory.markdownFileURLs(in: baseDirectory)
+            .map { ($0, MeetingHistory.modificationDate(of: $0)) }
+            .sorted { $0.1 > $1.1 }
+            .map(\.0)
+    }
+
+    /// Wait for the active meeting's first autosave (file URL set), or nil on timeout.
+    private func awaitMeetingFileReady(timeout: Duration) async -> MeetingSession? {
+        await Self.poll(timeout: timeout, interval: .milliseconds(100)) {
+            activeMeetingSession?.fileURL != nil ? activeMeetingSession : nil
+        }
+    }
+}

--- a/GhostPepper/Automation/AppState+Automation.swift
+++ b/GhostPepper/Automation/AppState+Automation.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 // MARK: - Shared instance + readiness gate
@@ -48,6 +49,8 @@ extension AppState {
             return stopMeetingAction()
         case .getLastTranscription:
             return await getLastTranscriptionAction()
+        case .copyLastRecording:
+            return copyLastRecordingAction()
         case .getStatus:
             return .success(statusSnapshot())
         case .summarizeMeeting(let ref):
@@ -135,6 +138,28 @@ extension AppState {
             }
         }
         return .failure(.notFound("No transcription available."))
+    }
+
+    /// Put the newest saved dictation's text on the clipboard, app-side. Writing here
+    /// (not in `URLActionHandler`, which stays pure) is what lets a launcher that can
+    /// only open a URL fire-and-forget: one `ghostpepper://copy-last-recording` lands
+    /// the text on the pasteboard with no callback. The text is also returned so a
+    /// caller that does pass `x-success` (or uses the App Intent) still receives it.
+    private func copyLastRecordingAction() -> Result<GhostPepperActionResult, GhostPepperActionError> {
+        guard transcriptionLabEnabled else {
+            return .failure(.notFound("No saved recordings. Turn on the Transcription Lab in Settings to keep them."))
+        }
+
+        // `loadEntries()` returns newest-first; take the newest entry that actually
+        // has transcribed text (an entry can hold audio but no transcription).
+        let entries = (try? loadTranscriptionLabEntries()) ?? []
+        guard let text = entries.lazy.map(\.preferredTranscript).first(where: { !$0.isEmpty }) else {
+            return .failure(.notFound("The last recording has no transcribed text to copy."))
+        }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        return .success(.transcription(text: text))
     }
 
     // MARK: Summarize

--- a/GhostPepper/Automation/GhostPepperAction.swift
+++ b/GhostPepper/Automation/GhostPepperAction.swift
@@ -13,6 +13,9 @@ enum GhostPepperAction: Equatable {
     case startMeeting(name: String?)
     case stopMeeting
     case getLastTranscription
+    /// Copy the newest Transcription Lab recording's text to the clipboard, app-side.
+    /// Distinct from `getLastTranscription`, which reads the meeting archive.
+    case copyLastRecording
     case getStatus
     /// `nil` ref → the active meeting.
     case summarizeMeeting(MeetingRef?)
@@ -25,7 +28,7 @@ enum GhostPepperAction: Equatable {
         switch self {
         case .getStatus, .openMeeting:
             return false
-        case .startMeeting, .stopMeeting, .getLastTranscription, .summarizeMeeting:
+        case .startMeeting, .stopMeeting, .getLastTranscription, .copyLastRecording, .summarizeMeeting:
             return true
         }
     }

--- a/GhostPepper/Automation/GhostPepperAction.swift
+++ b/GhostPepper/Automation/GhostPepperAction.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// The single action vocabulary shared by every automation front-end (menu,
+/// configurable hotkeys, the `ghostpepper://` URL scheme, and App Intents). Front-ends
+/// only *trigger* these; the behaviour lives in `AppState.perform(_:)`.
+///
+/// The surface is deliberately small: once exposed, every action becomes a caller
+/// contract (Hyrum's law). Window navigation and the "+" menu's note / ad-hoc variants
+/// are intentionally not actions — they call `AppState` methods directly.
+enum GhostPepperAction: Equatable {
+    /// Start a meeting transcription. `nil` name → a generated default name
+    /// (the same path the in-app "+" menu uses). Subsumes note / ad-hoc.
+    case startMeeting(name: String?)
+    case stopMeeting
+    case getLastTranscription
+    case getStatus
+    /// `nil` ref → the active meeting.
+    case summarizeMeeting(MeetingRef?)
+    case openMeeting(MeetingRef)
+
+    /// Whether this action needs the "Allow automation" opt-in. The read-only
+    /// `getStatus` and the navigation-only `openMeeting` are always allowed;
+    /// everything that records, returns transcript text, or summarizes is gated.
+    var requiresAutomationConsent: Bool {
+        switch self {
+        case .getStatus, .openMeeting:
+            return false
+        case .startMeeting, .stopMeeting, .getLastTranscription, .summarizeMeeting:
+            return true
+        }
+    }
+}
+
+/// How a saved meeting is referenced. `id` resolves via the session id persisted
+/// in the saved file's YAML frontmatter; `path` is relative to the archive root.
+enum MeetingRef: Equatable {
+    case id(String)
+    case path(String)
+}
+
+/// Per-action result typing: value-returning actions carry typed payloads,
+/// everything else returns generic success.
+enum GhostPepperActionResult: Equatable {
+    case ok
+    case transcription(text: String)
+    /// `id` is the session UUID; `viewURL` reopens the meeting.
+    case meetingStarted(id: String, viewURL: URL)
+    case status(recording: Bool, appStatus: String, meetingID: String?, meetingName: String?)
+
+    var transcriptionText: String? {
+        if case .transcription(let text) = self { return text }
+        return nil
+    }
+
+    var startedMeetingID: String? {
+        if case .meetingStarted(let id, _) = self { return id }
+        return nil
+    }
+
+    var statusAppStatus: String? {
+        if case .status(_, let appStatus, _, _) = self { return appStatus }
+        return nil
+    }
+}
+
+/// One error shape for the whole surface: a stable `code` plus a human-readable
+/// `message`. The URL scheme sends both on `x-error`; App Intents surface the message.
+struct GhostPepperActionError: Error, Equatable {
+    /// Stable machine code. Keep this set small — it is part of the contract.
+    let code: Code
+    /// Human-readable detail. Put the specifics here, not in new codes.
+    let message: String
+
+    enum Code: String {
+        /// Malformed request: unknown action, missing/invalid argument.
+        case badRequest = "BAD_REQUEST"
+        /// Referenced meeting or active session not found.
+        case notFound = "NOT_FOUND"
+        /// A required subsystem (e.g. the summary model) is not loaded yet.
+        case notReady = "NOT_READY"
+        /// Action rejected by current state, e.g. start while already recording.
+        case conflict = "CONFLICT"
+        /// Automation disabled, or consent denied.
+        case forbidden = "FORBIDDEN"
+    }
+
+    static func badRequest(_ message: String) -> GhostPepperActionError { .init(code: .badRequest, message: message) }
+    static func notFound(_ message: String) -> GhostPepperActionError { .init(code: .notFound, message: message) }
+    static func notReady(_ message: String) -> GhostPepperActionError { .init(code: .notReady, message: message) }
+    static func conflict(_ message: String) -> GhostPepperActionError { .init(code: .conflict, message: message) }
+    static func forbidden(_ message: String) -> GhostPepperActionError { .init(code: .forbidden, message: message) }
+}

--- a/GhostPepper/Automation/GhostPepperAppIntents.swift
+++ b/GhostPepper/Automation/GhostPepperAppIntents.swift
@@ -1,0 +1,144 @@
+import AppIntents
+
+/// Shortcuts / Spotlight front-end over the shared action core. Each intent calls
+/// `AppState.perform(_:)` and maps the typed result back. No app logic lives here.
+///
+/// Spotlight phrase surfacing on macOS 14 is weaker than on later releases; verify in
+/// Shortcuts.app.
+
+/// Bridges a `GhostPepperActionError` into a user-facing intent error.
+struct GhostPepperIntentError: Error, CustomLocalizedStringResourceConvertible {
+    let message: String
+    var localizedStringResource: LocalizedStringResource { "\(message)" }
+}
+
+private enum GhostPepperIntentRunner {
+    @MainActor
+    static func run(_ action: GhostPepperAction) async throws -> GhostPepperActionResult {
+        guard let appState = await AppState.ready() else {
+            throw GhostPepperIntentError(message: "Ghost Pepper is still launching. Try again in a moment.")
+        }
+        switch await appState.perform(action) {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw GhostPepperIntentError(message: error.message)
+        }
+    }
+}
+
+struct StartMeetingIntent: AppIntent {
+    static var title: LocalizedStringResource = "Start Meeting"
+    static var description = IntentDescription("Start recording and transcribing a meeting. Prompts for consent unless you have turned that off.")
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Name")
+    var name: String?
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await GhostPepperIntentRunner.run(.startMeeting(name: name))
+        return .result(value: result.startedMeetingID ?? "")
+    }
+}
+
+struct StopMeetingIntent: AppIntent {
+    static var title: LocalizedStringResource = "Stop Meeting"
+    static var description = IntentDescription("Stop the meeting that is currently recording.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        _ = try await GhostPepperIntentRunner.run(.stopMeeting)
+        return .result()
+    }
+}
+
+struct GetLastTranscriptionIntent: AppIntent {
+    static var title: LocalizedStringResource = "Get Last Transcription"
+    static var description = IntentDescription("Return the transcript of the most recent meeting.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await GhostPepperIntentRunner.run(.getLastTranscription)
+        return .result(value: result.transcriptionText ?? "")
+    }
+}
+
+struct GetMeetingStatusIntent: AppIntent {
+    static var title: LocalizedStringResource = "Get Status"
+    static var description = IntentDescription("Return whether Ghost Pepper is recording, and the app's current state.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await GhostPepperIntentRunner.run(.getStatus)
+        return .result(value: result.statusAppStatus ?? "")
+    }
+}
+
+struct SummarizeMeetingIntent: AppIntent {
+    static var title: LocalizedStringResource = "Summarize Meeting"
+    static var description = IntentDescription("Summarize a meeting. Leave the id empty to summarize the active meeting.")
+    // Summary generation runs a local-LLM pass; foreground the app so a
+    // background-launched intent isn't killed mid-run.
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Meeting ID")
+    var meetingID: String?
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let ref = meetingID.flatMap { $0.isEmpty ? nil : MeetingRef.id($0) }
+        _ = try await GhostPepperIntentRunner.run(.summarizeMeeting(ref))
+        return .result()
+    }
+}
+
+struct OpenMeetingIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Meeting"
+    static var description = IntentDescription("Open a saved meeting by its id.")
+    static var openAppWhenRun = true
+
+    @Parameter(title: "Meeting ID")
+    var meetingID: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        _ = try await GhostPepperIntentRunner.run(.openMeeting(.id(meetingID)))
+        return .result()
+    }
+}
+
+struct GhostPepperShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: StartMeetingIntent(),
+            phrases: ["Start a \(.applicationName) meeting"],
+            shortTitle: "Start Meeting",
+            systemImageName: "record.circle"
+        )
+        AppShortcut(
+            intent: StopMeetingIntent(),
+            phrases: ["Stop the \(.applicationName) meeting"],
+            shortTitle: "Stop Meeting",
+            systemImageName: "stop.circle"
+        )
+        AppShortcut(
+            intent: GetLastTranscriptionIntent(),
+            phrases: ["Get the last \(.applicationName) transcription"],
+            shortTitle: "Last Transcription",
+            systemImageName: "text.quote"
+        )
+        AppShortcut(
+            intent: GetMeetingStatusIntent(),
+            phrases: ["Get \(.applicationName) status"],
+            shortTitle: "Status",
+            systemImageName: "info.circle"
+        )
+        AppShortcut(
+            intent: SummarizeMeetingIntent(),
+            phrases: ["Summarize the \(.applicationName) meeting"],
+            shortTitle: "Summarize Meeting",
+            systemImageName: "doc.text"
+        )
+    }
+}

--- a/GhostPepper/Automation/GhostPepperAppIntents.swift
+++ b/GhostPepper/Automation/GhostPepperAppIntents.swift
@@ -64,6 +64,17 @@ struct GetLastTranscriptionIntent: AppIntent {
     }
 }
 
+struct CopyLastRecordingIntent: AppIntent {
+    static var title: LocalizedStringResource = "Copy Last Recording"
+    static var description = IntentDescription("Copy the transcript of your most recent recording to the clipboard, and return it.")
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await GhostPepperIntentRunner.run(.copyLastRecording)
+        return .result(value: result.transcriptionText ?? "")
+    }
+}
+
 struct GetMeetingStatusIntent: AppIntent {
     static var title: LocalizedStringResource = "Get Status"
     static var description = IntentDescription("Return whether Ghost Pepper is recording, and the app's current state.")
@@ -127,6 +138,12 @@ struct GhostPepperShortcuts: AppShortcutsProvider {
             phrases: ["Get the last \(.applicationName) transcription"],
             shortTitle: "Last Transcription",
             systemImageName: "text.quote"
+        )
+        AppShortcut(
+            intent: CopyLastRecordingIntent(),
+            phrases: ["Copy the last \(.applicationName) recording"],
+            shortTitle: "Copy Last Recording",
+            systemImageName: "doc.on.clipboard"
         )
         AppShortcut(
             intent: GetMeetingStatusIntent(),

--- a/GhostPepper/Automation/URLActionHandler.swift
+++ b/GhostPepper/Automation/URLActionHandler.swift
@@ -110,53 +110,141 @@ enum URLActionHandler {
 
     /// Map an action result to the callback URL to open, or nil for a no-op.
     ///
-    /// On success: `.ok` opens `x-success` with no params; value-bearing results
-    /// append their fields to `x-success` — but only if `x-success` is a non-web
-    /// scheme (never hand transcript text or other payloads to `http`/`https`).
-    /// A value action with no `x-success` is a no-op over URL.
-    /// On failure: append `errorCode` + `errorMessage` to `x-error`.
+    /// On success: `.ok` opens `x-success` with no params; value-bearing results append
+    /// their fields to `x-success` — but only if `x-success` is a non-web scheme (never
+    /// hand transcript text or other payloads to `http`/`https`). Two optional params
+    /// shape the payload: `retParam` renames a single-value payload's key (and names the
+    /// envelope under `retFormat=json`), and `retFormat=json` packs the whole payload into
+    /// one JSON object. A value action with no `x-success` is a no-op over URL.
+    /// On failure — including a callback-shaping `BAD_REQUEST` — append `errorCode` +
+    /// `errorMessage` to `x-error`.
     static func callbackURL(
         for request: Request,
         result: Result<GhostPepperActionResult, GhostPepperActionError>
     ) -> URL? {
         switch result {
         case .success(let payload):
-            return successCallback(for: request, payload: payload)
+            switch successCallback(for: request, payload: payload) {
+            case .success(let url): return url
+            case .failure(let error): return errorCallback(for: request, error: error)
+            }
         case .failure(let error):
-            guard let xError = request.xError else { return nil }
-            return appending(
-                to: xError,
-                items: [("errorCode", error.code.rawValue), ("errorMessage", error.message)]
-            )
+            return errorCallback(for: request, error: error)
         }
     }
 
-    private static func successCallback(for request: Request, payload: GhostPepperActionResult) -> URL? {
+    private static func errorCallback(for request: Request, error: GhostPepperActionError) -> URL? {
+        guard let xError = request.xError else { return nil }
+        return appending(
+            to: xError,
+            items: [("errorCode", error.code.rawValue), ("errorMessage", error.message)]
+        )
+    }
+
+    /// Shape a successful payload into the callback URL to open. `.success(url)` is that
+    /// URL (nil = no-op); `.failure` is a shaping error the caller routes to `x-error`.
+    private static func successCallback(
+        for request: Request,
+        payload: GhostPepperActionResult
+    ) -> Result<URL?, GhostPepperActionError> {
+        let fields = payloadFields(for: payload)
+
+        // No payload (.ok): open x-success as-is — nothing to leak, so even web schemes are fine.
+        guard !fields.isEmpty else { return .success(request.xSuccess) }
+
+        let retParam = nonEmpty(request.parameters["retParam"])
+        let retFormat = nonEmpty(request.parameters["retFormat"])
+
+        // Validate the shaping combo before the delivery guards, so a malformed request
+        // reaches x-error even when x-success is absent or a (dropped) web scheme.
+        let useJSON: Bool
+        if let retFormat {
+            guard retFormat.lowercased() == "json" else {
+                return .failure(.badRequest("Unsupported retFormat \u{201C}\(retFormat)\u{201D}; only json is supported."))
+            }
+            useJSON = true
+        } else {
+            useJSON = false
+            // retParam alone renames the key of a single-value payload; a multi-value
+            // payload needs retFormat=json so no field is silently dropped.
+            if retParam != nil, fields.count > 1 {
+                return .failure(.badRequest("retParam needs retFormat=json for the multi-value \(request.action) response."))
+            }
+        }
+
+        // Value-bearing: no x-success is a no-op, and a web x-success is dropped so
+        // payloads never reach http/https.
+        guard let xSuccess = request.xSuccess else { return .success(nil) }
+        guard !isWebScheme(xSuccess) else { return .success(nil) }
+
+        if useJSON {
+            guard let json = jsonPayload(from: fields) else {
+                return .failure(.badRequest("Could not encode the \(request.action) response as JSON."))
+            }
+            return .success(appending(to: xSuccess, items: [(retParam ?? "payload", json)]))
+        }
+
+        if let retParam {
+            // fields.count == 1 here (validated above), so retParam names its lone value.
+            let (_, value) = fields[0]
+            return .success(appending(to: xSuccess, items: [(retParam, value.queryValue)]))
+        }
+
+        return .success(appending(to: xSuccess, items: fields.map { name, value in (name, value.queryValue) }))
+    }
+
+    /// The success payload as ordered `(name, value)` fields; empty for `.ok`.
+    private static func payloadFields(for payload: GhostPepperActionResult) -> [(String, PayloadValue)] {
         switch payload {
         case .ok:
-            // No payload, so opening any x-success leaks nothing.
-            return request.xSuccess
+            return []
         case .transcription(let text):
-            return dataCallback(for: request, items: [("text", text)])
+            return [("text", .string(text))]
         case .meetingStarted(let id, let viewURL):
-            return dataCallback(for: request, items: [("meetingID", id), ("viewURL", viewURL.absoluteString)])
+            return [("meetingID", .string(id)), ("viewURL", .string(viewURL.absoluteString))]
         case .status(let recording, let appStatus, let meetingID, let meetingName):
-            var items: [(String, String)] = [
-                ("recording", recording ? "true" : "false"),
-                ("appStatus", appStatus),
+            var fields: [(String, PayloadValue)] = [
+                ("recording", .bool(recording)),
+                ("appStatus", .string(appStatus)),
             ]
-            if let meetingID { items.append(("meetingID", meetingID)) }
-            if let meetingName { items.append(("meetingName", meetingName)) }
-            return dataCallback(for: request, items: items)
+            if let meetingID { fields.append(("meetingID", .string(meetingID))) }
+            if let meetingName { fields.append(("meetingName", .string(meetingName))) }
+            return fields
         }
     }
 
-    /// Value-bearing callback: drop `http`/`https` `x-success` so payloads
-    /// never reach the web; no `x-success` is a no-op.
-    private static func dataCallback(for request: Request, items: [(String, String)]) -> URL? {
-        guard let xSuccess = request.xSuccess else { return nil }
-        if isWebScheme(xSuccess) { return nil }
-        return appending(to: xSuccess, items: items)
+    /// A payload field value. Query callbacks stringify it; `retFormat=json` keeps its JSON
+    /// type — notably `recording` as a boolean, not the string "true".
+    private enum PayloadValue {
+        case string(String)
+        case bool(Bool)
+
+        var queryValue: String {
+            switch self {
+            case .string(let value): return value
+            case .bool(let value): return value ? "true" : "false"
+            }
+        }
+    }
+
+    /// Encode payload fields as one JSON object string, with sorted keys for a stable result.
+    private static func jsonPayload(from fields: [(String, PayloadValue)]) -> String? {
+        var object: [String: Any] = [:]
+        for (name, value) in fields {
+            switch value {
+            case .string(let string): object[name] = string
+            case .bool(let bool): object[name] = bool
+            }
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
     }
 
     private static func isWebScheme(_ url: URL) -> Bool {
@@ -180,13 +268,14 @@ enum URLActionHandler {
     }
 
     /// Append percent-encoded items to a callback URL, preserving its existing query
-    /// items and fragment. Every appended value — including nested `ghostpepper://`
-    /// URLs — is fully percent-encoded.
+    /// items and fragment. Both name and value — including a caller-supplied `retParam`
+    /// and nested `ghostpepper://` URLs — are fully percent-encoded. Names must be encoded
+    /// too: the `percentEncodedQueryItems` setter traps on a raw reserved character.
     private static func appending(to base: URL, items: [(String, String)]) -> URL? {
         guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return nil }
         var encoded = components.percentEncodedQueryItems ?? []
         for (name, value) in items {
-            encoded.append(URLQueryItem(name: name, value: percentEncode(value)))
+            encoded.append(URLQueryItem(name: percentEncode(name), value: percentEncode(value)))
         }
         components.percentEncodedQueryItems = encoded
         return components.url

--- a/GhostPepper/Automation/URLActionHandler.swift
+++ b/GhostPepper/Automation/URLActionHandler.swift
@@ -1,0 +1,206 @@
+import Foundation
+
+/// Pure translation between `ghostpepper://` URLs and the action core.
+///
+/// It parses an inbound URL into a `Request`, maps that to a `GhostPepperAction`,
+/// and maps an action `Result` back onto an x-callback-url callback URL. It performs
+/// no I/O and never opens anything — `AppDelegate` does the actual `NSWorkspace.open`,
+/// which keeps this fully unit-testable without mocking AppKit.
+///
+/// Conventions follow the x-callback-url spec: host `x-callback-url`, action in the
+/// path, reserved `x-source` / `x-success` / `x-error` / `x-cancel`, results appended
+/// as query items to `x-success`, errors sent to `x-error` with `errorCode` +
+/// `errorMessage`.
+enum URLActionHandler {
+    static let scheme = "ghostpepper"
+
+    struct Request: Equatable {
+        /// The action token (e.g. `start-meeting`).
+        let action: String
+        /// Non-reserved query items, decoded (last value wins on duplicates).
+        let parameters: [String: String]
+        let xSuccess: URL?
+        let xError: URL?
+        let xSource: String?
+        let xCancel: URL?
+    }
+
+    // MARK: - Parsing
+
+    /// Parse an inbound URL. Returns nil for a non-`ghostpepper` scheme or a URL with
+    /// no resolvable action token.
+    ///
+    /// Action-token rule: if `host == "x-callback-url"`, the action is the first path
+    /// segment; otherwise the action is the host. So
+    /// `ghostpepper://x-callback-url/start-meeting` and `ghostpepper://stop-meeting`
+    /// both resolve.
+    static func parse(_ url: URL) -> Request? {
+        guard url.scheme?.lowercased() == scheme else { return nil }
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+
+        let host = components.host ?? ""
+        let action: String
+        if host == "x-callback-url" {
+            guard let first = components.path.split(separator: "/").first else { return nil }
+            action = String(first)
+        } else if !host.isEmpty {
+            action = host
+        } else {
+            return nil
+        }
+
+        var parameters: [String: String] = [:]
+        var xSuccess: URL?
+        var xError: URL?
+        var xCancel: URL?
+        var xSource: String?
+        for item in components.queryItems ?? [] {
+            let value = item.value ?? ""
+            switch item.name {
+            case "x-success": xSuccess = URL(string: value)
+            case "x-error": xError = URL(string: value)
+            case "x-cancel": xCancel = URL(string: value)
+            case "x-source": xSource = value
+            default: parameters[item.name] = value
+            }
+        }
+
+        return Request(
+            action: action,
+            parameters: parameters,
+            xSuccess: xSuccess,
+            xError: xError,
+            xSource: xSource,
+            xCancel: xCancel
+        )
+    }
+
+    /// Map a parsed request to an action, or a `BAD_REQUEST` for an unknown action or
+    /// a missing required reference.
+    static func action(for request: Request) -> Result<GhostPepperAction, GhostPepperActionError> {
+        switch request.action {
+        case "start-meeting":
+            return .success(.startMeeting(name: request.parameters["name"]))
+        case "stop-meeting":
+            return .success(.stopMeeting)
+        case "get-last-transcription":
+            return .success(.getLastTranscription)
+        case "get-status":
+            return .success(.getStatus)
+        case "summarize-meeting":
+            return .success(.summarizeMeeting(meetingRef(from: request)))
+        case "open-meeting":
+            guard let ref = meetingRef(from: request) else {
+                return .failure(.badRequest("open-meeting requires an id or path."))
+            }
+            return .success(.openMeeting(ref))
+        default:
+            return .failure(.badRequest("Unknown action \u{201C}\(request.action)\u{201D}."))
+        }
+    }
+
+    /// `id` wins over `path` when both are present.
+    private static func meetingRef(from request: Request) -> MeetingRef? {
+        if let id = request.parameters["id"], !id.isEmpty { return .id(id) }
+        if let path = request.parameters["path"], !path.isEmpty { return .path(path) }
+        return nil
+    }
+
+    // MARK: - Callback mapping
+
+    /// Map an action result to the callback URL to open, or nil for a no-op.
+    ///
+    /// On success: `.ok` opens `x-success` with no params; value-bearing results
+    /// append their fields to `x-success` — but only if `x-success` is a non-web
+    /// scheme (never hand transcript text or other payloads to `http`/`https`).
+    /// A value action with no `x-success` is a no-op over URL.
+    /// On failure: append `errorCode` + `errorMessage` to `x-error`.
+    static func callbackURL(
+        for request: Request,
+        result: Result<GhostPepperActionResult, GhostPepperActionError>
+    ) -> URL? {
+        switch result {
+        case .success(let payload):
+            return successCallback(for: request, payload: payload)
+        case .failure(let error):
+            guard let xError = request.xError else { return nil }
+            return appending(
+                to: xError,
+                items: [("errorCode", error.code.rawValue), ("errorMessage", error.message)]
+            )
+        }
+    }
+
+    private static func successCallback(for request: Request, payload: GhostPepperActionResult) -> URL? {
+        switch payload {
+        case .ok:
+            // No payload, so opening any x-success leaks nothing.
+            return request.xSuccess
+        case .transcription(let text):
+            return dataCallback(for: request, items: [("text", text)])
+        case .meetingStarted(let id, let viewURL):
+            return dataCallback(for: request, items: [("meetingID", id), ("viewURL", viewURL.absoluteString)])
+        case .status(let recording, let appStatus, let meetingID, let meetingName):
+            var items: [(String, String)] = [
+                ("recording", recording ? "true" : "false"),
+                ("appStatus", appStatus),
+            ]
+            if let meetingID { items.append(("meetingID", meetingID)) }
+            if let meetingName { items.append(("meetingName", meetingName)) }
+            return dataCallback(for: request, items: items)
+        }
+    }
+
+    /// Value-bearing callback: drop `http`/`https` `x-success` so payloads
+    /// never reach the web; no `x-success` is a no-op.
+    private static func dataCallback(for request: Request, items: [(String, String)]) -> URL? {
+        guard let xSuccess = request.xSuccess else { return nil }
+        if isWebScheme(xSuccess) { return nil }
+        return appending(to: xSuccess, items: items)
+    }
+
+    private static func isWebScheme(_ url: URL) -> Bool {
+        let scheme = url.scheme?.lowercased()
+        return scheme == "http" || scheme == "https"
+    }
+
+    // MARK: - URL building
+
+    /// The stable view URL returned by `start-meeting`:
+    /// `ghostpepper://x-callback-url/open-meeting?id=<uuid>`.
+    static func viewURL(forMeetingID id: String) -> URL {
+        var components = URLComponents()
+        components.scheme = scheme
+        components.host = "x-callback-url"
+        components.path = "/open-meeting"
+        components.queryItems = [URLQueryItem(name: "id", value: id)]
+        // Safe to force-unwrap: scheme/host/path are valid and `id` is appended via
+        // queryItems, which URLComponents percent-encodes.
+        return components.url!
+    }
+
+    /// Append percent-encoded items to a callback URL, preserving its existing query
+    /// items and fragment. Every appended value — including nested `ghostpepper://`
+    /// URLs — is fully percent-encoded.
+    private static func appending(to base: URL, items: [(String, String)]) -> URL? {
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else { return nil }
+        var encoded = components.percentEncodedQueryItems ?? []
+        for (name, value) in items {
+            encoded.append(URLQueryItem(name: name, value: percentEncode(value)))
+        }
+        components.percentEncodedQueryItems = encoded
+        return components.url
+    }
+
+    /// RFC 3986 unreserved set only, so reserved characters (`:` `/` `?` `&` `=` `#` …)
+    /// in appended values are always escaped.
+    private static let unreserved: CharacterSet = {
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "-._~")
+        return set
+    }()
+
+    private static func percentEncode(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: unreserved) ?? ""
+    }
+}

--- a/GhostPepper/Automation/URLActionHandler.swift
+++ b/GhostPepper/Automation/URLActionHandler.swift
@@ -85,6 +85,8 @@ enum URLActionHandler {
             return .success(.stopMeeting)
         case "get-last-transcription":
             return .success(.getLastTranscription)
+        case "copy-last-recording":
+            return .success(.copyLastRecording)
         case "get-status":
             return .success(.getStatus)
         case "summarize-meeting":

--- a/GhostPepper/GhostPepperApp.swift
+++ b/GhostPepper/GhostPepperApp.swift
@@ -8,6 +8,7 @@ class LazyUpdaterController {
 @main
 struct GhostPepperApp: App {
     private static let automaticTerminationReason = "Ghost Pepper keeps a persistent menu bar presence."
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var appState = AppState()
     @AppStorage("onboardingCompleted") private var onboardingCompleted = false
     @State private var hasInitialized = false

--- a/GhostPepper/Info.plist
+++ b/GhostPepper/Info.plist
@@ -20,6 +20,14 @@
 				<string>com.github.matthartman.ghostpepper</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>Ghost Pepper Automation</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ghostpepper</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>18</string>

--- a/GhostPepper/Lab/TranscriptionLabEntry.swift
+++ b/GhostPepper/Lab/TranscriptionLabEntry.swift
@@ -105,3 +105,15 @@ struct TranscriptionLabEntry: Identifiable, Equatable, Codable {
         try container.encodeIfPresent(diarizationSummary, forKey: .diarizationSummary)
     }
 }
+
+extension TranscriptionLabEntry {
+    /// The transcript text to surface when copying this recording: the corrected
+    /// transcription when it holds text, else the raw transcription. Empty when the
+    /// entry has no usable text (e.g. audio archived but transcription failed).
+    var preferredTranscript: String {
+        if let corrected = correctedTranscription, !corrected.isEmpty {
+            return corrected
+        }
+        return rawTranscription ?? ""
+    }
+}

--- a/GhostPepper/Meeting/MeetingHistory.swift
+++ b/GhostPepper/Meeting/MeetingHistory.swift
@@ -86,4 +86,104 @@ enum MeetingHistory {
         }
         return (title, isGranola)
     }
+
+    /// Read the persisted session id from a saved meeting's YAML frontmatter
+    /// (`id: <uuid>`), without parsing the whole file. Returns nil for files that
+    /// predate id persistence or whose id is missing/invalid.
+    static func readSessionID(from fileURL: URL) -> UUID? {
+        guard let content = try? String(contentsOf: fileURL, encoding: .utf8) else { return nil }
+        var seenFence = false
+        var result: UUID?
+        content.enumerateLines { line, stop in
+            if line == "---" {
+                if seenFence { stop = true } else { seenFence = true }
+                return
+            }
+            guard seenFence else {
+                // No frontmatter fence before real content → no id.
+                if !line.isEmpty { stop = true }
+                return
+            }
+            if let id = sessionID(fromFrontmatterLine: line) {
+                result = id
+                stop = true
+            }
+        }
+        return result
+    }
+
+    static func sessionID(fromFrontmatterLine line: String) -> UUID? {
+        guard line.hasPrefix("id:") else { return nil }
+        let raw = line.dropFirst("id:".count).trimmingCharacters(in: .whitespaces)
+        return UUID(uuidString: raw)
+    }
+
+    /// All `.md` files under the date-foldered archive, without reading their contents.
+    static func markdownFileURLs(in baseDirectory: URL) -> [URL] {
+        let fm = FileManager.default
+        guard let dateFolders = try? fm.contentsOfDirectory(
+            at: baseDirectory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        return dateFolders
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+            .flatMap { folder -> [URL] in
+                let files = (try? fm.contentsOfDirectory(at: folder, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) ?? []
+                return files.filter { $0.pathExtension == "md" }
+            }
+    }
+
+    /// Stat'd once per URL (decorate-max), not per comparison.
+    static func newestByModificationDate(_ urls: [URL]) -> URL? {
+        urls.map { ($0, modificationDate(of: $0)) }.max { $0.1 < $1.1 }?.0
+    }
+
+    static func modificationDate(of url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
+    }
+}
+
+/// In-memory `sessionID → fileURL` index for resolving `open-meeting?id=…`.
+///
+/// Built once at launch by scanning the archive's frontmatter (off the main actor),
+/// and a recorded meeting is also registered in-process when it finishes. Avoids an
+/// O(n) disk scan on `@MainActor` per call. Files written by other paths (reader
+/// captures) or by another process are picked up at the next launch; an unresolved
+/// id falls back to `path`, and an active meeting resolves directly from its known
+/// file URL. A copied meeting file can yield duplicate ids; those resolve
+/// deterministically to the newest by modification time.
+actor MeetingSessionIndex {
+    private var map: [UUID: [URL]] = [:]
+    private var built = false
+
+    /// Build the index once; subsequent calls are no-ops. Use `build(from:)` to rebuild.
+    func ensureBuilt(from baseDirectory: URL) {
+        guard !built else { return }
+        build(from: baseDirectory)
+    }
+
+    func build(from baseDirectory: URL) {
+        var fresh: [UUID: [URL]] = [:]
+        for url in MeetingHistory.markdownFileURLs(in: baseDirectory) {
+            guard let id = MeetingHistory.readSessionID(from: url) else { continue }
+            fresh[id, default: []].append(url)
+        }
+        map = fresh
+        built = true
+    }
+
+    /// Called when a meeting is saved.
+    func register(sessionID: UUID, url: URL) {
+        var urls = map[sessionID] ?? []
+        if !urls.contains(url) { urls.append(url) }
+        map[sessionID] = urls
+    }
+
+    /// Resolve a session id to a file, preferring the newest existing file by mtime.
+    func resolve(_ id: UUID) -> URL? {
+        let candidates = (map[id] ?? []).filter { FileManager.default.fileExists(atPath: $0.path) }
+        return MeetingHistory.newestByModificationDate(candidates)
+    }
 }

--- a/GhostPepper/Meeting/MeetingMarkdownWriter.swift
+++ b/GhostPepper/Meeting/MeetingMarkdownWriter.swift
@@ -40,6 +40,14 @@ struct MeetingMarkdownWriter {
     private static func renderMeetingMarkdown(transcript: MeetingTranscript) -> String {
         var lines: [String] = []
 
+        // Machine-managed YAML frontmatter. The session id lets automation
+        // (URL scheme / App Intents) reopen a saved meeting by id. It is a stable,
+        // user-visible contract — do not edit it by hand.
+        lines.append("---")
+        lines.append("id: \(transcript.sessionID.uuidString)")
+        lines.append("---")
+        lines.append("")
+
         // Title
         lines.append("# \(transcript.meetingName)")
         lines.append("")
@@ -105,6 +113,7 @@ struct MeetingMarkdownWriter {
         var lines: [String] = []
 
         lines.append("---")
+        lines.append("id: \(transcript.sessionID.uuidString)")
         lines.append("type: reader")
         if let source = transcript.sourceURL, !source.isEmpty {
             lines.append("source: \(source)")
@@ -157,6 +166,7 @@ struct MeetingMarkdownWriter {
         var article = ""
         var importedFrom: String?
         var sourceURL: String?
+        var sessionID: UUID?
         var inFrontmatter = false
         var frontmatterSeen = false
         var inNotes = false
@@ -184,6 +194,9 @@ struct MeetingMarkdownWriter {
                 }
                 if line.hasPrefix("source:") {
                     sourceURL = line.replacingOccurrences(of: "source:", with: "").trimmingCharacters(in: .whitespaces)
+                }
+                if let id = MeetingHistory.sessionID(fromFrontmatterLine: line) {
+                    sessionID = id
                 }
                 continue
             }
@@ -237,7 +250,7 @@ struct MeetingMarkdownWriter {
             }
         }
 
-        let transcript = MeetingTranscript(meetingName: title)
+        let transcript = MeetingTranscript(meetingName: title, sessionID: sessionID ?? UUID())
         transcript.notes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedSummary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
         transcript.summary = trimmedSummary.isEmpty ? nil : trimmedSummary

--- a/GhostPepper/Meeting/MeetingSummaryGenerator.swift
+++ b/GhostPepper/Meeting/MeetingSummaryGenerator.swift
@@ -45,15 +45,9 @@ final class MeetingSummaryGenerator {
         chunkPrompt: String = MeetingSummaryGenerator.defaultPrompt,
         finalPrompt: String = MeetingSummaryGenerator.finalSummaryPrompt
     ) async -> String? {
-        let segments = transcript.segments
-        guard !segments.isEmpty else { return nil }
+        guard !transcript.segments.isEmpty else { return nil }
 
-        // Build the full transcript text
-        let fullText = segments.map { segment in
-            "[\(segment.formattedTimestamp)] \(segment.speaker.displayName): \(segment.text)"
-        }.joined(separator: "\n")
-
-        // Split into chunks
+        let fullText = transcript.plainText
         let chunks = splitIntoChunks(fullText)
 
         // Include user notes if available

--- a/GhostPepper/Meeting/MeetingTranscript.swift
+++ b/GhostPepper/Meeting/MeetingTranscript.swift
@@ -84,6 +84,13 @@ final class MeetingTranscript: ObservableObject {
         segments.append(segment)
     }
 
+    /// The transcript as flat, timestamped text: `[MM:SS] Speaker: text`, one line per segment.
+    var plainText: String {
+        segments
+            .map { "[\($0.formattedTimestamp)] \($0.speaker.displayName): \($0.text)" }
+            .joined(separator: "\n")
+    }
+
     /// Duration of the meeting so far, in seconds.
     var duration: TimeInterval {
         let end = endDate ?? Date()

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -1918,6 +1918,19 @@ struct SettingsView: View {
                 }
             }
 
+            SettingsCard("Automation") {
+                VStack(alignment: .leading, spacing: 18) {
+                    Toggle(
+                        "Allow automation",
+                        isOn: $appState.allowAutomation
+                    )
+
+                    Text("Lets the ghostpepper:// URL scheme and Shortcuts start or stop meetings, summarize, and read the last transcription. Off by default because a URL scheme is unauthenticated. Starting a meeting still asks for consent.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             if appState.meetingTranscriptEnabled {
                 SettingsCard("Google Calendar") {
                     VStack(alignment: .leading, spacing: 12) {

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -482,7 +482,7 @@ struct SettingsView: View {
     }
 
     private func copyTranscriptionLabTranscript(for entry: TranscriptionLabEntry) {
-        let transcript = preferredTranscriptToCopy(for: entry)
+        let transcript = entry.preferredTranscript
         guard !transcript.isEmpty else {
             return
         }
@@ -490,15 +490,6 @@ struct SettingsView: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(transcript, forType: .string)
     }
-
-    private func preferredTranscriptToCopy(for entry: TranscriptionLabEntry) -> String {
-        if let corrected = entry.correctedTranscription, !corrected.isEmpty {
-            return corrected
-        }
-
-        return entry.rawTranscription ?? ""
-    }
-
 
     private func formattedStageDuration(_ duration: TimeInterval) -> String {
         if duration < 1 {
@@ -1065,7 +1056,7 @@ struct SettingsView: View {
                             }
                             .buttonStyle(.borderless)
                             .help("Copy this transcript")
-                            .disabled(preferredTranscriptToCopy(for: entry).isEmpty)
+                            .disabled(entry.preferredTranscript.isEmpty)
                             .padding(.top, 12)
 
                             Button {

--- a/GhostPepperTests/MeetingSessionIndexTests.swift
+++ b/GhostPepperTests/MeetingSessionIndexTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import GhostPepper
+
+final class MeetingSessionIndexTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent("MeetingIndexTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    @discardableResult
+    private func writeMeeting(id: UUID, dateFolder: String, name: String, modified: Date? = nil) throws -> URL {
+        let folder = root.appendingPathComponent(dateFolder)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let url = folder.appendingPathComponent("\(name).md")
+        try "---\nid: \(id.uuidString)\n---\n\n# \(name)\n".write(to: url, atomically: true, encoding: .utf8)
+        if let modified {
+            try FileManager.default.setAttributes([.modificationDate: modified], ofItemAtPath: url.path)
+        }
+        return url
+    }
+
+    // MARK: - Frontmatter persistence
+
+    @MainActor
+    func testWriteThenParsePreservesSessionID() throws {
+        let id = UUID()
+        let transcript = MeetingTranscript(meetingName: "Standup", sessionID: id)
+        let url = try MeetingMarkdownWriter.write(transcript: transcript, to: root)
+
+        XCTAssertEqual(MeetingHistory.readSessionID(from: url), id)
+        XCTAssertEqual(try MeetingMarkdownWriter.parse(from: url).sessionID, id)
+    }
+
+    func testReadSessionIDReturnsNilForLegacyFile() throws {
+        let folder = root.appendingPathComponent("2026-06-30")
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let url = folder.appendingPathComponent("legacy.md")
+        try "# Legacy meeting\n\nNo frontmatter here.".write(to: url, atomically: true, encoding: .utf8)
+
+        XCTAssertNil(MeetingHistory.readSessionID(from: url))
+    }
+
+    // MARK: - Index resolution
+
+    func testResolvesRegisteredSession() async throws {
+        let id = UUID()
+        let url = try writeMeeting(id: id, dateFolder: "2026-06-30", name: "sync")
+        let index = MeetingSessionIndex()
+        await index.register(sessionID: id, url: url)
+        let resolved = await index.resolve(id)
+        XCTAssertEqual(resolved, url)
+    }
+
+    func testBuildScansFrontmatter() async throws {
+        let id = UUID()
+        let url = try writeMeeting(id: id, dateFolder: "2026-06-30", name: "scanned")
+        let index = MeetingSessionIndex()
+        await index.build(from: root)
+        let resolved = await index.resolve(id)
+        XCTAssertEqual(resolved?.resolvingSymlinksInPath(), url.resolvingSymlinksInPath())
+    }
+
+    func testDuplicateIDResolvesToNewestByModificationTime() async throws {
+        let id = UUID()
+        let older = try writeMeeting(id: id, dateFolder: "2026-06-01", name: "old", modified: Date(timeIntervalSince1970: 1_000_000))
+        let newer = try writeMeeting(id: id, dateFolder: "2026-06-02", name: "new", modified: Date(timeIntervalSince1970: 2_000_000))
+
+        let index = MeetingSessionIndex()
+        await index.build(from: root)
+        let resolved = await index.resolve(id)?.resolvingSymlinksInPath()
+        XCTAssertEqual(resolved, newer.resolvingSymlinksInPath())
+        XCTAssertNotEqual(resolved, older.resolvingSymlinksInPath())
+    }
+
+    func testResolveSkipsDeletedFile() async throws {
+        let id = UUID()
+        let url = try writeMeeting(id: id, dateFolder: "2026-06-30", name: "gone")
+        let index = MeetingSessionIndex()
+        await index.register(sessionID: id, url: url)
+        try FileManager.default.removeItem(at: url)
+        let resolved = await index.resolve(id)
+        XCTAssertNil(resolved)
+    }
+}

--- a/GhostPepperTests/URLActionHandlerTests.swift
+++ b/GhostPepperTests/URLActionHandlerTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import GhostPepper
+
+final class URLActionHandlerTests: XCTestCase {
+
+    private func parse(_ string: String) -> URLActionHandler.Request? {
+        guard let url = URL(string: string) else { return nil }
+        return URLActionHandler.parse(url)
+    }
+
+    private func queryDict(_ url: URL) -> [String: String] {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        return Dictionary(items.map { ($0.name, $0.value ?? "") }, uniquingKeysWith: { _, last in last })
+    }
+
+    // MARK: - Action-token parsing
+
+    func testParsesActionFromCallbackPath() {
+        let request = parse("ghostpepper://x-callback-url/start-meeting?name=Standup")
+        XCTAssertEqual(request?.action, "start-meeting")
+        XCTAssertEqual(request?.parameters["name"], "Standup")
+    }
+
+    func testParsesActionFromHostShorthand() {
+        XCTAssertEqual(parse("ghostpepper://stop-meeting")?.action, "stop-meeting")
+        XCTAssertEqual(parse("ghostpepper://x-callback-url/open-meeting?id=abc")?.action, "open-meeting")
+    }
+
+    func testRejectsNonGhostPepperScheme() {
+        XCTAssertNil(parse("https://example.com/start-meeting"))
+    }
+
+    func testRejectsMissingActionToken() {
+        XCTAssertNil(parse("ghostpepper://"))
+        XCTAssertNil(parse("ghostpepper://x-callback-url"))
+    }
+
+    func testExtractsReservedParameters() {
+        let request = parse("ghostpepper://x-callback-url/get-status?x-success=raycast://ok&x-error=raycast://err&x-source=Raycast&x-cancel=raycast://cancel")
+        XCTAssertEqual(request?.xSuccess, URL(string: "raycast://ok"))
+        XCTAssertEqual(request?.xError, URL(string: "raycast://err"))
+        XCTAssertEqual(request?.xSource, "Raycast")
+        XCTAssertEqual(request?.xCancel, URL(string: "raycast://cancel"))
+        XCTAssertTrue(request?.parameters.isEmpty == true)
+    }
+
+    // MARK: - Action mapping
+
+    func testMapsKnownActions() {
+        XCTAssertEqual(map("ghostpepper://x-callback-url/start-meeting?name=Sync"), .startMeeting(name: "Sync"))
+        XCTAssertEqual(map("ghostpepper://stop-meeting"), .stopMeeting)
+        XCTAssertEqual(map("ghostpepper://get-last-transcription"), .getLastTranscription)
+        XCTAssertEqual(map("ghostpepper://get-status"), .getStatus)
+        XCTAssertEqual(map("ghostpepper://summarize-meeting"), .summarizeMeeting(nil))
+        XCTAssertEqual(map("ghostpepper://x-callback-url/summarize-meeting?id=xyz"), .summarizeMeeting(.id("xyz")))
+        XCTAssertEqual(map("ghostpepper://x-callback-url/open-meeting?path=2026-06-30/x.md"), .openMeeting(.path("2026-06-30/x.md")))
+    }
+
+    func testIdWinsOverPath() {
+        XCTAssertEqual(map("ghostpepper://x-callback-url/open-meeting?id=abc&path=x.md"), .openMeeting(.id("abc")))
+    }
+
+    func testUnknownActionIsBadRequest() {
+        XCTAssertEqual(mapError("ghostpepper://frobnicate")?.code, .badRequest)
+    }
+
+    func testOpenMeetingWithoutRefIsBadRequest() {
+        XCTAssertEqual(mapError("ghostpepper://open-meeting")?.code, .badRequest)
+    }
+
+    private func map(_ string: String) -> GhostPepperAction? {
+        guard let request = parse(string) else { return nil }
+        if case .success(let action) = URLActionHandler.action(for: request) { return action }
+        return nil
+    }
+
+    private func mapError(_ string: String) -> GhostPepperActionError? {
+        guard let request = parse(string) else { return nil }
+        if case .failure(let error) = URLActionHandler.action(for: request) { return error }
+        return nil
+    }
+
+    // MARK: - Callback mapping: success
+
+    func testOkOpensSuccessWithNoParams() {
+        let request = parse("ghostpepper://x-callback-url/stop-meeting?x-success=raycast://done")!
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.ok))
+        XCTAssertEqual(callback, URL(string: "raycast://done"))
+    }
+
+    func testOkWithoutSuccessIsNoOp() {
+        let request = parse("ghostpepper://stop-meeting")!
+        XCTAssertNil(URLActionHandler.callbackURL(for: request, result: .success(.ok)))
+    }
+
+    func testValueActionWithoutSuccessIsNoOp() {
+        let request = parse("ghostpepper://get-last-transcription")!
+        XCTAssertNil(URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "hi"))))
+    }
+
+    func testTranscriptionAppendsText() {
+        let request = parse("ghostpepper://x-callback-url/get-last-transcription?x-success=raycast://done")!
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "hello world")))
+        XCTAssertEqual(queryDict(callback!)["text"], "hello world")
+    }
+
+    func testStatusAppendsFields() {
+        let request = parse("ghostpepper://x-callback-url/get-status?x-success=raycast://done")!
+        let result = GhostPepperActionResult.status(recording: true, appStatus: "recording", meetingID: "mid", meetingName: "Standup")
+        let dict = queryDict(URLActionHandler.callbackURL(for: request, result: .success(result))!)
+        XCTAssertEqual(dict["recording"], "true")
+        XCTAssertEqual(dict["appStatus"], "recording")
+        XCTAssertEqual(dict["meetingID"], "mid")
+        XCTAssertEqual(dict["meetingName"], "Standup")
+    }
+
+    func testStatusOmitsNilMeetingFields() {
+        let request = parse("ghostpepper://x-callback-url/get-status?x-success=raycast://done")!
+        let result = GhostPepperActionResult.status(recording: false, appStatus: "idle", meetingID: nil, meetingName: nil)
+        let dict = queryDict(URLActionHandler.callbackURL(for: request, result: .success(result))!)
+        XCTAssertNil(dict["meetingID"])
+        XCTAssertNil(dict["meetingName"])
+    }
+
+    // MARK: - Callback mapping: B0 web-scheme rejection
+
+    func testHttpSuccessDoesNotReturnTranscript() {
+        for scheme in ["http", "https"] {
+            let request = parse("ghostpepper://x-callback-url/get-last-transcription?x-success=\(scheme)://evil.example")!
+            XCTAssertNil(
+                URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "secret"))),
+                "\(scheme) x-success must not receive transcript text"
+            )
+        }
+    }
+
+    func testHttpSuccessDropsStatusPayload() {
+        let request = parse("ghostpepper://x-callback-url/get-status?x-success=http://evil.example")!
+        let result = GhostPepperActionResult.status(recording: true, appStatus: "recording", meetingID: "m", meetingName: "n")
+        XCTAssertNil(URLActionHandler.callbackURL(for: request, result: .success(result)))
+    }
+
+    func testHttpSuccessDropsMeetingStartedPayload() {
+        for scheme in ["http", "https"] {
+            let request = parse("ghostpepper://x-callback-url/start-meeting?x-success=\(scheme)://evil.example")!
+            let id = "22222222-2222-2222-2222-222222222222"
+            let result = GhostPepperActionResult.meetingStarted(id: id, viewURL: URLActionHandler.viewURL(forMeetingID: id))
+            XCTAssertNil(
+                URLActionHandler.callbackURL(for: request, result: .success(result)),
+                "\(scheme) x-success must not receive the meeting id / viewURL"
+            )
+        }
+    }
+
+    // MARK: - Callback mapping: meetingStarted round-trip
+
+    func testMeetingStartedViewURLRoundTrips() {
+        let request = parse("ghostpepper://x-callback-url/start-meeting?x-success=raycast://done")!
+        let id = "11111111-1111-1111-1111-111111111111"
+        let viewURL = URLActionHandler.viewURL(forMeetingID: id)
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.meetingStarted(id: id, viewURL: viewURL)))!
+        let dict = queryDict(callback)
+        XCTAssertEqual(dict["meetingID"], id)
+        // Decoding the appended (percent-encoded) viewURL yields the original URL.
+        XCTAssertEqual(dict["viewURL"], viewURL.absoluteString)
+        XCTAssertEqual(dict["viewURL"], "ghostpepper://x-callback-url/open-meeting?id=\(id)")
+    }
+
+    func testAppendingPreservesExistingQueryItems() {
+        let request = parse("ghostpepper://x-callback-url/get-status?x-success=raycast://run%3Ffoo%3Dbar")!
+        let result = GhostPepperActionResult.status(recording: false, appStatus: "idle", meetingID: nil, meetingName: nil)
+        let dict = queryDict(URLActionHandler.callbackURL(for: request, result: .success(result))!)
+        XCTAssertEqual(dict["foo"], "bar")
+        XCTAssertEqual(dict["appStatus"], "idle")
+    }
+
+    func testValueWithSpecialCharactersIsEscaped() {
+        let request = parse("ghostpepper://x-callback-url/get-last-transcription?x-success=raycast://done")!
+        let text = "a&b=c d/e?f#g"
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: text)))!
+        // The raw query must be escaped (no stray separators), yet decode back to the original.
+        XCTAssertFalse(callback.absoluteString.contains("a&b=c"))
+        XCTAssertEqual(queryDict(callback)["text"], text)
+    }
+
+    // MARK: - Callback mapping: errors
+
+    func testErrorGoesToErrorCallback() {
+        let request = parse("ghostpepper://x-callback-url/open-meeting?id=missing&x-error=raycast://err")!
+        let error = GhostPepperActionError.notFound("No meeting with id missing")
+        let dict = queryDict(URLActionHandler.callbackURL(for: request, result: .failure(error))!)
+        XCTAssertEqual(dict["errorCode"], "NOT_FOUND")
+        XCTAssertEqual(dict["errorMessage"], "No meeting with id missing")
+    }
+
+    func testErrorWithoutErrorCallbackIsNoOp() {
+        let request = parse("ghostpepper://open-meeting?id=missing")!
+        let error = GhostPepperActionError.notFound("nope")
+        XCTAssertNil(URLActionHandler.callbackURL(for: request, result: .failure(error)))
+    }
+}

--- a/GhostPepperTests/URLActionHandlerTests.swift
+++ b/GhostPepperTests/URLActionHandlerTests.swift
@@ -59,6 +59,8 @@ final class URLActionHandlerTests: XCTestCase {
         XCTAssertEqual(map("ghostpepper://x-callback-url/start-meeting?name=Sync"), .startMeeting(name: "Sync"))
         XCTAssertEqual(map("ghostpepper://stop-meeting"), .stopMeeting)
         XCTAssertEqual(map("ghostpepper://get-last-transcription"), .getLastTranscription)
+        XCTAssertEqual(map("ghostpepper://copy-last-recording"), .copyLastRecording)
+        XCTAssertEqual(map("ghostpepper://x-callback-url/copy-last-recording"), .copyLastRecording)
         XCTAssertEqual(map("ghostpepper://get-status"), .getStatus)
         XCTAssertEqual(map("ghostpepper://summarize-meeting"), .summarizeMeeting(nil))
         XCTAssertEqual(map("ghostpepper://x-callback-url/summarize-meeting?id=xyz"), .summarizeMeeting(.id("xyz")))
@@ -75,6 +77,13 @@ final class URLActionHandlerTests: XCTestCase {
 
     func testOpenMeetingWithoutRefIsBadRequest() {
         XCTAssertEqual(mapError("ghostpepper://open-meeting")?.code, .badRequest)
+    }
+
+    // Copy-last-recording exposes transcript text, so it must be behind the automation
+    // opt-in. `perform` enforces this uniformly for any consent-gated action; asserting
+    // the contract here locks it in without needing the app context.
+    func testCopyLastRecordingRequiresAutomationConsent() {
+        XCTAssertTrue(GhostPepperAction.copyLastRecording.requiresAutomationConsent)
     }
 
     private func map(_ string: String) -> GhostPepperAction? {
@@ -309,6 +318,48 @@ final class URLActionHandlerTests: XCTestCase {
         let result = GhostPepperActionResult.status(recording: false, appStatus: "idle", meetingID: nil, meetingName: nil)
         let callback = URLActionHandler.callbackURL(for: request, result: .success(result))!
         XCTAssertEqual(jsonPayload(in: callback, param: "a b")?["appStatus"] as? String, "idle")
+    }
+
+    // MARK: - copy-last-recording
+
+    // The clipboard write happens app-side in AppState; over URL the action reuses the
+    // transcription payload, so the same delivery + web-scheme rules apply.
+
+    func testCopyLastRecordingFireAndForgetIsNoOp() {
+        // The launcher-facing path: no x-success, so nothing to open — the copy already
+        // happened app-side.
+        let request = parse("ghostpepper://copy-last-recording")!
+        XCTAssertNil(URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "dictated text"))))
+    }
+
+    func testCopyLastRecordingAppendsTextToNonWebSuccess() {
+        let request = parse("ghostpepper://x-callback-url/copy-last-recording?x-success=raycast://done")!
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "dictated text")))!
+        XCTAssertEqual(queryDict(callback)["text"], "dictated text")
+    }
+
+    func testCopyLastRecordingDropsTextForWebSuccess() {
+        for scheme in ["http", "https"] {
+            let request = parse("ghostpepper://x-callback-url/copy-last-recording?x-success=\(scheme)://evil.example")!
+            XCTAssertNil(
+                URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "secret"))),
+                "\(scheme) x-success must not receive the copied transcript"
+            )
+        }
+    }
+
+    func testCopyLastRecordingNotFoundGoesToErrorCallback() {
+        let request = parse("ghostpepper://x-callback-url/copy-last-recording?x-error=raycast://err")!
+        let error = GhostPepperActionError.notFound("The last recording has no transcribed text to copy.")
+        let dict = queryDict(URLActionHandler.callbackURL(for: request, result: .failure(error))!)
+        XCTAssertEqual(dict["errorCode"], "NOT_FOUND")
+    }
+
+    func testCopyLastRecordingForbiddenGoesToErrorCallback() {
+        let request = parse("ghostpepper://x-callback-url/copy-last-recording?x-error=raycast://err")!
+        let error = GhostPepperActionError.forbidden("Automation is disabled.")
+        let dict = queryDict(URLActionHandler.callbackURL(for: request, result: .failure(error))!)
+        XCTAssertEqual(dict["errorCode"], "FORBIDDEN")
     }
 
     // MARK: - Callback mapping: errors

--- a/GhostPepperTests/URLActionHandlerTests.swift
+++ b/GhostPepperTests/URLActionHandlerTests.swift
@@ -13,6 +13,15 @@ final class URLActionHandlerTests: XCTestCase {
         return Dictionary(items.map { ($0.name, $0.value ?? "") }, uniquingKeysWith: { _, last in last })
     }
 
+    /// The JSON object carried in `url`'s `param` query item (percent-decoded by `queryDict`).
+    private func jsonPayload(in url: URL, param: String) -> [String: Any]? {
+        guard let value = queryDict(url)[param],
+              let data = value.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object
+    }
+
     // MARK: - Action-token parsing
 
     func testParsesActionFromCallbackPath() {
@@ -181,6 +190,125 @@ final class URLActionHandlerTests: XCTestCase {
         // The raw query must be escaped (no stray separators), yet decode back to the original.
         XCTAssertFalse(callback.absoluteString.contains("a&b=c"))
         XCTAssertEqual(queryDict(callback)["text"], text)
+    }
+
+    // MARK: - Callback shaping: retParam (no retFormat)
+
+    func testRetParamRenamesSingleValuePayload() {
+        let request = parse("ghostpepper://x-callback-url/get-last-transcription?retParam=q&x-success=tuna://text")!
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "caught a tuna")))!
+        XCTAssertEqual(queryDict(callback)["q"], "caught a tuna")
+        XCTAssertNil(queryDict(callback)["text"])
+    }
+
+    func testRetParamOnMultiValuePayloadIsBadRequest() {
+        let request = parse("ghostpepper://x-callback-url/get-status?retParam=context&x-success=raycast://ok&x-error=raycast://err")!
+        let result = GhostPepperActionResult.status(recording: true, appStatus: "recording", meetingID: "m", meetingName: "n")
+        let dict = queryDict(URLActionHandler.callbackURL(for: request, result: .success(result))!)
+        // No field is silently dropped — the caller is told to use retFormat=json.
+        XCTAssertEqual(dict["errorCode"], "BAD_REQUEST")
+        XCTAssertNil(dict["recording"])
+        XCTAssertNil(dict["appStatus"])
+    }
+
+    func testRetParamOnMeetingStartedIsBadRequest() {
+        let request = parse("ghostpepper://x-callback-url/start-meeting?retParam=out&x-success=raycast://ok&x-error=raycast://err")!
+        let id = "33333333-3333-3333-3333-333333333333"
+        let result = GhostPepperActionResult.meetingStarted(id: id, viewURL: URLActionHandler.viewURL(forMeetingID: id))
+        XCTAssertEqual(queryDict(URLActionHandler.callbackURL(for: request, result: .success(result))!)["errorCode"], "BAD_REQUEST")
+    }
+
+    func testEmptyRetParamFallsBackToNaturalNames() {
+        let request = parse("ghostpepper://x-callback-url/get-status?retParam=&x-success=raycast://done")!
+        let result = GhostPepperActionResult.status(recording: false, appStatus: "idle", meetingID: nil, meetingName: nil)
+        let dict = queryDict(URLActionHandler.callbackURL(for: request, result: .success(result))!)
+        XCTAssertEqual(dict["appStatus"], "idle")
+        XCTAssertEqual(dict["recording"], "false")
+    }
+
+    func testRetParamNeverReachesWebSuccess() {
+        let request = parse("ghostpepper://x-callback-url/get-last-transcription?retParam=q&x-success=https://evil.example")!
+        XCTAssertNil(URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "secret"))))
+    }
+
+    // MARK: - Callback shaping: retFormat=json
+
+    func testJSONFormatEncodesStatusPayloadUnderRetParam() {
+        let request = parse("ghostpepper://x-callback-url/get-status?retFormat=json&retParam=context&x-success=raycast://extensions/me/ext/cmd")!
+        let result = GhostPepperActionResult.status(recording: true, appStatus: "recording", meetingID: "mid", meetingName: "Standup")
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(result))!
+        let json = jsonPayload(in: callback, param: "context")
+        XCTAssertEqual(json?["recording"] as? Bool, true)
+        XCTAssertEqual(json?["appStatus"] as? String, "recording")
+        XCTAssertEqual(json?["meetingID"] as? String, "mid")
+        XCTAssertEqual(json?["meetingName"] as? String, "Standup")
+        // recording is a JSON boolean, not the string "true" or the number 1.
+        XCTAssertTrue(queryDict(callback)["context"]!.contains("\"recording\":true"))
+    }
+
+    func testJSONFormatDefaultsEnvelopeToPayload() {
+        let request = parse("ghostpepper://x-callback-url/get-status?retFormat=json&x-success=raycast://done")!
+        let result = GhostPepperActionResult.status(recording: false, appStatus: "idle", meetingID: nil, meetingName: nil)
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(result))!
+        let json = jsonPayload(in: callback, param: "payload")
+        XCTAssertEqual(json?["recording"] as? Bool, false)
+        XCTAssertEqual(json?["appStatus"] as? String, "idle")
+        // Nil meeting fields stay out of the JSON object.
+        XCTAssertNil(json?["meetingID"])
+        XCTAssertNil(json?["meetingName"])
+    }
+
+    func testJSONFormatEncodesTranscription() {
+        let request = parse("ghostpepper://x-callback-url/get-last-transcription?retFormat=json&retParam=arguments&x-success=raycast://extensions/me/ext/cmd")!
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "the whole thing")))!
+        let json = jsonPayload(in: callback, param: "arguments")
+        XCTAssertEqual(json?["text"] as? String, "the whole thing")
+        XCTAssertEqual(json?.count, 1)
+    }
+
+    func testJSONFormatNeverReachesWebSuccess() {
+        let request = parse("ghostpepper://x-callback-url/get-status?retFormat=json&x-success=http://evil.example")!
+        let result = GhostPepperActionResult.status(recording: true, appStatus: "recording", meetingID: "m", meetingName: "n")
+        XCTAssertNil(URLActionHandler.callbackURL(for: request, result: .success(result)))
+    }
+
+    func testUnsupportedRetFormatIsBadRequest() {
+        let request = parse("ghostpepper://x-callback-url/get-status?retFormat=xml&x-success=raycast://ok&x-error=raycast://err")!
+        let result = GhostPepperActionResult.status(recording: true, appStatus: "recording", meetingID: nil, meetingName: nil)
+        XCTAssertEqual(queryDict(URLActionHandler.callbackURL(for: request, result: .success(result))!)["errorCode"], "BAD_REQUEST")
+    }
+
+    func testJSONFormatEncodesMeetingStarted() {
+        let request = parse("ghostpepper://x-callback-url/start-meeting?retFormat=json&x-success=raycast://done")!
+        let id = "44444444-4444-4444-4444-444444444444"
+        let viewURL = URLActionHandler.viewURL(forMeetingID: id)
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.meetingStarted(id: id, viewURL: viewURL)))!
+        let json = jsonPayload(in: callback, param: "payload")
+        XCTAssertEqual(json?["meetingID"] as? String, id)
+        XCTAssertEqual(json?["viewURL"] as? String, viewURL.absoluteString)
+    }
+
+    func testOkIgnoresShapingParams() {
+        // A no-payload success just opens x-success; retParam/retFormat have nothing to shape.
+        let request = parse("ghostpepper://x-callback-url/stop-meeting?retFormat=json&retParam=p&x-success=raycast://done")!
+        XCTAssertEqual(URLActionHandler.callbackURL(for: request, result: .success(.ok)), URL(string: "raycast://done"))
+    }
+
+    // A user-controlled retParam becomes a query-item name; a reserved character in it must
+    // be percent-encoded, not fed raw to URLComponents (which traps and would crash on the
+    // unauthenticated URL scheme).
+
+    func testRetParamNameWithReservedCharIsEncoded() {
+        let request = parse("ghostpepper://x-callback-url/get-last-transcription?retParam=q%26r&x-success=tuna://text")!
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(.transcription(text: "hi")))!
+        XCTAssertEqual(queryDict(callback)["q&r"], "hi")
+    }
+
+    func testJSONEnvelopeNameWithReservedCharIsEncoded() {
+        let request = parse("ghostpepper://x-callback-url/get-status?retFormat=json&retParam=a%20b&x-success=raycast://done")!
+        let result = GhostPepperActionResult.status(recording: false, appStatus: "idle", meetingID: nil, meetingName: nil)
+        let callback = URLActionHandler.callbackURL(for: request, result: .success(result))!
+        XCTAssertEqual(jsonPayload(in: callback, param: "a b")?["appStatus"] as? String, "idle")
     }
 
     // MARK: - Callback mapping: errors


### PR DESCRIPTION
Implements #142.

Adds a `ghostpepper://` URL scheme and App Intents automation over a shared action boundary: `AppState.perform(_:)`. URL handling stays in `URLActionHandler`, app behavior stays in `AppState`, and inbound URLs are handled through an app delegate so menu-bar launches and cold starts have the same path.

## Actions

The automation vocabulary is intentionally small and shared by the URL scheme and App Intents:

- `start-meeting`: starts meeting transcription, with an optional `name` parameter.
- `stop-meeting`: stops the active meeting transcription.
- `get-last-transcription`: returns the active meeting transcript, or the newest saved meeting transcript with segments.
- `copy-last-recording`: copies the newest Transcription Lab dictation to the clipboard app-side, then returns that text for callers with a non-web `x-success`.
- `get-status`: returns `recording`, `appStatus`, and, when available, the current meeting id and name. Public statuses are `idle`, `recording`, `transcribing`, and `busy`.
- `summarize-meeting`: summarizes the active meeting, or a saved meeting addressed by `id` or `path`.
- `open-meeting`: opens a saved meeting by session `id` or archive-relative `.md` path.

URLs support both the shorthand form, such as `ghostpepper://copy-last-recording`, and the x-callback-url form, such as `ghostpepper://x-callback-url/get-status?x-success=raycast://done`.

## URL callbacks

Success callbacks follow x-callback-url conventions. A no-payload success opens `x-success` as-is. A value-bearing success appends named query fields to `x-success`, but only for non-web callback schemes.

Callers can shape returned values with two optional parameters:

- `retParam` renames a single-value result, such as `text` from `get-last-transcription` or `copy-last-recording`.
- `retFormat=json` packs the full payload into one URL-encoded JSON object under `retParam`, or under `payload` when `retParam` is omitted. This is required when using `retParam` with multi-value responses such as `get-status` or `start-meeting`.

Errors open `x-error` with `errorCode` and `errorMessage`.

## Security model

Automation is opt-in. Settings > Automation > Allow automation gates every action that records, returns transcript text, or summarizes. With the setting off, those actions return `FORBIDDEN`. `get-status` and `open-meeting` remain available because they are read-only or navigation-only.

Value payloads never go to `http` or `https` `x-success` callbacks. That keeps transcript text, copied dictations, status fields, meeting ids, and meeting view URLs out of web callbacks. `start-meeting` still uses the existing recording-consent path.

`open-meeting` paths go through `PathSandbox`. Archive-relative paths must end in `.md`, and absolute paths, `..`, symlink escapes, and non-markdown files are rejected.

## Implementation notes

- Registers the `ghostpepper` URL scheme in `Info.plist`.
- Adds an app readiness gate so cold-launch URL and intent requests return `NOT_READY` instead of touching missing app state.
- Persists meeting session ids in markdown frontmatter, indexes them, and uses that index for `open-meeting?id=...`.
- Shares transcript selection for Transcription Lab copies through `TranscriptionLabEntry.preferredTranscript`, which prefers `correctedTranscription` and falls back to `rawTranscription`.
- Implements the `Copy Last Recording` App Intent for Shortcuts and Spotlight. The URL action is also useful fire-and-forget: `ghostpepper://copy-last-recording` copies the newest Lab dictation without requiring a callback channel.

## Testing

Built and tested on macOS with Xcode 26.3 using `xcodebuild -scheme GhostPepper -destination 'platform=macOS'`.

- App target compiles cleanly against the real SDK.
- `URLActionHandlerTests` pass, 43/43, including routing, consent contract coverage for `copy-last-recording`, fire-and-forget behavior, non-web value delivery, the `http`/`https` payload guard, callback shaping with `retParam` and `retFormat=json`, malformed URLs, error callbacks, nested `viewURL` round-trips, and `NOT_FOUND` / `FORBIDDEN` mapping.
- Meeting session-id indexing is covered by `MeetingSessionIndexTests`.