### PR TITLE
Keep app-state tests out of Documents TCC

### DIFF
--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -76,10 +76,33 @@ private final class FakeRecordingTranscriptionSession: RecordingTranscriptionSes
 
 @MainActor
 final class GhostPepperTests: XCTestCase {
+    private static let usageStatsBackfillKey = "usageStats.backfill.v2"
+    private static var previousUsageStatsBackfillValue: Any?
+
     private let pepperChatAppStorageKeys = [
         "pepperChatEnabled",
         "pepperChatApiKey"
     ]
+
+    override class func setUp() {
+        super.setUp()
+        let defaults = UserDefaults.standard
+        previousUsageStatsBackfillValue = defaults.object(forKey: usageStatsBackfillKey)
+        // AppState startup backfill scans the user's Documents directory. The
+        // app-state tests use temporary fixtures, so skip that disk scan here
+        // to keep XCTest from prompting for TCC access to Documents.
+        defaults.set(true, forKey: usageStatsBackfillKey)
+    }
+
+    override class func tearDown() {
+        let defaults = UserDefaults.standard
+        if let previousUsageStatsBackfillValue {
+            defaults.set(previousUsageStatsBackfillValue, forKey: usageStatsBackfillKey)
+        } else {
+            defaults.removeObject(forKey: usageStatsBackfillKey)
+        }
+        super.tearDown()
+    }
 
     private func makeDebugLogStore() -> DebugLogStore {
         let fileURL = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Summary

- Prevent app-state XCTest cases from triggering the one-time UsageStats backfill of `~/Documents/Ghost Pepper Meetings/`.
- Preserve and restore the existing backfill sentinel so the test suite does not alter the user's defaults.
- Keep this test-only isolation separate from the SpeechAnalyzer implementation.

## Verification

- Focused app-state verification passed: 2 tests, 0 failures.
- The TCC-isolated SpeechAnalyzer/lifecycle verification also passed 43 selected tests without a Documents access prompt.
