### PR TITLE
feat(media): resume playback after recording completes

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		E62BA209042B0FA8B53E2C76 /* CleanupPromptEvalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA783B889855B0811E210751 /* CleanupPromptEvalTests.swift */; };
 		E6D90B88DFC16CA9EFD343B4 /* SpeakerIdentityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA71CE818E7248813A08248 /* SpeakerIdentityResolver.swift */; };
 		EA0A1ECE203067342B2E2CF6 /* MarkdownArchivePathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2703FAF4A3B8D55B84100BA /* MarkdownArchivePathsTests.swift */; };
+		EC9D3DF50039DB0403DDEC20 /* MediaPlaybackControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB83ECF2249CB96A4DC0AEDB /* MediaPlaybackControllerTests.swift */; };
 		ED6279A88A99C00B4F6C49CC /* ReaderCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AFC0BE8F74723D68B647A6 /* ReaderCapture.swift */; };
 		EE25B297BB7834C3C90423B9 /* TextCleanerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49848DB685A19FBB6557B76E /* TextCleanerTests.swift */; };
 		F0598B5D027A5B31EF1B7664 /* FocusedElementLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBC0D906FF181E91A758F58 /* FocusedElementLocatorTests.swift */; };
@@ -403,6 +404,7 @@
 		F96030E4F754A444667F7B07 /* RecognizedVoiceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizedVoiceStore.swift; sourceTree = "<group>"; };
 		FA48EF56983A55149A084D1B /* sprite_frame_3@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_3@2x.png"; sourceTree = "<group>"; };
 		FA652178AA004E557356FA93 /* IndexEntryFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexEntryFileTests.swift; sourceTree = "<group>"; };
+		FB83ECF2249CB96A4DC0AEDB /* MediaPlaybackControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPlaybackControllerTests.swift; sourceTree = "<group>"; };
 		FB90C0FCC4C82E14297BE616 /* ReaderCaptureSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCaptureSheet.swift; sourceTree = "<group>"; };
 		FDC6FD42E70C7163E281332B /* CleanupPromptBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupPromptBuilder.swift; sourceTree = "<group>"; };
 		FECE990F52DED36EC4C5458D /* AppRelauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRelauncher.swift; sourceTree = "<group>"; };
@@ -818,6 +820,7 @@
 				AF04305B5AE9665D25C23A2C /* IndexSystemPromptTests.swift */,
 				0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */,
 				D2703FAF4A3B8D55B84100BA /* MarkdownArchivePathsTests.swift */,
+				FB83ECF2249CB96A4DC0AEDB /* MediaPlaybackControllerTests.swift */,
 				1AFEA05207B7965A3D44D000 /* MeetingQAAgentTests.swift */,
 				35A699887678B31BAF27498A /* MeetingQASystemPromptTests.swift */,
 				785F5D6EDD25D78F6220268E /* MeetingQAToolsTests.swift */,
@@ -927,7 +930,6 @@
 				};
 			};
 			buildConfigurationList = 4DD304029FEB6147483470FD /* Build configuration list for PBXProject "GhostPepper" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -943,6 +945,7 @@
 				E56E28037799FE95D6CB5F71 /* XCRemoteSwiftPackageReference "WhisperKit" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 3705D6F7BCD01CB7D37DF812 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -1144,6 +1147,7 @@
 				5A4D2E405B6F7A519BA6F6F0 /* IndexSystemPromptTests.swift in Sources */,
 				AB0AC6DC19EC0DB440F5B123 /* KeyChordTests.swift in Sources */,
 				EA0A1ECE203067342B2E2CF6 /* MarkdownArchivePathsTests.swift in Sources */,
