### PR TITLE
Fix hold-to-record firing when an unbound modifier is also held

### DIFF
--- a/GhostPepper/Input/HotkeyMonitor.swift
+++ b/GhostPepper/Input/HotkeyMonitor.swift
@@ -345,14 +345,23 @@ final class HotkeyMonitor: NSObject, HotkeyMonitoring {
         }
     }
 
+    /// All standard modifier keycodes except Caps Lock (57), whose flag bit reflects the
+    /// lock toggle state rather than whether the key is currently held down.
+    private static let physicalModifierKeyCodes: [UInt16] = [54, 55, 56, 58, 59, 60, 61, 62, 63]
+
+    /// Reports every physically held modifier key, regardless of whether it's part of a
+    /// configured binding. Matching must see extra held modifiers (e.g. Option held alongside
+    /// a Control+Space chord) so it can reject the match instead of only comparing against
+    /// modifiers that happen to be bound.
     private func modifierPressedKeys(from flags: CGEventFlags) -> Set<PhysicalKey> {
-        monitoredKeys.filter { key in
+        Set(Self.physicalModifierKeyCodes.compactMap { keyCode in
+            let key = PhysicalKey(keyCode: keyCode)
             guard let modifierMaskRawValue = key.modifierMaskRawValue else {
-                return false
+                return nil
             }
 
-            return flags.rawValue & modifierMaskRawValue == modifierMaskRawValue
-        }
+            return flags.rawValue & modifierMaskRawValue == modifierMaskRawValue ? key : nil
+        })
     }
 
     private func currentStateReflectsCurrentEvent(

--- a/GhostPepperTests/HotkeyMonitorTests.swift
+++ b/GhostPepperTests/HotkeyMonitorTests.swift
@@ -7,6 +7,8 @@ final class HotkeyMonitorTests: XCTestCase {
     private let a = PhysicalKey(keyCode: 0)
     private let rightCommand = PhysicalKey(keyCode: 54)
     private let rightOption = PhysicalKey(keyCode: 61)
+    private let leftOption = PhysicalKey(keyCode: 58)
+    private let leftControl = PhysicalKey(keyCode: 59)
     private let space = PhysicalKey(keyCode: 49)
 
     func testPushChordTriggersStartAndStopCallbacks() throws {
@@ -504,6 +506,78 @@ final class HotkeyMonitorTests: XCTestCase {
             event: modifierEvent(
                 key: space,
                 flagsRawValue: UInt64(NX_COMMANDMASK | NX_ALTERNATEMASK | NX_DEVICERCMDKEYMASK | NX_DEVICERALTKEYMASK)
+            )
+        )
+
+        XCTAssertEqual(events, ["start"])
+    }
+
+    func testUnboundModifierHeldAlongsideChordPreventsMatch() throws {
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([leftControl, space])))
+            ],
+            keyStateProvider: { _ in false },
+            eventProcessor: { work in work() }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+        monitor.onRecordingStop = {
+            events.append("stop")
+        }
+
+        monitor.handleEvent(
+            .flagsChanged,
+            event: modifierEvent(
+                key: leftControl,
+                flagsRawValue: UInt64(NX_CONTROLMASK | NX_DEVICELCTLKEYMASK)
+            )
+        )
+
+        // Left Option is also physically held, even though it isn't part of the Control+Space
+        // binding. The chord must not match just because Option happens to be unbound.
+        monitor.handleEvent(
+            .keyDown,
+            event: modifierEvent(
+                key: space,
+                flagsRawValue: UInt64(
+                    NX_CONTROLMASK | NX_DEVICELCTLKEYMASK | NX_ALTERNATEMASK | NX_DEVICELALTKEYMASK
+                )
+            )
+        )
+
+        XCTAssertEqual(events, [])
+    }
+
+    func testChordStillMatchesWhenOnlyItsOwnModifierIsHeld() throws {
+        let monitor = HotkeyMonitor(
+            bindings: [
+                .pushToTalk: try XCTUnwrap(KeyChord(keys: Set([leftControl, space])))
+            ],
+            keyStateProvider: { _ in false },
+            eventProcessor: { work in work() }
+        )
+        var events: [String] = []
+
+        monitor.onRecordingStart = {
+            events.append("start")
+        }
+
+        monitor.handleEvent(
+            .flagsChanged,
+            event: modifierEvent(
+                key: leftControl,
+                flagsRawValue: UInt64(NX_CONTROLMASK | NX_DEVICELCTLKEYMASK)
+            )
+        )
+        monitor.handleEvent(
+            .keyDown,
+            event: modifierEvent(
+                key: space,
+                flagsRawValue: UInt64(NX_CONTROLMASK | NX_DEVICELCTLKEYMASK)
             )
         )
 


### PR DESCRIPTION
## Summary
- Hold-to-Record (and other hotkey chords) fired even when an extra, unbound modifier was held alongside the configured chord — e.g. Control+Space fired even with Option also held — because the matcher only tracked modifier keys that were part of some configured binding.
- `modifierPressedKeys(from:)` now reports the full physical modifier state (all standard modifiers except Caps Lock, whose flag reflects lock-toggle state rather than being held), so an unbound extra modifier correctly breaks the match.

## Test plan
- [x] Added `testUnboundModifierHeldAlongsideChordPreventsMatch` — Control+Space with Option also held no longer starts recording.
- [x] Added `testChordStillMatchesWhenOnlyItsOwnModifierIsHeld` — plain Control+Space still works.
- [x] Ran full `HotkeyMonitorTests` suite via `xcodebuild test` — all 17 tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)