+				EC9D3DF50039DB0403DDEC20 /* MediaPlaybackControllerTests.swift in Sources */,
 				4961DAF729CE58AAAACBC1AC /* MeetingQAAgentTests.swift in Sources */,
 				190EA523BC8AAF93599DD038 /* MeetingQASystemPromptTests.swift in Sources */,
 				04654E621041E2A81CC2CFC7 /* MeetingQAToolsTests.swift in Sources */,

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -766,6 +766,8 @@ class AppState: ObservableObject {
         } catch {
             recordingOCRPrefetch.cancel()
             releasePipeline(owner: .liveRecording)
+            // Recording never started, so restore any media we paused above.
+            mediaPlaybackController.resumeIfPaused()
             activePerformanceTrace = nil
             errorMessage = "Failed to start recording: \(error.localizedDescription)"
             status = .error

--- a/GhostPepper/Media/MediaPlaybackController.swift
+++ b/GhostPepper/Media/MediaPlaybackController.swift
@@ -1,61 +1,111 @@
 import Foundation
 import Darwin
 
-/// Pauses system media playback during recording and resumes when done.
+/// Pauses system media playback during recording and resumes it afterward.
 /// Uses the private MediaRemote framework via dynamic loading.
 /// Gracefully degrades if the framework is unavailable.
+///
+/// Auto-resume is safe because we only send the play command when *we* were
+/// the ones who paused playback. Before pausing we query the now-playing
+/// state; if nothing is playing we don't touch anything, so we never send a
+/// stray play command. This avoids the old bug where blindly sending play
+/// launched Apple Music even when nothing had been playing before recording.
 final class MediaPlaybackController {
     private let enabled: () -> Bool
+    private let isPlaying: () -> Bool
+    private let sendPause: () -> Void
+    private let sendPlay: () -> Void
+    private let teardown: () -> Void
+
+    /// True only while we hold a pause we issued and haven't resumed yet.
+    private var didPauseMedia = false
 
     private typealias SendCommandFunc = @convention(c) (UInt32, UnsafeRawPointer?) -> Bool
-
-    private let frameworkHandle: UnsafeMutableRawPointer?
-    private let sendCommand: SendCommandFunc?
+    private typealias GetIsPlayingFunc = @convention(c) (DispatchQueue, @escaping @convention(block) (Bool) -> Void) -> Void
 
     private static let kMRPlay: UInt32 = 0
     private static let kMRPause: UInt32 = 1
 
-    init(enabled: @escaping () -> Bool) {
+    /// Designated initializer. The seams are injected so the pause/resume
+    /// bookkeeping can be exercised in tests without the private framework.
+    init(
+        enabled: @escaping () -> Bool,
+        isPlaying: @escaping () -> Bool,
+        sendPause: @escaping () -> Void,
+        sendPlay: @escaping () -> Void,
+        teardown: @escaping () -> Void = {}
+    ) {
         self.enabled = enabled
+        self.isPlaying = isPlaying
+        self.sendPause = sendPause
+        self.sendPlay = sendPlay
+        self.teardown = teardown
+    }
 
+    /// Production initializer. Wires the seams to the MediaRemote framework.
+    convenience init(enabled: @escaping () -> Bool) {
         let handle = dlopen(
             "/System/Library/PrivateFrameworks/MediaRemote.framework/MediaRemote",
             RTLD_NOW
         )
-        frameworkHandle = handle
 
+        var sendCommand: SendCommandFunc?
+        var getIsPlaying: GetIsPlayingFunc?
         if let handle {
             if let sym = dlsym(handle, "MRMediaRemoteSendCommand") {
                 sendCommand = unsafeBitCast(sym, to: SendCommandFunc.self)
-            } else {
-                sendCommand = nil
             }
-        } else {
-            sendCommand = nil
+            if let sym = dlsym(handle, "MRMediaRemoteGetNowPlayingApplicationIsPlaying") {
+                getIsPlaying = unsafeBitCast(sym, to: GetIsPlayingFunc.self)
+            }
         }
+
+        self.init(
+            enabled: enabled,
+            isPlaying: {
+                guard let getIsPlaying else { return false }
+                // The framework answers asynchronously; wait briefly so the
+                // synchronous pause path can act on the result. Bounded so a
+                // hung framework can never stall the start of a recording.
+                let semaphore = DispatchSemaphore(value: 0)
+                var playing = false
+                getIsPlaying(DispatchQueue.global(qos: .userInitiated)) { isPlaying in
+                    playing = isPlaying
+                    semaphore.signal()
+                }
+                _ = semaphore.wait(timeout: .now() + 0.5)
+                return playing
+            },
+            sendPause: { _ = sendCommand?(MediaPlaybackController.kMRPause, nil) },
+            sendPlay: { _ = sendCommand?(MediaPlaybackController.kMRPlay, nil) },
+            teardown: {
+                if let handle { dlclose(handle) }
+            }
+        )
     }
 
     deinit {
-        if let frameworkHandle {
-            dlclose(frameworkHandle)
-        }
+        teardown()
     }
 
     /// Pause media if currently playing. Call before recording starts.
-    /// Sends the pause command — it's a no-op if nothing is playing.
-    /// Does NOT auto-resume afterward; the user presses play themselves.
-    /// This avoids the bug where sending kMRPlay opens Apple Music
-    /// even when nothing was playing before recording started.
+    /// Records that we issued the pause so `resumeIfPaused()` can undo it.
+    /// If nothing is playing (or the feature is disabled) we do nothing, so
+    /// no stray play command is sent later.
     func pauseIfPlaying() {
-        guard enabled(), let sendCommand else { return }
-        _ = sendCommand(Self.kMRPause, nil)
+        guard enabled() else { return }
+        guard isPlaying() else { return }
+        sendPause()
+        didPauseMedia = true
     }
 
-    /// No-op. Kept for API compatibility.
-    /// We no longer auto-resume because sending kMRPlay when nothing was
-    /// playing causes Apple Music to launch (macOS routes the play command
-    /// to the default media handler).
+    /// Resume media if — and only if — we paused it. Call when recording ends.
+    /// Deliberately not gated on `enabled()`: if the setting is toggled off
+    /// mid-recording we still restore whatever we changed, so playback never
+    /// ends up stuck paused because of us.
     func resumeIfPaused() {
-        // Intentionally empty — user resumes media manually.
+        guard didPauseMedia else { return }
+        didPauseMedia = false
+        sendPlay()
     }
 }

--- a/GhostPepperTests/MediaPlaybackControllerTests.swift
+++ b/GhostPepperTests/MediaPlaybackControllerTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import GhostPepper
+
+final class MediaPlaybackControllerTests: XCTestCase {
+    /// Builds a controller with injected seams and records the commands it sends.
+    private func makeController(
+        enabled: Bool,
+        isPlaying: Bool
+    ) -> (controller: MediaPlaybackController, sent: () -> [String]) {
+        var commands: [String] = []
+        let controller = MediaPlaybackController(
+            enabled: { enabled },
+            isPlaying: { isPlaying },
+            sendPause: { commands.append("pause") },
+            sendPlay: { commands.append("play") }
+        )
+        return (controller, { commands })
+    }
+
+    func testPausesAndResumesWhenMediaIsPlaying() {
+        let (controller, sent) = makeController(enabled: true, isPlaying: true)
+
+        controller.pauseIfPlaying()
+        XCTAssertEqual(sent(), ["pause"])
+
+        controller.resumeIfPaused()
+        XCTAssertEqual(sent(), ["pause", "play"])
+    }
+
+    func testDoesNotResumeWhenNothingWasPlaying() {
+        // The core guard against the Apple-Music-launch bug: if nothing was
+        // playing we never paused, so we must never send a stray play command.
+        let (controller, sent) = makeController(enabled: true, isPlaying: false)
+
+        controller.pauseIfPlaying()
+        controller.resumeIfPaused()
+
+        XCTAssertEqual(sent(), [])
+    }
+
+    func testDoesNothingWhenDisabled() {
+        let (controller, sent) = makeController(enabled: false, isPlaying: true)
+
+        controller.pauseIfPlaying()
+        controller.resumeIfPaused()
+
+        XCTAssertEqual(sent(), [])
+    }
+
+    func testResumeWithoutPriorPauseIsNoOp() {
+        let (controller, sent) = makeController(enabled: true, isPlaying: true)
+
+        controller.resumeIfPaused()
+
+        XCTAssertEqual(sent(), [])
+    }
+
+    func testResumeIsIdempotent() {
+        let (controller, sent) = makeController(enabled: true, isPlaying: true)
+
+        controller.pauseIfPlaying()
+        controller.resumeIfPaused()
+        controller.resumeIfPaused()
+
+        XCTAssertEqual(sent(), ["pause", "play"])
+    }
+
+    func testResumesEvenIfSettingTogglesOffMidRecording() {
+        // We paused because the setting was on; if the user turns it off before
+        // the recording ends we still restore playback we changed.
+        var enabled = true
+        var commands: [String] = []
+        let controller = MediaPlaybackController(
+            enabled: { enabled },
+            isPlaying: { true },
+            sendPause: { commands.append("pause") },
+            sendPlay: { commands.append("play") }
+        )
+
+        controller.pauseIfPlaying()
+        enabled = false
+        controller.resumeIfPaused()
+
+        XCTAssertEqual(commands, ["pause", "play"])
+    }
+}


### PR DESCRIPTION
## Why

When you start a recording, Ghost Pepper pauses whatever media is playing so it doesn't bleed into the recording. But it never resumed it — you had to manually hit play again after every dictation. That's an easy thing to forget and a small annoyance dozens of times a day.

The reason auto-resume was removed originally was a real bug: blindly sending a "play" command when nothing had been playing caused macOS to launch Apple Music (the system routes an orphan play command to the default media handler). So the safe-but-worse choice was made to never resume.

## What

- Ghost Pepper now resumes media automatically when a recording ends — but only the media it actually paused.
- Before pausing, it checks whether something is currently playing (via MediaRemote's now-playing state). If nothing is playing, it does nothing, so no stray play command is ever sent and Apple Music never launches.
- A failed recording start also restores media, so playback can't get stuck paused.
- `MediaPlaybackController` is refactored with injectable seams and gets a unit test suite covering the pause/resume bookkeeping.

## So What

Users get their music/podcast back automatically after each dictation, with none of the Apple-Music-launching side effect that made this feature risky before. This is gated by the existing "Pause media while recording" setting — no new UI.

## How It Works

When a recording is about to start and the pause-media setting is on, the app asks the system whether any media is currently playing and waits briefly for the answer. If something is playing, it sends a pause command and remembers that it did so. When the recording finishes (or fails to start), it checks that remembered flag and, only if it was the one that paused, sends a play command to resume. Because it never sends play unless it previously paused something that was genuinely playing, there's no orphan play command for the system to misroute into launching Apple Music.
