### PR TITLE
Add streaming Nemotron MLX transcription models

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -1010,6 +1010,10 @@
 						DevelopmentTeam = "";
 						ProvisioningStyle = Automatic;
 					};
+					7EC925A714005FEB57488230 = {
+						DevelopmentTeam = "";
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 4DD304029FEB6147483470FD /* Build configuration list for PBXProject "GhostPepper" */;
@@ -1318,6 +1322,7 @@
 		};
 		5A5A6FF9BFB695BDD467C31A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 112E1B08BAA94CE3D91F2E00 /* Signing.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1349,6 +1354,7 @@
 		};
 		84D221D8273E90FEF61D490D /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 112E1B08BAA94CE3D91F2E00 /* Signing.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COMBINE_HIDPI_IMAGES = YES;

--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -7,38 +7,27 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00A17B847D4D401A8E89F14A /* AirtableImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A17B837D4D401A8E89F14A /* AirtableImporter.swift */; };
-		00A17B867D4D401A8E89F14A /* AirtableImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A17B857D4D401A8E89F14A /* AirtableImportView.swift */; };
-		00B000000000000000000001 /* IndexBuilding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000001 /* IndexBuilding.swift */; };
-		00B000000000000000000002 /* WikiKindStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000002 /* WikiKindStore.swift */; };
-		00B000000000000000000003 /* QMDService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000003 /* QMDService.swift */; };
-		00B000000000000000000004 /* NewWikiSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000004 /* NewWikiSheet.swift */; };
-		00B000000000000000000007 /* LocalStructuredLLM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000007 /* LocalStructuredLLM.swift */; };
-		00B000000000000000000008 /* LocalWikiEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000008 /* LocalWikiEngine.swift */; };
-		00B000000000000000000009 /* LocalWikiPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000009 /* LocalWikiPrompts.swift */; };
-		00B000000000000000000010 /* MeetingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000010 /* MeetingCard.swift */; };
-		00B000000000000000000011 /* MeetingChunker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000011 /* MeetingChunker.swift */; };
-		00B000000000000000000012 /* WikiEntityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000012 /* WikiEntityResolver.swift */; };
-		00B000000000000000000013 /* WikiKindProposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000013 /* WikiKindProposer.swift */; };
-		00B000000000000000000015 /* GeneratedWikiEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000015 /* GeneratedWikiEngine.swift */; };
-		00B000000000000000000016 /* WikiSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000016 /* WikiSearchService.swift */; };
-		00B000000000000000000017 /* GhostPepperHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A000000000000000000017 /* GhostPepperHistoryStore.swift */; };
+		005DF679067DC503DDB078D8 /* WikiSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66A5230C9D1EF1BAC0E65DA5 /* WikiSearchService.swift */; };
 		00D963F24233D19221F6F3BA /* ClaudePricing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45CD91720FB67A72CAEF0E9C /* ClaudePricing.swift */; };
 		04654E621041E2A81CC2CFC7 /* MeetingQAToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785F5D6EDD25D78F6220268E /* MeetingQAToolsTests.swift */; };
 		056C454F3BD1A9795C6775A5 /* ScreenRecordingPermissionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E4B61BA7270EEC11A8AC69 /* ScreenRecordingPermissionController.swift */; };
 		0606E11E6F102BBB44ED08B6 /* ScreenRecordingPermissionControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C9ECBFE04804AA79262A07B /* ScreenRecordingPermissionControllerTests.swift */; };
+		08C38FC1FE9822CA8FB68728 /* QMDService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD43D666CB62342B723A1C98 /* QMDService.swift */; };
+		0906BD4E84CEB5BD6B746876 /* cytoscape.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 1C82FF777F1863DC84525AC2 /* cytoscape.min.js */; };
 		09DA02222FFAFD8F32DB0212 /* TranscriptionLabStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */; };
 		0A1823314AE4FF4E17DCF627 /* sprite_frame_0.png in Resources */ = {isa = PBXBuildFile; fileRef = 2AF744C59EEAE51FC81BE6D6 /* sprite_frame_0.png */; };
-		0AC7A5C3B9E8424694D7A001 /* cytoscape.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 0AC7A5C3B9E8424694D7A000 /* cytoscape.min.js */; };
 		0B50B23BDEAFA03CE3FFA368 /* Secrets.example in Resources */ = {isa = PBXBuildFile; fileRef = 84630A373DA596D94B45E867 /* Secrets.example */; };
+		0BC51EE5185DD2A114A4639D /* WikiKindStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4637BBA19A2CAD1BF89D1EC4 /* WikiKindStoreTests.swift */; };
 		0BC5D4645D21CA8AA000972E /* RecordingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3540C6212101C885EA22CD /* RecordingOverlay.swift */; };
 		0CDA12F05A7C7464334FDD37 /* RecordingOCRPrefetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E9AADC67C525B0A9E382AB /* RecordingOCRPrefetch.swift */; };
 		0D32E8DDD47F77F86D9C1816 /* CleanupModelProbeRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B93B4F9F40EE6BD8525677 /* CleanupModelProbeRunnerTests.swift */; };
+		0D3CC162174A2BD3F96D1179 /* GeneratedWikiEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9250554BD8AFCA914A2E0F69 /* GeneratedWikiEngine.swift */; };
 		0ECF7A214F925A7EBAF7FDA6 /* IndexKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC2402355479C57FB26A884B /* IndexKind.swift */; };
 		0EE1ACB128322AD4F18CE96C /* AnthropicProviderSSETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 426AD7D84015B8A5FE446715 /* AnthropicProviderSSETests.swift */; };
 		117E06290C6E2BB843E9BEBF /* AnthropicProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFD3380CA7073693ADCAE0A /* AnthropicProvider.swift */; };
 		11B19088ACBD174CFD3DD531 /* CleanupPromptBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC6FD42E70C7163E281332B /* CleanupPromptBuilder.swift */; };
 		124405C2042DC7A4D8C3BCBC /* AgentBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4259D5539739F5536872B7D3 /* AgentBackend.swift */; };
+		160D6AB39F87C2045BE156F4 /* MeetingChunkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00B029C7A13483CD703B723 /* MeetingChunkerTests.swift */; };
 		17AF31EA19761CA8B7DF5F9A /* CleanupSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065F99395EEC3EB77997C2C /* CleanupSettings.swift */; };
 		190EA523BC8AAF93599DD038 /* MeetingQASystemPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35A699887678B31BAF27498A /* MeetingQASystemPromptTests.swift */; };
 		194F5FBCC55E0EA3E0351C15 /* SpeechModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD317A8D8E749E5596734DB7 /* SpeechModelCatalog.swift */; };
@@ -50,6 +39,7 @@
 		1D6267B10B14E90561E8BD46 /* RightSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA211C873C6A5836ADA89EB /* RightSidebarView.swift */; };
 		1EF06A7EA54855634307E6A8 /* sprite_frame_4@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E0BBD0F5DD1B827D03F0F8F6 /* sprite_frame_4@2x.png */; };
 		1F0BFAEE62163EFA88F3F19C /* ReaderCaptureSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB90C0FCC4C82E14297BE616 /* ReaderCaptureSheet.swift */; };
+		218AE026F8527BA4AA4F6AC1 /* LocalWikiEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB15E476FA6663CD0A6BE67 /* LocalWikiEngine.swift */; };
 		2230B29BF920D15E5150B97E /* ChordAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E725F86E5430DC36EB03272 /* ChordAction.swift */; };
 		242A5D63A9F6E3FAD4E09F7D /* AudioRecorderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 960D35875D60655B17574DF8 /* AudioRecorderTests.swift */; };
 		250BFD8AD225CE0845C4C516 /* BuildIndexSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EC7E1A9685759595E98ABB5 /* BuildIndexSheet.swift */; };
@@ -59,6 +49,8 @@
 		2BEB4B4A879A749C8B92BE44 /* CorrectionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D087A4D4CD5C6D3C293AE56 /* CorrectionStore.swift */; };
 		2D74E2B753F02B4D39999E57 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40927DEAA2F7DE3C290536F7 /* main.swift */; };
 		2E80774D95EAC6D6B53A226D /* RecordingSessionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0C972BC69839C41ACA2E8C /* RecordingSessionCoordinatorTests.swift */; };
+		2FC02F0B70C62E6E4EEC8FE6 /* WikiEntityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FA2814A2B1E8A59525306B6 /* WikiEntityResolver.swift */; };
+		3123B94EC8D14C4679E20918 /* MeetingCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09095C80171572F5C5B3ECDA /* MeetingCard.swift */; };
 		31E37E3EDDB8A0E5011BCA54 /* GhostPepperApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9AE24266DDCCADE832CF33 /* GhostPepperApp.swift */; };
 		3512549BBD28CC74C0137FA3 /* CorrectionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350AC3A5A34A78F96226831C /* CorrectionStoreTests.swift */; };
 		361E7532F651C1BF7F0D0724 /* TextCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37863EC2F34067ED0C5B2B6F /* TextCleaner.swift */; };
@@ -73,6 +65,7 @@
 		3B8354B1BAACB0F28DF98815 /* ZoBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FEC2E37841B0CF1F320F326 /* ZoBackend.swift */; };
 		3DD297DFB3E56835BBD705EF /* MeetingTranscriptWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E1B6653DAE6ED42FE9910B /* MeetingTranscriptWindow.swift */; };
 		3ED58FA92E41F5A79A1190AF /* IndexEntryFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA652178AA004E557356FA93 /* IndexEntryFileTests.swift */; };
+		4051A9E01314A93D67C6F850 /* WikiEntityResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91548F1CB636E180B4CA92C /* WikiEntityResolverTests.swift */; };
 		408C8D6C7BE897429324F4F1 /* PerformanceTrace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016C38149DDDAA03B88E35C0 /* PerformanceTrace.swift */; };
 		41585ECBAFB5534CB6AE4FC5 /* GranolaImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9452C09EB8A7AC2E5E69A502 /* GranolaImporter.swift */; };
 		41C94A48B97D3A6861EA1E92 /* PostPasteLearningCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */; };
@@ -82,6 +75,7 @@
 		478299189CD80630739E9150 /* MeetingQASystemPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87733132E66F36BCE7103250 /* MeetingQASystemPrompt.swift */; };
 		47B377ADA2B2F12226744122 /* MeetingDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE672F443903BF4B47EF96EF /* MeetingDetector.swift */; };
 		4961DAF729CE58AAAACBC1AC /* MeetingQAAgentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFEA05207B7965A3D44D000 /* MeetingQAAgentTests.swift */; };
+		4BB6E415F122404580A7C80D /* NemotronStreamingModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E73165C63B4179008B8EA59 /* NemotronStreamingModel.swift */; };
 		4CFBE4928A2B811D649B4140 /* TextCleanupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C0D4F04FFD2C13DEACA238 /* TextCleanupManager.swift */; };
 		4DD74E9C222518EEB0DA2A9B /* RecordingOCRPrefetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */; };
 		4EAE492B8F7F4CB18D2E0FE9 /* AudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5407DA5D09555EDD69CA54 /* AudioRecorder.swift */; };
@@ -96,22 +90,26 @@
 		571085951E318B0ADD2B00EA /* RuntimeModelInventoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38C742095D3934D70BCE44E4 /* RuntimeModelInventoryTests.swift */; };
 		572FDC1B8744EECF73C0EA86 /* PasteSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934F425F25CCB580B8202127 /* PasteSession.swift */; };
 		58786AC40C6823691E15369C /* FocusedElementLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E3575D1B5EA81CBB2CD1C2B /* FocusedElementLocator.swift */; };
-		58A000000000000000000001 /* AppleSpeechAnalyzerBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A000000000000000000000 /* AppleSpeechAnalyzerBackend.swift */; };
 		5A4D2E405B6F7A519BA6F6F0 /* IndexSystemPromptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF04305B5AE9665D25C23A2C /* IndexSystemPromptTests.swift */; };
 		5AB7257704509FD4BC36F69E /* TextPaster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB2D492BFBDC803133A31 /* TextPaster.swift */; };
 		5AC883ADFD11721A8E9E4D37 /* ModelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BAE65A5741A98AEADF6498D /* ModelManager.swift */; };
 		5AFD58B50823656E71CF3AA9 /* OCRContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3BCEA6FF268C1759D1F20 /* OCRContext.swift */; };
 		5CCF5560BDC9AD0982A69F3D /* OCRContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27D1ADB87391BB00E156008 /* OCRContext.swift */; };
+		61D05926E16756EAD4EC13C6 /* IndexKindCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D080B6685FCD6476F47C97B /* IndexKindCodableTests.swift */; };
 		635E00F7C849159760D86642 /* CleanupModelProbeCLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397AC156E3D2AF040A998E68 /* CleanupModelProbeCLI.swift */; };
 		637A68B05AD8479E0B5D52A7 /* HotkeyMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 589AC554EEF132B519736D92 /* HotkeyMonitorTests.swift */; };
 		6585677AF7949BEA14C0B3B2 /* CleanupSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3252290627807046966D956B /* CleanupSettings.swift */; };
+		660C682858BDA505AF802113 /* WikiKindStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96CABA1D2598574AB426FE8F /* WikiKindStore.swift */; };
 		660FCA13EFCA0BC0B8A1FA8E /* TrelloBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8F478894D0A3A49A91C8CC /* TrelloBackend.swift */; };
-		666D2339FC0689F41A3AE715 /* LLM in Frameworks */ = {isa = PBXBuildFile; productRef = 985AD96FDE69D89C0B2DA245 /* LLM */; };
+		666D2339FC0689F41A3AE715 /* MLXAudioSTT in Frameworks */ = {isa = PBXBuildFile; productRef = 856273CF717253EE0B84C6ED /* MLXAudioSTT */; };
+		66CFEC09452F5F23E9747669 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 52CD995A5FADA02097BCD33F /* Sparkle */; };
+		6A1BF15DDA0E15BFE4BB4426 /* QMDServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1396E3728596BB5BE6C451 /* QMDServiceTests.swift */; };
 		6EA6ACF174AAA398586CC03A /* ChordEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518567C8CE0F7841ACE62BD1 /* ChordEngine.swift */; };
 		6F3DA53FA7B4119405D86DE8 /* CleanupModelProbeRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853418773B99673FB27791AC /* CleanupModelProbeRunner.swift */; };
 		6F9B246766050DABB6DE046A /* MeetingTranscriptSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624731D133FE2A9EB3A12740 /* MeetingTranscriptSettings.swift */; };
 		736FB3EB1125A9A9D328400E /* MarkdownArchivePaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F971536E7FB4527A61DBC9 /* MarkdownArchivePaths.swift */; };
 		74300E8BF96FFDE33F3830BB /* MeetingTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3172F66BB9EF510F4E17D76 /* MeetingTranscript.swift */; };
+		746CDB0CF3373CFFA79071A0 /* MeetingChunker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F68CC2980332BEC494C2FCD /* MeetingChunker.swift */; };
 		74C8907D76A8E0433442CA77 /* IndexBuildEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14601041CEB40DAB3828382 /* IndexBuildEvent.swift */; };
 		750B0226D3A035D24259B606 /* WindowCaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F70F511A956DAB5778D430 /* WindowCaptureService.swift */; };
 		75509873255097FF99B8071F /* DebugLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB052D817F3005B509E9D479 /* DebugLogStore.swift */; };
@@ -122,6 +120,8 @@
 		783179FB65E4B507B25CF691 /* ChordEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65270DAE5CA7F1A37B4D890B /* ChordEngineTests.swift */; };
 		78678A0067436B71C2C1C3C9 /* sprite_frame_1.png in Resources */ = {isa = PBXBuildFile; fileRef = 24362CABE7BBCAF53CB9B4A8 /* sprite_frame_1.png */; };
 		7A76401386357A585F42C422 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 777FDA0FC9C05B5D278C6C3E /* KeychainHelper.swift */; };
+		7B7F8B9645EEDA1A331EE280 /* LocalStructuredLLM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145894D3AD8A3F184A9E9854 /* LocalStructuredLLM.swift */; };
+		7CCC6CA01DEFDE524CC8747F /* NewWikiSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9666B5433621920087AA3DD4 /* NewWikiSheet.swift */; };
 		7F6B796521231B6254976F79 /* TranscriptionLabEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2FBE70052D41935CC26FC6 /* TranscriptionLabEntry.swift */; };
 		80C9E55FF57A1A03033DDDAE /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207AAC1CBC60052D1493D13D /* SettingsWindow.swift */; };
 		814EF252650AB2BAADC12D49 /* QAAnswerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF10422C55DDA1F8B026ADA7 /* QAAnswerView.swift */; };
@@ -130,8 +130,10 @@
 		8323B1A2E48B64B493939727 /* GranolaImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B89E71C9D2C08957AB78FA5E /* GranolaImportView.swift */; };
 		8990B2F77435E351A458EDD9 /* DebugLogWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2715D9117D8664700616D95A /* DebugLogWindow.swift */; };
 		8BCB1AE8A984462B0635BA09 /* SystemAudioRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BBAF87158BF49AB528B979 /* SystemAudioRecorder.swift */; };
+		8DACA8CFD1EACC324B9F0A42 /* GhostPepperHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F3A28C4C8FDE75A66B93F1 /* GhostPepperHistoryStore.swift */; };
 		8F4C6360C1304C4A145DC34F /* LocalLLMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE5336D97A974B974B025ED4 /* LocalLLMProvider.swift */; };
 		8F72E86B5335738940C35A67 /* MeetingWindowHeuristicsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */; };
+		8F765C2E7A9ACA6878E1EC02 /* AirtableImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F798C98BE9BF562FC97730 /* AirtableImporter.swift */; };
 		90F411F8E3564F1C5DDD1A5F /* TextPasterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */; };
 		9114B9CC3A96A49F51A622A8 /* UsageStatsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B219A1BCAC2EBC64DDAE6960 /* UsageStatsStore.swift */; };
 		91B80C940C09B24CE80A4B81 /* ChordBindingStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF767CF1AA15DB2C2B82A1C /* ChordBindingStoreTests.swift */; };
@@ -145,10 +147,12 @@
 		9F0C599099252C3E7C8846F2 /* IndexEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F22B92A6ECEE8A19C9A5095 /* IndexEntryView.swift */; };
 		9FF4377D176BB2AE30E4B08B /* sprite_frame_3@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FA48EF56983A55149A084D1B /* sprite_frame_3@2x.png */; };
 		A3183D30BAD0A1C2712E033F /* PermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC1BDC9C549491AC003117EC /* PermissionChecker.swift */; };
-		A31E9987608164A53D5255EB /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 52CD995A5FADA02097BCD33F /* Sparkle */; };
+		A31E9987608164A53D5255EB /* LLM in Frameworks */ = {isa = PBXBuildFile; productRef = 985AD96FDE69D89C0B2DA245 /* LLM */; };
 		A3E327275ED67114E0400C99 /* RecognizedVoiceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F96030E4F754A444667F7B07 /* RecognizedVoiceStore.swift */; };
 		A4826C92959DD203D5239B8E /* CleanupPromptBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F36633332009332F588C183E /* CleanupPromptBuilderTests.swift */; };
+		A53F4F79DB112740AF5F3262 /* IndexBuilding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B831886F170626577F143DA /* IndexBuilding.swift */; };
 		A5C0FD97A59CA8F8AACCF328 /* QwenToolCallParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EAB6FB92135AD07ACA34963 /* QwenToolCallParser.swift */; };
+		A696504AAE0D7BCC4E066EFF /* WikiKindProposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0879FCBD94CE7356B3E576 /* WikiKindProposer.swift */; };
 		A97D2B15C80A932D1D9BF222 /* MeetingQATools.swift in Sources */ = {isa = PBXBuildFile; fileRef = F811DEE65308CAB8B574BAFD /* MeetingQATools.swift */; };
 		A9826A25D65BE571100B792C /* ChunkedTranscriptionPipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CAEC58BA358D8ED4206D550 /* ChunkedTranscriptionPipeline.swift */; };
 		A9DB6627D058705A602BED84 /* IndexEntryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8BC15638B3E29136594B44 /* IndexEntryFile.swift */; };
@@ -179,12 +183,14 @@
 		C6EDBC09902D8470DBFD5255 /* IndexSystemPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D736758B588185CCE102504 /* IndexSystemPrompt.swift */; };
 		C6F4C6C95E2835A2EEB58861 /* MeetingHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 648497BCB18036D3B10EADD2 /* MeetingHistory.swift */; };
 		CB39E9A8C16C4704B087F40C /* PathSandbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659E43C6D2C350FE7DB967A3 /* PathSandbox.swift */; };
+		CBA6939BF3E98BAD81D0A41F /* AirtableImportView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3549A7875AAEE3CC42F3B223 /* AirtableImportView.swift */; };
 		CBDE26BEEBD0419A73D09DFC /* OCRRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E45DE13042196F9DF2445E66 /* OCRRequestFactory.swift */; };
 		CC795C47BAF8CEF62790BAFF /* LocalLLMCleanupBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDE96F13974B4DC0EEB3C17E /* LocalLLMCleanupBackend.swift */; };
 		CD1993731E37C507B43CED9F /* ModelsSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0C0CBEADEB8791C4D738B1 /* ModelsSidebarView.swift */; };
 		CE62853358A180E54150BCA4 /* OnboardingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EBA7ECAEFCAC714F83C2C5 /* OnboardingWindow.swift */; };
 		D0C9E92678ECFF9228D0B7F0 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 51FBB4B31E8E9293DC11143E /* WhisperKit */; };
 		D647909F8F2D5C2046352750 /* MeetingTranscriptWindowPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B112C736F05F0A7CFA7784A2 /* MeetingTranscriptWindowPresentationTests.swift */; };
+		D6557CAE938DA4B11B4B1C38 /* AppleSpeechAnalyzerBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C67C4751B4243F33B01113 /* AppleSpeechAnalyzerBackend.swift */; };
 		D87DC24D05DAC4ED292C077B /* ShortcutCaptureState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01C000BF0DFBCCCF549921A /* ShortcutCaptureState.swift */; };
 		DA27C59BD3F0752E0E337813 /* CleanupBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F8EC51C74573DD4A47E1CEB /* CleanupBackend.swift */; };
 		DBA25ED4D9D561452CE6EA50 /* ChordBindingStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D91666EEE2CF7B4B78E3061 /* ChordBindingStore.swift */; };
@@ -198,10 +204,12 @@
 		E30E215812243E696D4BA75F /* QATranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2387F1E285001F18E98F967 /* QATranscript.swift */; };
 		E32E0657B858A9BBF528126A /* MeetingQAAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86139A1597D208E3748C3155 /* MeetingQAAgent.swift */; };
 		E3302E239909CAEC0865A035 /* PerformanceTraceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59666FBC728BF70A61983188 /* PerformanceTraceTests.swift */; };
+		E345F0200A178136FDE7BC43 /* LocalWikiPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FD43BF39DAD8F40FE05BFBE /* LocalWikiPrompts.swift */; };
 		E3FB1CC9DA749F6CCCE3EBD3 /* DebugLogStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29EC2918929DBE8F6F9743A1 /* DebugLogStore.swift */; };
 		E5E590FA60691DA4B57DA7CB /* OCRContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */; };
 		E62BA209042B0FA8B53E2C76 /* CleanupPromptEvalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA783B889855B0811E210751 /* CleanupPromptEvalTests.swift */; };
 		E6D90B88DFC16CA9EFD343B4 /* SpeakerIdentityResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA71CE818E7248813A08248 /* SpeakerIdentityResolver.swift */; };
+		E7165BCC53E626252EC92C98 /* MeetingCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C926BF4341F8D3448FE7096 /* MeetingCardTests.swift */; };
 		EA0A1ECE203067342B2E2CF6 /* MarkdownArchivePathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2703FAF4A3B8D55B84100BA /* MarkdownArchivePathsTests.swift */; };
 		ED6279A88A99C00B4F6C49CC /* ReaderCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27AFC0BE8F74723D68B647A6 /* ReaderCapture.swift */; };
 		EE25B297BB7834C3C90423B9 /* TextCleanerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49848DB685A19FBB6557B76E /* TextCleanerTests.swift */; };
@@ -231,44 +239,31 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		00A17B837D4D401A8E89F14A /* AirtableImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirtableImporter.swift; sourceTree = "<group>"; };
-		00A17B857D4D401A8E89F14A /* AirtableImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirtableImportView.swift; sourceTree = "<group>"; };
-		00A000000000000000000001 /* IndexBuilding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexBuilding.swift; sourceTree = "<group>"; };
-		00A000000000000000000002 /* WikiKindStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiKindStore.swift; sourceTree = "<group>"; };
-		00A000000000000000000003 /* QMDService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QMDService.swift; sourceTree = "<group>"; };
-		00A000000000000000000004 /* NewWikiSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWikiSheet.swift; sourceTree = "<group>"; };
-		00A000000000000000000007 /* LocalStructuredLLM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStructuredLLM.swift; sourceTree = "<group>"; };
-		00A000000000000000000008 /* LocalWikiEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalWikiEngine.swift; sourceTree = "<group>"; };
-		00A000000000000000000009 /* LocalWikiPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalWikiPrompts.swift; sourceTree = "<group>"; };
-		00A000000000000000000010 /* MeetingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCard.swift; sourceTree = "<group>"; };
-		00A000000000000000000011 /* MeetingChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingChunker.swift; sourceTree = "<group>"; };
-		00A000000000000000000012 /* WikiEntityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiEntityResolver.swift; sourceTree = "<group>"; };
-		00A000000000000000000013 /* WikiKindProposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiKindProposer.swift; sourceTree = "<group>"; };
-		00A000000000000000000015 /* GeneratedWikiEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedWikiEngine.swift; sourceTree = "<group>"; };
-		00A000000000000000000016 /* WikiSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiSearchService.swift; sourceTree = "<group>"; };
-		00A000000000000000000017 /* GhostPepperHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostPepperHistoryStore.swift; sourceTree = "<group>"; };
 		0065F99395EEC3EB77997C2C /* CleanupSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupSettings.swift; sourceTree = "<group>"; };
 		016C38149DDDAA03B88E35C0 /* PerformanceTrace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTrace.swift; sourceTree = "<group>"; };
 		01A8B88DFD046F1EC74E5CD6 /* TranscriptionLabStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabStore.swift; sourceTree = "<group>"; };
 		0267B716FEB381C08F172EE6 /* UsageReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageReportView.swift; sourceTree = "<group>"; };
 		029E36727193D8502C69FB38 /* sprite_frame_2@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_2@2x.png"; sourceTree = "<group>"; };
-		0AC7A5C3B9E8424694D7A000 /* cytoscape.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = cytoscape.min.js; sourceTree = "<group>"; };
+		09095C80171572F5C5B3ECDA /* MeetingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCard.swift; sourceTree = "<group>"; };
 		0D91666EEE2CF7B4B78E3061 /* ChordBindingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordBindingStore.swift; sourceTree = "<group>"; };
 		0EDE03E93B2A9E420B2C74CA /* PostPasteLearningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPasteLearningCoordinator.swift; sourceTree = "<group>"; };
 		0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChordTests.swift; sourceTree = "<group>"; };
 		112E1B08BAA94CE3D91F2E00 /* Signing.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Signing.xcconfig; sourceTree = "<group>"; };
 		11E4B61BA7270EEC11A8AC69 /* ScreenRecordingPermissionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordingPermissionController.swift; sourceTree = "<group>"; };
+		145894D3AD8A3F184A9E9854 /* LocalStructuredLLM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStructuredLLM.swift; sourceTree = "<group>"; };
 		14BBAF87158BF49AB528B979 /* SystemAudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemAudioRecorder.swift; sourceTree = "<group>"; };
 		17F70F511A956DAB5778D430 /* WindowCaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureService.swift; sourceTree = "<group>"; };
 		19DE683197A1CFDF171F2F38 /* ghost-pepper-character.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "ghost-pepper-character.png"; sourceTree = "<group>"; };
 		1AC12AC919C182CDEF77DB11 /* CommandKSearchSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandKSearchSheet.swift; sourceTree = "<group>"; };
 		1AFEA05207B7965A3D44D000 /* MeetingQAAgentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingQAAgentTests.swift; sourceTree = "<group>"; };
+		1C82FF777F1863DC84525AC2 /* cytoscape.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = cytoscape.min.js; sourceTree = "<group>"; };
 		1DC632CC6DD4F55F2FA05480 /* FrontmostWindowOCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmostWindowOCRService.swift; sourceTree = "<group>"; };
 		1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogStoreTests.swift; sourceTree = "<group>"; };
 		207AAC1CBC60052D1493D13D /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		231812B1BF8E3F2D5E0209F3 /* ShortcutCaptureStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureStateTests.swift; sourceTree = "<group>"; };
 		23B813180F29336A298BE44E /* LocalLLMCleanupBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLLMCleanupBackend.swift; sourceTree = "<group>"; };
 		24362CABE7BBCAF53CB9B4A8 /* sprite_frame_1.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_1.png; sourceTree = "<group>"; };
+		24F3A28C4C8FDE75A66B93F1 /* GhostPepperHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostPepperHistoryStore.swift; sourceTree = "<group>"; };
 		2715D9117D8664700616D95A /* DebugLogWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogWindow.swift; sourceTree = "<group>"; };
 		2771A24BE8CE83A8BDE8DB0B /* FluidAudioSpeechSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluidAudioSpeechSession.swift; sourceTree = "<group>"; };
 		27AFC0BE8F74723D68B647A6 /* ReaderCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCapture.swift; sourceTree = "<group>"; };
@@ -276,6 +271,7 @@
 		2ADE6885C71A11CEC8B2A50E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2AF744C59EEAE51FC81BE6D6 /* sprite_frame_0.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = sprite_frame_0.png; sourceTree = "<group>"; };
 		2B43697CC08695B8E8F8AD01 /* PromptEditorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptEditorWindow.swift; sourceTree = "<group>"; };
+		2B831886F170626577F143DA /* IndexBuilding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexBuilding.swift; sourceTree = "<group>"; };
 		2CD55E5B8D8B9A82E9774A2C /* AccessibilityWindowTitles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityWindowTitles.swift; sourceTree = "<group>"; };
 		2F22B92A6ECEE8A19C9A5095 /* IndexEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexEntryView.swift; sourceTree = "<group>"; };
 		2F32B8CF5E22FF8A9A5D42E8 /* IndexEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexEntry.swift; sourceTree = "<group>"; };
@@ -285,12 +281,14 @@
 		335E3F3AA3803E2274CF6197 /* TranscriptionLabControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabControllerTests.swift; sourceTree = "<group>"; };
 		338FDBA950D81CE2B3AC4EA0 /* GhostPepperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GhostPepperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		350AC3A5A34A78F96226831C /* CorrectionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionStoreTests.swift; sourceTree = "<group>"; };
+		3549A7875AAEE3CC42F3B223 /* AirtableImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirtableImportView.swift; sourceTree = "<group>"; };
 		35A699887678B31BAF27498A /* MeetingQASystemPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingQASystemPromptTests.swift; sourceTree = "<group>"; };
 		363A3F98CDFC4CCAD927835C /* GhostPepperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhostPepperTests.swift; sourceTree = "<group>"; };
 		37863EC2F34067ED0C5B2B6F /* TextCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleaner.swift; sourceTree = "<group>"; };
 		37C0D4F04FFD2C13DEACA238 /* TextCleanupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanupManager.swift; sourceTree = "<group>"; };
 		38C742095D3934D70BCE44E4 /* RuntimeModelInventoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuntimeModelInventoryTests.swift; sourceTree = "<group>"; };
 		397AC156E3D2AF040A998E68 /* CleanupModelProbeCLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupModelProbeCLI.swift; sourceTree = "<group>"; };
+		3A1396E3728596BB5BE6C451 /* QMDServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QMDServiceTests.swift; sourceTree = "<group>"; };
 		3A4D4E875210CD0DADAF5D7E /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		3A8F478894D0A3A49A91C8CC /* TrelloBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrelloBackend.swift; sourceTree = "<group>"; };
 		3B68F46BA90BDD633868A8CE /* ModelInventoryViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelInventoryViews.swift; sourceTree = "<group>"; };
@@ -301,6 +299,7 @@
 		43A2B55CB980E02EC1E16BF2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		440454805353FB26F7C77E12 /* MeetingWindowHeuristics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingWindowHeuristics.swift; sourceTree = "<group>"; };
 		45CD91720FB67A72CAEF0E9C /* ClaudePricing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudePricing.swift; sourceTree = "<group>"; };
+		4637BBA19A2CAD1BF89D1EC4 /* WikiKindStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiKindStoreTests.swift; sourceTree = "<group>"; };
 		48F971536E7FB4527A61DBC9 /* MarkdownArchivePaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownArchivePaths.swift; sourceTree = "<group>"; };
 		48FD8FBD546233B0547BB89D /* TranscriptionLabRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabRunnerTests.swift; sourceTree = "<group>"; };
 		49848DB685A19FBB6557B76E /* TextCleanerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanerTests.swift; sourceTree = "<group>"; };
@@ -317,16 +316,19 @@
 		5588D5D8742520186BBD4970 /* IndexManifestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexManifestTests.swift; sourceTree = "<group>"; };
 		589AC554EEF132B519736D92 /* HotkeyMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyMonitorTests.swift; sourceTree = "<group>"; };
 		59666FBC728BF70A61983188 /* PerformanceTraceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTraceTests.swift; sourceTree = "<group>"; };
+		5C926BF4341F8D3448FE7096 /* MeetingCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCardTests.swift; sourceTree = "<group>"; };
+		5D080B6685FCD6476F47C97B /* IndexKindCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexKindCodableTests.swift; sourceTree = "<group>"; };
 		5D68EDD354F149B2EF3963B7 /* CleanupModelProbe */ = {isa = PBXFileReference; includeInIndex = 0; path = CleanupModelProbe; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DCEBF68EFD590E3779D72D5 /* DiarizationSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiarizationSummary.swift; sourceTree = "<group>"; };
 		5F85AD0262D40047E6FCA3D8 /* UpdaterController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdaterController.swift; sourceTree = "<group>"; };
-		58A000000000000000000000 /* AppleSpeechAnalyzerBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSpeechAnalyzerBackend.swift; sourceTree = "<group>"; };
+		5FA2814A2B1E8A59525306B6 /* WikiEntityResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiEntityResolver.swift; sourceTree = "<group>"; };
 		624731D133FE2A9EB3A12740 /* MeetingTranscriptSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingTranscriptSettings.swift; sourceTree = "<group>"; };
 		626F06D7734BB38A033B6F48 /* IndexManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexManifest.swift; sourceTree = "<group>"; };
 		648497BCB18036D3B10EADD2 /* MeetingHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingHistory.swift; sourceTree = "<group>"; };
 		64F59E7884CF5A1ABFB3C387 /* PathSandboxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathSandboxTests.swift; sourceTree = "<group>"; };
 		65270DAE5CA7F1A37B4D890B /* ChordEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordEngineTests.swift; sourceTree = "<group>"; };
 		659E43C6D2C350FE7DB967A3 /* PathSandbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathSandbox.swift; sourceTree = "<group>"; };
+		66A5230C9D1EF1BAC0E65DA5 /* WikiSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiSearchService.swift; sourceTree = "<group>"; };
 		6A797BF8671DD4D44E9B1188 /* PepperChatSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PepperChatSession.swift; sourceTree = "<group>"; };
 		6B1A6E1B8F3D8C8F234BD408 /* SpeechTranscriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechTranscriberTests.swift; sourceTree = "<group>"; };
 		6BAE65A5741A98AEADF6498D /* ModelManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManager.swift; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 		6CAEC58BA358D8ED4206D550 /* ChunkedTranscriptionPipeline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChunkedTranscriptionPipeline.swift; sourceTree = "<group>"; };
 		6D736758B588185CCE102504 /* IndexSystemPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSystemPrompt.swift; sourceTree = "<group>"; };
 		6F3496D74914A4B865A1A0DF /* TranscriptionLabSpeakerProfileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabSpeakerProfileStoreTests.swift; sourceTree = "<group>"; };
+		6F68CC2980332BEC494C2FCD /* MeetingChunker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingChunker.swift; sourceTree = "<group>"; };
 		6FEC2E37841B0CF1F320F326 /* ZoBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoBackend.swift; sourceTree = "<group>"; };
 		7201BD31C20BC2B1D0E51DB6 /* CleanupModelProbeRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupModelProbeRunner.swift; sourceTree = "<group>"; };
 		74815C21991689C25D83ACE9 /* SpeakerIdentityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakerIdentityResolverTests.swift; sourceTree = "<group>"; };
@@ -341,6 +344,7 @@
 		777FDA0FC9C05B5D278C6C3E /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		785F5D6EDD25D78F6220268E /* MeetingQAToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingQAToolsTests.swift; sourceTree = "<group>"; };
 		79231C6829FD88741536FF4A /* sprite_frame_0@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_0@2x.png"; sourceTree = "<group>"; };
+		7E73165C63B4179008B8EA59 /* NemotronStreamingModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NemotronStreamingModel.swift; sourceTree = "<group>"; };
 		7ECFAFC0144B6B9203BF4EE0 /* RecognizedVoiceStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecognizedVoiceStoreTests.swift; sourceTree = "<group>"; };
 		7FC3D36DE7AC456246062883 /* IndexListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexListView.swift; sourceTree = "<group>"; };
 		80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOCRPrefetchTests.swift; sourceTree = "<group>"; };
@@ -358,6 +362,7 @@
 		8EC7E1A9685759595E98ABB5 /* BuildIndexSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildIndexSheet.swift; sourceTree = "<group>"; };
 		8F5407DA5D09555EDD69CA54 /* AudioRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorder.swift; sourceTree = "<group>"; };
 		8F95A4E9746B97273AFA6904 /* QAAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAAttachment.swift; sourceTree = "<group>"; };
+		9250554BD8AFCA914A2E0F69 /* GeneratedWikiEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedWikiEngine.swift; sourceTree = "<group>"; };
 		934F425F25CCB580B8202127 /* PasteSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteSession.swift; sourceTree = "<group>"; };
 		9452C09EB8A7AC2E5E69A502 /* GranolaImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GranolaImporter.swift; sourceTree = "<group>"; };
 		948064EDD38AFB0872A99BD6 /* CleanupPromptBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupPromptBuilder.swift; sourceTree = "<group>"; };
@@ -365,6 +370,8 @@
 		94E9AADC67C525B0A9E382AB /* RecordingOCRPrefetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOCRPrefetch.swift; sourceTree = "<group>"; };
 		95281DF90A125CA223FCEE7A /* ContextBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextBubbleView.swift; sourceTree = "<group>"; };
 		960D35875D60655B17574DF8 /* AudioRecorderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderTests.swift; sourceTree = "<group>"; };
+		9666B5433621920087AA3DD4 /* NewWikiSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWikiSheet.swift; sourceTree = "<group>"; };
+		96CABA1D2598574AB426FE8F /* WikiKindStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiKindStore.swift; sourceTree = "<group>"; };
 		97408213D206AAF1B1C29FFC /* PepperChatBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PepperChatBackend.swift; sourceTree = "<group>"; };
 		9A3540C6212101C885EA22CD /* RecordingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOverlay.swift; sourceTree = "<group>"; };
 		9A54422D17879836781B7F71 /* KeyChord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChord.swift; sourceTree = "<group>"; };
@@ -373,6 +380,7 @@
 		9CA473A11BE2285D5F27714C /* ClaudeAPIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeAPIModel.swift; sourceTree = "<group>"; };
 		9E3575D1B5EA81CBB2CD1C2B /* FocusedElementLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedElementLocator.swift; sourceTree = "<group>"; };
 		9FBC0D906FF181E91A758F58 /* FocusedElementLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedElementLocatorTests.swift; sourceTree = "<group>"; };
+		9FD43BF39DAD8F40FE05BFBE /* LocalWikiPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalWikiPrompts.swift; sourceTree = "<group>"; };
 		A1B93B4F9F40EE6BD8525677 /* CleanupModelProbeRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CleanupModelProbeRunnerTests.swift; sourceTree = "<group>"; };
 		A2E051FC96D522216E8C2F01 /* OCRContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRContextTests.swift; sourceTree = "<group>"; };
 		A5F781190896573C3BA687CB /* FluidAudioSpeechSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluidAudioSpeechSessionTests.swift; sourceTree = "<group>"; };
@@ -386,6 +394,7 @@
 		AF04305B5AE9665D25C23A2C /* IndexSystemPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexSystemPromptTests.swift; sourceTree = "<group>"; };
 		AF10422C55DDA1F8B026ADA7 /* QAAnswerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAAnswerView.swift; sourceTree = "<group>"; };
 		AFB9204EC17BB248E71D930A /* LLMProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMProvider.swift; sourceTree = "<group>"; };
+		B00B029C7A13483CD703B723 /* MeetingChunkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingChunkerTests.swift; sourceTree = "<group>"; };
 		B0F0BBC9BB83FDC0739EF319 /* TranscriptionLabRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabRunner.swift; sourceTree = "<group>"; };
 		B112C736F05F0A7CFA7784A2 /* MeetingTranscriptWindowPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingTranscriptWindowPresentationTests.swift; sourceTree = "<group>"; };
 		B15111386E6EE359ACF9BF66 /* MeetingWindowHeuristicsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingWindowHeuristicsTests.swift; sourceTree = "<group>"; };
@@ -393,6 +402,7 @@
 		B7327B46CAF5B3DDE5325601 /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
 		B8760607B80C14BCBD5F9FC0 /* TextPasterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextPasterTests.swift; sourceTree = "<group>"; };
 		B89E71C9D2C08957AB78FA5E /* GranolaImportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GranolaImportView.swift; sourceTree = "<group>"; };
+		B91548F1CB636E180B4CA92C /* WikiEntityResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiEntityResolverTests.swift; sourceTree = "<group>"; };
 		BA57E9C267251FC86A8C8672 /* PhysicalKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhysicalKey.swift; sourceTree = "<group>"; };
 		BB052D817F3005B509E9D479 /* DebugLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogStore.swift; sourceTree = "<group>"; };
 		BC2402355479C57FB26A884B /* IndexKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IndexKind.swift; sourceTree = "<group>"; };
@@ -406,12 +416,16 @@
 		CA0C0CBEADEB8791C4D738B1 /* ModelsSidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsSidebarView.swift; sourceTree = "<group>"; };
 		CC0F71B32FF6973FD42639C7 /* ModelInventory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelInventory.swift; sourceTree = "<group>"; };
 		CCE81899A3B0F5CB9777BD6A /* TextCleanupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleanupManager.swift; sourceTree = "<group>"; };
+		CD43D666CB62342B723A1C98 /* QMDService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QMDService.swift; sourceTree = "<group>"; };
 		CDB3BCEA6FF268C1759D1F20 /* OCRContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRContext.swift; sourceTree = "<group>"; };
 		CE672F443903BF4B47EF96EF /* MeetingDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetector.swift; sourceTree = "<group>"; };
+		CF0879FCBD94CE7356B3E576 /* WikiKindProposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WikiKindProposer.swift; sourceTree = "<group>"; };
+		CFB15E476FA6663CD0A6BE67 /* LocalWikiEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalWikiEngine.swift; sourceTree = "<group>"; };
 		CFECDC789B0C81589A3D6B69 /* CorrectionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionStore.swift; sourceTree = "<group>"; };
 		D2703FAF4A3B8D55B84100BA /* MarkdownArchivePathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownArchivePathsTests.swift; sourceTree = "<group>"; };
 		D2CC027B53AAE03079D78761 /* SpeechTranscriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechTranscriber.swift; sourceTree = "<group>"; };
 		D6A098A2516C7563B1E4FDD3 /* ModelManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagerTests.swift; sourceTree = "<group>"; };
+		D6F798C98BE9BF562FC97730 /* AirtableImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirtableImporter.swift; sourceTree = "<group>"; };
 		D7E1E5A0F12FE2B2FB5CD874 /* TranscriptionLabController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabController.swift; sourceTree = "<group>"; };
 		D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabStoreTests.swift; sourceTree = "<group>"; };
 		DB753C40197FA7255E1DEA29 /* PepperChatWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PepperChatWindow.swift; sourceTree = "<group>"; };
@@ -425,6 +439,7 @@
 		E1E1B6653DAE6ED42FE9910B /* MeetingTranscriptWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingTranscriptWindow.swift; sourceTree = "<group>"; };
 		E45DE13042196F9DF2445E66 /* OCRRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRRequestFactory.swift; sourceTree = "<group>"; };
 		E5A9294BC5DAF7D7ED625ECD /* TrelloCommandParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrelloCommandParser.swift; sourceTree = "<group>"; };
+		E8C67C4751B4243F33B01113 /* AppleSpeechAnalyzerBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSpeechAnalyzerBackend.swift; sourceTree = "<group>"; };
 		E9369F8E6A32A99F693A5DF3 /* QAEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QAEvent.swift; sourceTree = "<group>"; };
 		EAF6390CFE5F526DD23C316D /* AudioDeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDeviceManager.swift; sourceTree = "<group>"; };
 		EBAB39218D09F11336C4F684 /* TextCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextCleaner.swift; sourceTree = "<group>"; };
@@ -460,8 +475,9 @@
 			files = (
 				D0C9E92678ECFF9228D0B7F0 /* WhisperKit in Frameworks */,
 				9965C422E2E6A1F48E717C28 /* FluidAudio in Frameworks */,
-				666D2339FC0689F41A3AE715 /* LLM in Frameworks */,
-				A31E9987608164A53D5255EB /* Sparkle in Frameworks */,
+				666D2339FC0689F41A3AE715 /* MLXAudioSTT in Frameworks */,
+				A31E9987608164A53D5255EB /* LLM in Frameworks */,
+				66CFEC09452F5F23E9747669 /* Sparkle in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -532,7 +548,7 @@
 				B242BF76D6E42784C2A05EB5 /* Transcription */,
 				50C964CA46111D1FD8AFE84B /* UI */,
 				BD5B7BB40BFF38FE122102AC /* UsageStats */,
-				00C000000000000000000001 /* Wiki */,
+				4EAAE0DE183F29879C8A07C7 /* Wiki */,
 			);
 			path = GhostPepper;
 			sourceTree = "<group>";
@@ -562,9 +578,9 @@
 				659E43C6D2C350FE7DB967A3 /* PathSandbox.swift */,
 				E9369F8E6A32A99F693A5DF3 /* QAEvent.swift */,
 				F2387F1E285001F18E98F967 /* QATranscript.swift */,
-				00A000000000000000000003 /* QMDService.swift */,
-				00A000000000000000000016 /* WikiSearchService.swift */,
+				CD43D666CB62342B723A1C98 /* QMDService.swift */,
 				4EAB6FB92135AD07ACA34963 /* QwenToolCallParser.swift */,
+				66A5230C9D1EF1BAC0E65DA5 /* WikiSearchService.swift */,
 			);
 			path = QA;
 			sourceTree = "<group>";
@@ -615,6 +631,7 @@
 		4694A9A6CDA9C5FA6623F377 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				1C82FF777F1863DC84525AC2 /* cytoscape.min.js */,
 				19DE683197A1CFDF171F2F38 /* ghost-pepper-character.png */,
 				2AF744C59EEAE51FC81BE6D6 /* sprite_frame_0.png */,
 				79231C6829FD88741536FF4A /* sprite_frame_0@2x.png */,
@@ -626,7 +643,6 @@
 				FA48EF56983A55149A084D1B /* sprite_frame_3@2x.png */,
 				E02A8770518755585231EA8E /* sprite_frame_4.png */,
 				E0BBD0F5DD1B827D03F0F8F6 /* sprite_frame_4@2x.png */,
-				0AC7A5C3B9E8424694D7A000 /* cytoscape.min.js */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -646,7 +662,7 @@
 			isa = PBXGroup;
 			children = (
 				2CD55E5B8D8B9A82E9774A2C /* AccessibilityWindowTitles.swift */,
-				00A17B837D4D401A8E89F14A /* AirtableImporter.swift */,
+				D6F798C98BE9BF562FC97730 /* AirtableImporter.swift */,
 				9452C09EB8A7AC2E5E69A502 /* GranolaImporter.swift */,
 				CE672F443903BF4B47EF96EF /* MeetingDetector.swift */,
 				648497BCB18036D3B10EADD2 /* MeetingHistory.swift */,
@@ -660,10 +676,26 @@
 			path = Meeting;
 			sourceTree = "<group>";
 		};
+		4EAAE0DE183F29879C8A07C7 /* Wiki */ = {
+			isa = PBXGroup;
+			children = (
+				9250554BD8AFCA914A2E0F69 /* GeneratedWikiEngine.swift */,
+				24F3A28C4C8FDE75A66B93F1 /* GhostPepperHistoryStore.swift */,
+				145894D3AD8A3F184A9E9854 /* LocalStructuredLLM.swift */,
+				CFB15E476FA6663CD0A6BE67 /* LocalWikiEngine.swift */,
+				9FD43BF39DAD8F40FE05BFBE /* LocalWikiPrompts.swift */,
+				09095C80171572F5C5B3ECDA /* MeetingCard.swift */,
+				6F68CC2980332BEC494C2FCD /* MeetingChunker.swift */,
+				5FA2814A2B1E8A59525306B6 /* WikiEntityResolver.swift */,
+				CF0879FCBD94CE7356B3E576 /* WikiKindProposer.swift */,
+			);
+			path = Wiki;
+			sourceTree = "<group>";
+		};
 		50C964CA46111D1FD8AFE84B /* UI */ = {
 			isa = PBXGroup;
 			children = (
-				00A17B857D4D401A8E89F14A /* AirtableImportView.swift */,
+				3549A7875AAEE3CC42F3B223 /* AirtableImportView.swift */,
 				8EC7E1A9685759595E98ABB5 /* BuildIndexSheet.swift */,
 				1AC12AC919C182CDEF77DB11 /* CommandKSearchSheet.swift */,
 				95281DF90A125CA223FCEE7A /* ContextBubbleView.swift */,
@@ -676,7 +708,7 @@
 				AACCB8CD3CFA3BA1C91B5B87 /* MenuBarView.swift */,
 				3B68F46BA90BDD633868A8CE /* ModelInventoryViews.swift */,
 				CA0C0CBEADEB8791C4D738B1 /* ModelsSidebarView.swift */,
-				00A000000000000000000004 /* NewWikiSheet.swift */,
+				9666B5433621920087AA3DD4 /* NewWikiSheet.swift */,
 				F0EBA7ECAEFCAC714F83C2C5 /* OnboardingWindow.swift */,
 				DB753C40197FA7255E1DEA29 /* PepperChatWindow.swift */,
 				2B43697CC08695B8E8F8AD01 /* PromptEditorWindow.swift */,
@@ -747,32 +779,16 @@
 			children = (
 				DCF8311B6325214FE6B40CDE /* IndexBuilder.swift */,
 				F14601041CEB40DAB3828382 /* IndexBuildEvent.swift */,
-				00A000000000000000000001 /* IndexBuilding.swift */,
+				2B831886F170626577F143DA /* IndexBuilding.swift */,
 				2F32B8CF5E22FF8A9A5D42E8 /* IndexEntry.swift */,
 				AC8BC15638B3E29136594B44 /* IndexEntryFile.swift */,
 				BC2402355479C57FB26A884B /* IndexKind.swift */,
 				626F06D7734BB38A033B6F48 /* IndexManifest.swift */,
 				6D736758B588185CCE102504 /* IndexSystemPrompt.swift */,
 				48F971536E7FB4527A61DBC9 /* MarkdownArchivePaths.swift */,
-				00A000000000000000000002 /* WikiKindStore.swift */,
+				96CABA1D2598574AB426FE8F /* WikiKindStore.swift */,
 			);
 			path = Indexing;
-			sourceTree = "<group>";
-		};
-		00C000000000000000000001 /* Wiki */ = {
-			isa = PBXGroup;
-			children = (
-				00A000000000000000000007 /* LocalStructuredLLM.swift */,
-				00A000000000000000000015 /* GeneratedWikiEngine.swift */,
-				00A000000000000000000017 /* GhostPepperHistoryStore.swift */,
-				00A000000000000000000008 /* LocalWikiEngine.swift */,
-				00A000000000000000000009 /* LocalWikiPrompts.swift */,
-				00A000000000000000000010 /* MeetingCard.swift */,
-				00A000000000000000000011 /* MeetingChunker.swift */,
-				00A000000000000000000012 /* WikiEntityResolver.swift */,
-				00A000000000000000000013 /* WikiKindProposer.swift */,
-			);
-			path = Wiki;
 			sourceTree = "<group>";
 		};
 		A02E15F442CE34FDC04742D1 = {
@@ -790,11 +806,12 @@
 		B242BF76D6E42784C2A05EB5 /* Transcription */ = {
 			isa = PBXGroup;
 			children = (
-				58A000000000000000000000 /* AppleSpeechAnalyzerBackend.swift */,
+				E8C67C4751B4243F33B01113 /* AppleSpeechAnalyzerBackend.swift */,
 				6CAEC58BA358D8ED4206D550 /* ChunkedTranscriptionPipeline.swift */,
 				5DCEBF68EFD590E3779D72D5 /* DiarizationSummary.swift */,
 				2771A24BE8CE83A8BDE8DB0B /* FluidAudioSpeechSession.swift */,
 				6BAE65A5741A98AEADF6498D /* ModelManager.swift */,
+				7E73165C63B4179008B8EA59 /* NemotronStreamingModel.swift */,
 				F5DEE2CB8B9ED5B0CAE8C152 /* RecordingSessionCoordinator.swift */,
 				BD317A8D8E749E5596734DB7 /* SpeechModelCatalog.swift */,
 				D2CC027B53AAE03079D78761 /* SpeechTranscriber.swift */,
@@ -876,10 +893,13 @@
 				589AC554EEF132B519736D92 /* HotkeyMonitorTests.swift */,
 				53B62D588B7637FC35F1EC0B /* IndexBuilderHelpersTests.swift */,
 				FA652178AA004E557356FA93 /* IndexEntryFileTests.swift */,
+				5D080B6685FCD6476F47C97B /* IndexKindCodableTests.swift */,
 				5588D5D8742520186BBD4970 /* IndexManifestTests.swift */,
 				AF04305B5AE9665D25C23A2C /* IndexSystemPromptTests.swift */,
 				0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */,
 				D2703FAF4A3B8D55B84100BA /* MarkdownArchivePathsTests.swift */,
+				5C926BF4341F8D3448FE7096 /* MeetingCardTests.swift */,
+				B00B029C7A13483CD703B723 /* MeetingChunkerTests.swift */,
 				1AFEA05207B7965A3D44D000 /* MeetingQAAgentTests.swift */,
 				35A699887678B31BAF27498A /* MeetingQASystemPromptTests.swift */,
 				785F5D6EDD25D78F6220268E /* MeetingQAToolsTests.swift */,
@@ -891,6 +911,7 @@
 				64F59E7884CF5A1ABFB3C387 /* PathSandboxTests.swift */,
 				59666FBC728BF70A61983188 /* PerformanceTraceTests.swift */,
 				ABAC2D0F6C311FB1DA3E9ABF /* PostPasteLearningCoordinatorTests.swift */,
+				3A1396E3728596BB5BE6C451 /* QMDServiceTests.swift */,
 				7ECFAFC0144B6B9203BF4EE0 /* RecognizedVoiceStoreTests.swift */,
 				80731398639640F62FFC4524 /* RecordingOCRPrefetchTests.swift */,
 				AD0C972BC69839C41ACA2E8C /* RecordingSessionCoordinatorTests.swift */,
@@ -906,6 +927,8 @@
 				48FD8FBD546233B0547BB89D /* TranscriptionLabRunnerTests.swift */,
 				6F3496D74914A4B865A1A0DF /* TranscriptionLabSpeakerProfileStoreTests.swift */,
 				D7EC6EEC8F041DE99399C3E3 /* TranscriptionLabStoreTests.swift */,
+				B91548F1CB636E180B4CA92C /* WikiEntityResolverTests.swift */,
+				4637BBA19A2CAD1BF89D1EC4 /* WikiKindStoreTests.swift */,
 			);
 			path = GhostPepperTests;
 			sourceTree = "<group>";
@@ -929,6 +952,7 @@
 			packageProductDependencies = (
 				51FBB4B31E8E9293DC11143E /* WhisperKit */,
 				23213B149CFD96C7F4B7B0F5 /* FluidAudio */,
+				856273CF717253EE0B84C6ED /* MLXAudioSTT */,
 				985AD96FDE69D89C0B2DA245 /* LLM */,
 				52CD995A5FADA02097BCD33F /* Sparkle */,
 			);
@@ -1001,6 +1025,7 @@
 			packageReferences = (
 				3BC7A258ECE1E44892C0C351 /* XCRemoteSwiftPackageReference "FluidAudio" */,
 				FF5143DA3A0A948A0A7F982D /* XCRemoteSwiftPackageReference "LLM.swift" */,
+				3848E5026D7AAA09B527B2DD /* XCRemoteSwiftPackageReference "mlx-audio-swift" */,
 				7193259C7B8193E12A21EF21 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				E56E28037799FE95D6CB5F71 /* XCRemoteSwiftPackageReference "WhisperKit" */,
 			);
@@ -1022,6 +1047,7 @@
 			files = (
 				9BE17BC60B1F9CFD3747A844 /* Assets.xcassets in Resources */,
 				0B50B23BDEAFA03CE3FFA368 /* Secrets.example in Resources */,
+				0906BD4E84CEB5BD6B746876 /* cytoscape.min.js in Resources */,
 				BF5FCF390A41E50CEF527720 /* ghost-pepper-character.png in Resources */,
 				0A1823314AE4FF4E17DCF627 /* sprite_frame_0.png in Resources */,
 				527B55EBCA9ACB4EC0FBC618 /* sprite_frame_0@2x.png in Resources */,
@@ -1033,7 +1059,6 @@
 				9FF4377D176BB2AE30E4B08B /* sprite_frame_3@2x.png in Resources */,
 				5473AA5B45F41F058B0503A0 /* sprite_frame_4.png in Resources */,
 				1EF06A7EA54855634307E6A8 /* sprite_frame_4@2x.png in Resources */,
-				0AC7A5C3B9E8424694D7A001 /* cytoscape.min.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1046,9 +1071,12 @@
 			files = (
 				9702D125E2DECC58D973E80F /* AccessibilityWindowTitles.swift in Sources */,
 				124405C2042DC7A4D8C3BCBC /* AgentBackend.swift in Sources */,
+				CBA6939BF3E98BAD81D0A41F /* AirtableImportView.swift in Sources */,
+				8F765C2E7A9ACA6878E1EC02 /* AirtableImporter.swift in Sources */,
 				117E06290C6E2BB843E9BEBF /* AnthropicProvider.swift in Sources */,
 				B4F9DA24EDE1C2CCDDC80AE5 /* AppRelauncher.swift in Sources */,
 				A9E5AB4DC4D58FB4C50A1B23 /* AppState.swift in Sources */,
+				D6557CAE938DA4B11B4B1C38 /* AppleSpeechAnalyzerBackend.swift in Sources */,
 				780CB9207962633AEE3E69BD /* AudioDeviceManager.swift in Sources */,
 				4EAE492B8F7F4CB18D2E0FE9 /* AudioRecorder.swift in Sources */,
 				250BFD8AD225CE0845C4C516 /* BuildIndexSheet.swift in Sources */,
@@ -1063,8 +1091,6 @@
 				1AB34878C4E7E375F34A1339 /* CleanupModelProbeRunner.swift in Sources */,
 				1D533340C55B7F67AE1B4E94 /* CleanupPromptBuilder.swift in Sources */,
 				17AF31EA19761CA8B7DF5F9A /* CleanupSettings.swift in Sources */,
-				00A17B867D4D401A8E89F14A /* AirtableImportView.swift in Sources */,
-				00A17B847D4D401A8E89F14A /* AirtableImporter.swift in Sources */,
 				9A6A342D232B4D11E8604B89 /* CommandKSearchSheet.swift in Sources */,
 				38CDCD968C2E4EBA2F8C59A5 /* ContextBubbleView.swift in Sources */,
 				2BEB4B4A879A749C8B92BE44 /* CorrectionStore.swift in Sources */,
@@ -1075,7 +1101,9 @@
 				761730C7D555A5E165541B02 /* FluidAudioSpeechSession.swift in Sources */,
 				58786AC40C6823691E15369C /* FocusedElementLocator.swift in Sources */,
 				2911F1771ED7BA232F973EC1 /* FrontmostWindowOCRService.swift in Sources */,
+				0D3CC162174A2BD3F96D1179 /* GeneratedWikiEngine.swift in Sources */,
 				31E37E3EDDB8A0E5011BCA54 /* GhostPepperApp.swift in Sources */,
+				8DACA8CFD1EACC324B9F0A42 /* GhostPepperHistoryStore.swift in Sources */,
 				B3DB833B0C853CCB9A2C52ED /* GoogleCalendarService.swift in Sources */,
 				8323B1A2E48B64B493939727 /* GranolaImportView.swift in Sources */,
 				41585ECBAFB5534CB6AE4FC5 /* GranolaImporter.swift in Sources */,
@@ -1083,7 +1111,7 @@
 				BF329CF451CC34A3B74348CC /* HotkeyMonitor.swift in Sources */,
 				74C8907D76A8E0433442CA77 /* IndexBuildEvent.swift in Sources */,
 				C5D011A82469050DF1E7F462 /* IndexBuilder.swift in Sources */,
-				00B000000000000000000001 /* IndexBuilding.swift in Sources */,
+				A53F4F79DB112740AF5F3262 /* IndexBuilding.swift in Sources */,
 				269C54824B06E5918813D297 /* IndexEntry.swift in Sources */,
 				A9DB6627D058705A602BED84 /* IndexEntryFile.swift in Sources */,
 				9F0C599099252C3E7C8846F2 /* IndexEntryView.swift in Sources */,
@@ -1096,15 +1124,13 @@
 				B8877739DF84D885A825C19F /* LLMProvider.swift in Sources */,
 				CC795C47BAF8CEF62790BAFF /* LocalLLMCleanupBackend.swift in Sources */,
 				8F4C6360C1304C4A145DC34F /* LocalLLMProvider.swift in Sources */,
-				00B000000000000000000007 /* LocalStructuredLLM.swift in Sources */,
-				00B000000000000000000015 /* GeneratedWikiEngine.swift in Sources */,
-				00B000000000000000000017 /* GhostPepperHistoryStore.swift in Sources */,
-				00B000000000000000000008 /* LocalWikiEngine.swift in Sources */,
-				00B000000000000000000009 /* LocalWikiPrompts.swift in Sources */,
+				7B7F8B9645EEDA1A331EE280 /* LocalStructuredLLM.swift in Sources */,
+				218AE026F8527BA4AA4F6AC1 /* LocalWikiEngine.swift in Sources */,
+				E345F0200A178136FDE7BC43 /* LocalWikiPrompts.swift in Sources */,
 				736FB3EB1125A9A9D328400E /* MarkdownArchivePaths.swift in Sources */,
 				FCEE3C748338E66F1246B917 /* MediaPlaybackController.swift in Sources */,
-				00B000000000000000000010 /* MeetingCard.swift in Sources */,
-				00B000000000000000000011 /* MeetingChunker.swift in Sources */,
+				3123B94EC8D14C4679E20918 /* MeetingCard.swift in Sources */,
+				746CDB0CF3373CFFA79071A0 /* MeetingChunker.swift in Sources */,
 				47B377ADA2B2F12226744122 /* MeetingDetector.swift in Sources */,
 				C6F4C6C95E2835A2EEB58861 /* MeetingHistory.swift in Sources */,
 				52583C82CF1B27757D2154DC /* MeetingMarkdownWriter.swift in Sources */,
@@ -1120,10 +1146,10 @@
 				5589DDF10DE9446993C99B6B /* MenuBarView.swift in Sources */,
 				9A7637F5576B21D74F14149D /* ModelInventory.swift in Sources */,
 				C1A07FBD7318A26BA879232A /* ModelInventoryViews.swift in Sources */,
-				58A000000000000000000001 /* AppleSpeechAnalyzerBackend.swift in Sources */,
 				5AC883ADFD11721A8E9E4D37 /* ModelManager.swift in Sources */,
 				CD1993731E37C507B43CED9F /* ModelsSidebarView.swift in Sources */,
-				00B000000000000000000004 /* NewWikiSheet.swift in Sources */,
+				4BB6E415F122404580A7C80D /* NemotronStreamingModel.swift in Sources */,
+				7CCC6CA01DEFDE524CC8747F /* NewWikiSheet.swift in Sources */,
 				5AFD58B50823656E71CF3AA9 /* OCRContext.swift in Sources */,
 				CBDE26BEEBD0419A73D09DFC /* OCRRequestFactory.swift in Sources */,
 				CE62853358A180E54150BCA4 /* OnboardingWindow.swift in Sources */,
@@ -1141,8 +1167,7 @@
 				ACC06182C51F75BDF79E571E /* QAAttachment.swift in Sources */,
 				FD49BB359F176351FCAB7BBC /* QAEvent.swift in Sources */,
 				E30E215812243E696D4BA75F /* QATranscript.swift in Sources */,
-				00B000000000000000000003 /* QMDService.swift in Sources */,
-				00B000000000000000000016 /* WikiSearchService.swift in Sources */,
+				08C38FC1FE9822CA8FB68728 /* QMDService.swift in Sources */,
 				A5C0FD97A59CA8F8AACCF328 /* QwenToolCallParser.swift in Sources */,
 				ED6279A88A99C00B4F6C49CC /* ReaderCapture.swift in Sources */,
 				1F0BFAEE62163EFA88F3F19C /* ReaderCaptureSheet.swift in Sources */,
@@ -1173,9 +1198,10 @@
 				829C83DF25112D375A8DB767 /* UpdaterController.swift in Sources */,
 				3867702A684F28E1B31A4440 /* UsageReportView.swift in Sources */,
 				9114B9CC3A96A49F51A622A8 /* UsageStatsStore.swift in Sources */,
-				00B000000000000000000012 /* WikiEntityResolver.swift in Sources */,
-				00B000000000000000000002 /* WikiKindStore.swift in Sources */,
-				00B000000000000000000013 /* WikiKindProposer.swift in Sources */,
+				2FC02F0B70C62E6E4EEC8FE6 /* WikiEntityResolver.swift in Sources */,
+				A696504AAE0D7BCC4E066EFF /* WikiKindProposer.swift in Sources */,
+				660C682858BDA505AF802113 /* WikiKindStore.swift in Sources */,
+				005DF679067DC503DDB078D8 /* WikiSearchService.swift in Sources */,
 				750B0226D3A035D24259B606 /* WindowCaptureService.swift in Sources */,
 				3B8354B1BAACB0F28DF98815 /* ZoBackend.swift in Sources */,
 			);
@@ -1220,10 +1246,13 @@
 				637A68B05AD8479E0B5D52A7 /* HotkeyMonitorTests.swift in Sources */,
 				FD7B709BD5FB256BB5EAB2FB /* IndexBuilderHelpersTests.swift in Sources */,
 				3ED58FA92E41F5A79A1190AF /* IndexEntryFileTests.swift in Sources */,
+				61D05926E16756EAD4EC13C6 /* IndexKindCodableTests.swift in Sources */,
 				3653237D6C0C44E3AFF33800 /* IndexManifestTests.swift in Sources */,
 				5A4D2E405B6F7A519BA6F6F0 /* IndexSystemPromptTests.swift in Sources */,
 				AB0AC6DC19EC0DB440F5B123 /* KeyChordTests.swift in Sources */,
 				EA0A1ECE203067342B2E2CF6 /* MarkdownArchivePathsTests.swift in Sources */,
+				E7165BCC53E626252EC92C98 /* MeetingCardTests.swift in Sources */,
+				160D6AB39F87C2045BE156F4 /* MeetingChunkerTests.swift in Sources */,
 				4961DAF729CE58AAAACBC1AC /* MeetingQAAgentTests.swift in Sources */,
 				190EA523BC8AAF93599DD038 /* MeetingQASystemPromptTests.swift in Sources */,
 				04654E621041E2A81CC2CFC7 /* MeetingQAToolsTests.swift in Sources */,
@@ -1235,6 +1264,7 @@
 				B48B6FC5DEAB303E1A2DE5DC /* PathSandboxTests.swift in Sources */,
 				E3302E239909CAEC0865A035 /* PerformanceTraceTests.swift in Sources */,
 				41C94A48B97D3A6861EA1E92 /* PostPasteLearningCoordinatorTests.swift in Sources */,
+				6A1BF15DDA0E15BFE4BB4426 /* QMDServiceTests.swift in Sources */,
 				4FCEB4322F0DA8C7F6FFD12D /* RecognizedVoiceStoreTests.swift in Sources */,
 				4DD74E9C222518EEB0DA2A9B /* RecordingOCRPrefetchTests.swift in Sources */,
 				2E80774D95EAC6D6B53A226D /* RecordingSessionCoordinatorTests.swift in Sources */,
@@ -1250,6 +1280,8 @@
 				950E9B7AB1223E2B2D679B71 /* TranscriptionLabRunnerTests.swift in Sources */,
 				37669DE8B07FA0D5E77661ED /* TranscriptionLabSpeakerProfileStoreTests.swift in Sources */,
 				09DA02222FFAFD8F32DB0212 /* TranscriptionLabStoreTests.swift in Sources */,
+				4051A9E01314A93D67C6F850 /* WikiEntityResolverTests.swift in Sources */,
+				0BC51EE5185DD2A114A4639D /* WikiKindStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1264,15 +1296,15 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-			1E4BC3C9A2D9995B5339A1F0 /* Release */ = {
-				isa = XCBuildConfiguration;
-				baseConfigurationReference = 112E1B08BAA94CE3D91F2E00 /* Signing.xcconfig */;
-				buildSettings = {
-					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-					CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-					CODE_SIGN_ENTITLEMENTS = GhostPepper/GhostPepper.entitlements;
-					COMBINE_HIDPI_IMAGES = YES;
-					ENABLE_APP_SANDBOX = NO;
+		1E4BC3C9A2D9995B5339A1F0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 112E1B08BAA94CE3D91F2E00 /* Signing.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = GhostPepper/GhostPepper.entitlements;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = GhostPepper/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1409,15 +1441,15 @@
 			};
 			name = Debug;
 		};
-			E539A0CB0CD4C3B8D54B2855 /* Debug */ = {
-				isa = XCBuildConfiguration;
-				baseConfigurationReference = 112E1B08BAA94CE3D91F2E00 /* Signing.xcconfig */;
-				buildSettings = {
-					ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-					CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-					CODE_SIGN_ENTITLEMENTS = GhostPepper/GhostPepper.entitlements;
-					COMBINE_HIDPI_IMAGES = YES;
-					ENABLE_APP_SANDBOX = NO;
+		E539A0CB0CD4C3B8D54B2855 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 112E1B08BAA94CE3D91F2E00 /* Signing.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = GhostPepper/GhostPepper.entitlements;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = GhostPepper/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1527,6 +1559,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		3848E5026D7AAA09B527B2DD /* XCRemoteSwiftPackageReference "mlx-audio-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/obra/mlx-audio-swift.git";
+			requirement = {
+				kind = revision;
+				revision = 6361aebbb1e580fffac4e00241413fe018d73b0c;
+			};
+		};
 		3BC7A258ECE1E44892C0C351 /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/FluidInference/FluidAudio.git";
@@ -1581,6 +1621,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7193259C7B8193E12A21EF21 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		856273CF717253EE0B84C6ED /* MLXAudioSTT */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3848E5026D7AAA09B527B2DD /* XCRemoteSwiftPackageReference "mlx-audio-swift" */;
+			productName = MLXAudioSTT;
 		};
 		985AD96FDE69D89C0B2DA245 /* LLM */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/GhostPepper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GhostPepper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "d796bec25efd1f5ec2afefa21d753b6c87f3ae242ee15946fcde1a26b94bd84b",
+  "originHash" : "07feb133d32e73194686664069e1ef79ff0e234a7ba9e204a685dd38b4a8657f",
   "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
@@ -17,6 +26,32 @@
       "state" : {
         "branch" : "main",
         "revision" : "c2144e1a0e29c280ec6080b7da85e876d51f8509"
+      }
+    },
+    {
+      "identity" : "mlx-audio-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/obra/mlx-audio-swift.git",
+      "state" : {
+        "revision" : "6361aebbb1e580fffac4e00241413fe018d73b0c"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version" : "3.31.4"
       }
     },
     {
@@ -47,6 +82,15 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -65,6 +109,15 @@
       }
     },
     {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
       "identity" : "swift-jinja",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
@@ -74,12 +127,39 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
         "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
+        "version" : "1.7.5"
       }
     },
     {

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -828,7 +828,9 @@ class AppState: ObservableObject {
                 activeRecordingTranscriptionSession = recordingTranscriptionSessionFactory(
                     speechModelDescriptor
                 )
-            } else if let recordingTranscriptionSession = modelManager.makeRecordingTranscriptionSession() {
+            } else if let recordingTranscriptionSession = modelManager.makeRecordingTranscriptionSession(
+                language: preferredLanguage == "auto" ? nil : preferredLanguage
+            ) {
                 activeRecordingTranscriptionSession = recordingTranscriptionSession
             } else if speechModelDescriptor.backend == .fluidAudio {
                 activeRecordingTranscriptionSession = ChunkedRecordingTranscriptionSession(

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -276,6 +276,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
     private let cleanupModelAvailabilityOverrides: [LocalCleanupModelKind: Bool]
     private let probeExecutionOverride: CleanupModelProbeExecutionOverride?
     private let backendShutdownOverride: (() -> Void)?
+    private let modelsDirectory: URL
     private let probeExecutionGate = CleanupProbeExecutionGate()
     private var promptPrefillTask: Task<Void, Never>?
     private var preparedPromptContext: PreparedPromptContext?
@@ -289,12 +290,14 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         selectedCleanupModelKind: LocalCleanupModelKind? = nil,
         cleanupModelAvailabilityOverrides: [LocalCleanupModelKind: Bool] = [:],
         probeExecutionOverride: CleanupModelProbeExecutionOverride? = nil,
-        backendShutdownOverride: (() -> Void)? = nil
+        backendShutdownOverride: (() -> Void)? = nil,
+        modelsDirectory: URL? = nil
     ) {
         self.defaults = defaults
         self.cleanupModelAvailabilityOverrides = cleanupModelAvailabilityOverrides
         self.probeExecutionOverride = probeExecutionOverride
         self.backendShutdownOverride = backendShutdownOverride
+        self.modelsDirectory = modelsDirectory ?? Self.modelsDirectory
 
         let storedKind = LocalCleanupModelKind(
             rawValue: defaults.string(forKey: Self.selectedCleanupModelDefaultsKey) ?? ""
@@ -322,10 +325,6 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         case .error:
             return errorMessage ?? "Cleanup model error"
         }
-    }
-
-    private var modelsDirectory: URL {
-        Self.modelsDirectory
     }
 
     private func modelPath(for fileName: String) -> URL {

--- a/GhostPepper/QA/MeetingQATools.swift
+++ b/GhostPepper/QA/MeetingQATools.swift
@@ -45,7 +45,10 @@ struct MeetingQATools {
         // get context "for free" without needing a follow-up read_file. grep
         // emits "--" separators between non-adjacent match groups; we split
         // on those and cap by group count rather than raw line count.
-        var args: [String] = ["-r", "-n", "--include=*.md", "--exclude-dir=.git", "-B", "2", "-A", "2"]
+        let isRipgrep = URL(fileURLWithPath: binary).lastPathComponent == "rg"
+        var args: [String] = isRipgrep
+            ? ["-n", "--glob=*.md", "--glob=!.git/**", "-B", "2", "-A", "2"]
+            : ["-r", "-n", "--include=*.md", "--exclude-dir=.git", "-B", "2", "-A", "2"]
         if caseInsensitive { args.append("-i") }
         args.append("-e")
         args.append(pattern)

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -7,6 +7,7 @@ import WhisperKit
 final class ModelManager: ObservableObject {
     typealias ModelLoadOverride = @MainActor (SpeechModelDescriptor) async throws -> Void
     typealias RetryDelayOverride = @MainActor () async -> Void
+    typealias ModelDeletionOverride = @MainActor (SpeechModelDescriptor) -> Void
     typealias NemotronModelFactory = @MainActor (
         _ repository: String
     ) async throws -> any NemotronStreamingModel
@@ -50,6 +51,7 @@ final class ModelManager: ObservableObject {
 
     private let modelLoadOverride: ModelLoadOverride?
     private let loadRetryDelayOverride: RetryDelayOverride?
+    private let modelDeletionOverride: ModelDeletionOverride?
     private let nemotronModelFactory: NemotronModelFactory?
     private let speechAnalyzerBackendFactory: SpeechAnalyzerBackendFactory?
     private var queuedLoadRequest: (name: String, language: String?)?
@@ -59,12 +61,14 @@ final class ModelManager: ObservableObject {
         modelName: String = SpeechModelCatalog.defaultModelID,
         modelLoadOverride: ModelLoadOverride? = nil,
         loadRetryDelayOverride: RetryDelayOverride? = nil,
+        modelDeletionOverride: ModelDeletionOverride? = nil,
         nemotronModelFactory: NemotronModelFactory? = nil,
         speechAnalyzerBackendFactory: SpeechAnalyzerBackendFactory? = nil
     ) {
         self.modelName = modelName
         self.modelLoadOverride = modelLoadOverride
         self.loadRetryDelayOverride = loadRetryDelayOverride
+        self.modelDeletionOverride = modelDeletionOverride
         self.nemotronModelFactory = nemotronModelFactory
         self.speechAnalyzerBackendFactory = speechAnalyzerBackendFactory
     }
@@ -710,7 +714,11 @@ final class ModelManager: ObservableObject {
         guard model.isSystemManaged == false else {
             return
         }
-        Self.removeCachedModelFiles(for: model)
+        if let modelDeletionOverride = modelDeletionOverride {
+            modelDeletionOverride(model)
+        } else {
+            Self.removeCachedModelFiles(for: model)
+        }
 
         if model.name == modelName {
             clearLoadedModelInstances()

--- a/GhostPepper/Transcription/ModelManager.swift
+++ b/GhostPepper/Transcription/ModelManager.swift
@@ -7,6 +7,9 @@ import WhisperKit
 final class ModelManager: ObservableObject {
     typealias ModelLoadOverride = @MainActor (SpeechModelDescriptor) async throws -> Void
     typealias RetryDelayOverride = @MainActor () async -> Void
+    typealias NemotronModelFactory = @MainActor (
+        _ repository: String
+    ) async throws -> any NemotronStreamingModel
     typealias SpeechAnalyzerBackendFactory = @MainActor (
         _ language: String?
     ) async throws -> any SpeechAnalyzerTranscribing
@@ -19,6 +22,7 @@ final class ModelManager: ObservableObject {
     /// Stored as `Any?` because `Qwen3AsrManager` is `@available(macOS 15, *)`
     /// and the app deploys to macOS 14. Cast at use sites under `#available`.
     private var qwen3AsrManagerStorage: Any?
+    private var nemotronStreamingModel: (any NemotronStreamingModel)?
     private var speechAnalyzerBackend: (any SpeechAnalyzerTranscribing)?
     private var loadedSpeechAnalyzerLanguage: String?
 
@@ -46,6 +50,7 @@ final class ModelManager: ObservableObject {
 
     private let modelLoadOverride: ModelLoadOverride?
     private let loadRetryDelayOverride: RetryDelayOverride?
+    private let nemotronModelFactory: NemotronModelFactory?
     private let speechAnalyzerBackendFactory: SpeechAnalyzerBackendFactory?
     private var queuedLoadRequest: (name: String, language: String?)?
     private var queuedLoadWaiters: [CheckedContinuation<Void, Never>] = []
@@ -54,11 +59,13 @@ final class ModelManager: ObservableObject {
         modelName: String = SpeechModelCatalog.defaultModelID,
         modelLoadOverride: ModelLoadOverride? = nil,
         loadRetryDelayOverride: RetryDelayOverride? = nil,
+        nemotronModelFactory: NemotronModelFactory? = nil,
         speechAnalyzerBackendFactory: SpeechAnalyzerBackendFactory? = nil
     ) {
         self.modelName = modelName
         self.modelLoadOverride = modelLoadOverride
         self.loadRetryDelayOverride = loadRetryDelayOverride
+        self.nemotronModelFactory = nemotronModelFactory
         self.speechAnalyzerBackendFactory = speechAnalyzerBackendFactory
     }
 
@@ -156,6 +163,8 @@ final class ModelManager: ObservableObject {
             case .parakeetV3, .none:
                 try await loadFluidAudioModel(requestedModel)
             }
+        case .mlxAudio:
+            try await loadNemotronModel(requestedModel)
         case .speechAnalyzer:
             try await loadSpeechAnalyzer(language: language)
         }
@@ -225,6 +234,12 @@ final class ModelManager: ObservableObject {
                     let cleaned = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                     return cleaned.isEmpty ? nil : cleaned
                 }
+            case .mlxAudio:
+                return await transcribeWithNemotronStreaming(
+                    audioBuffer: audioBuffer,
+                    model: model,
+                    language: language
+                )
             case .speechAnalyzer:
                 guard let speechAnalyzerBackend else { return nil }
                 return try await speechAnalyzerBackend.transcribe(audioBuffer: audioBuffer)
@@ -235,36 +250,44 @@ final class ModelManager: ObservableObject {
         }
     }
 
-    func makeRecordingTranscriptionSession() -> RecordingTranscriptionSession? {
-        guard let model = SpeechModelCatalog.model(named: modelName),
-              model.backend == .fluidAudio else {
+    func makeRecordingTranscriptionSession(language: String? = nil) -> RecordingTranscriptionSession? {
+        guard let model = SpeechModelCatalog.model(named: modelName) else {
             return nil
         }
 
-        switch model.fluidAudioVariant {
-        case .qwen3AsrInt8:
-            if #available(macOS 15, iOS 18, *),
-               let manager = qwen3AsrManagerStorage as? Qwen3AsrManager {
-                return QwenRecordingTranscriptionSession(asrManager: manager)
-            }
-            return nil
-        case .parakeetV3, .none:
-            guard let fluidAudioModels,
-                  let fluidAudioManager else {
-                return nil
-            }
-            return SlidingWindowRecordingTranscriptionSession(
-                models: fluidAudioModels,
-                fullBufferTranscription: { audioBuffer in
-                    do {
-                        let result = try await fluidAudioManager.transcribe(audioBuffer, source: .microphone)
-                        let cleaned = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-                        return cleaned.isEmpty ? nil : cleaned
-                    } catch {
-                        return nil
-                    }
+        switch model.backend {
+        case .fluidAudio:
+            switch model.fluidAudioVariant {
+            case .qwen3AsrInt8:
+                if #available(macOS 15, iOS 18, *),
+                   let manager = qwen3AsrManagerStorage as? Qwen3AsrManager {
+                    return QwenRecordingTranscriptionSession(asrManager: manager)
                 }
+                return nil
+            case .parakeetV3, .none:
+                guard let fluidAudioModels,
+                      let fluidAudioManager else {
+                    return nil
+                }
+                return SlidingWindowRecordingTranscriptionSession(
+                    models: fluidAudioModels,
+                    fullBufferTranscription: { audioBuffer in
+                        do {
+                            let result = try await fluidAudioManager.transcribe(audioBuffer, source: .microphone)
+                            let cleaned = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                            return cleaned.isEmpty ? nil : cleaned
+                        } catch {
+                            return nil
+                        }
+                    }
+                )
+            }
+        case .mlxAudio:
+            return nemotronStreamingModel?.makeSession(
+                language: model.isEnglishOnly ? "en" : language
             )
+        case .whisperKit, .speechAnalyzer:
+            return nil
         }
     }
 
@@ -506,6 +529,39 @@ final class ModelManager: ObservableObject {
         qwen3AsrManagerStorage = manager
     }
 
+    private func loadNemotronModel(_ model: SpeechModelDescriptor) async throws {
+        guard let repository = model.mlxAudioRepository else {
+            throw NSError(
+                domain: "GhostPepper.ModelManager",
+                code: 500,
+                userInfo: [NSLocalizedDescriptionKey: "Missing MLX repository for \(model.name)"]
+            )
+        }
+
+        if let nemotronModelFactory {
+            nemotronStreamingModel = try await nemotronModelFactory(repository)
+        } else {
+            nemotronStreamingModel = try await MLXNemotronStreamingModel.load(repository: repository)
+        }
+    }
+
+    private func transcribeWithNemotronStreaming(
+        audioBuffer: [Float],
+        model: SpeechModelDescriptor,
+        language: String?
+    ) async -> String? {
+        guard let session = nemotronStreamingModel?.makeSession(
+            language: model.isEnglishOnly ? "en" : language
+        ) else {
+            return nil
+        }
+
+        for chunk in Self.audioChunks(from: audioBuffer, maxCount: 1280) {
+            session.appendAudioChunk(chunk)
+        }
+        return await session.finishTranscription()
+    }
+
     private func resetLoadedModels() {
         clearLoadedModelInstances()
         state = .idle
@@ -517,6 +573,7 @@ final class ModelManager: ObservableObject {
         fluidAudioModels = nil
         sortformerModels = nil
         qwen3AsrManagerStorage = nil
+        nemotronStreamingModel = nil
         speechAnalyzerBackend = nil
         loadedSpeechAnalyzerLanguage = nil
         downloadProgress = nil
@@ -681,6 +738,15 @@ final class ModelManager: ObservableObject {
             case .qwen3AsrInt8:
                 break // Qwen3 cache cleanup handled by FluidAudio internally
             }
+        case .mlxAudio:
+            guard let repository = model.mlxAudioRepository else { return }
+            if let modelDirectory = mlxAudioModelDirectory(for: model) {
+                try? FileManager.default.removeItem(at: modelDirectory)
+            }
+            let hubRepositoryName = repository.replacingOccurrences(of: "/", with: "--")
+            let hubRepositoryDirectory = huggingFaceHubCacheDirectory
+                .appendingPathComponent("models--\(hubRepositoryName)", isDirectory: true)
+            try? FileManager.default.removeItem(at: hubRepositoryDirectory)
         case .speechAnalyzer:
             break
         }
@@ -710,9 +776,50 @@ final class ModelManager: ObservableObject {
                 }
                 return false
             }
+        case .mlxAudio:
+            guard let modelDirectory = mlxAudioModelDirectory(for: model),
+                  FileManager.default.fileExists(
+                      atPath: modelDirectory.appendingPathComponent("config.json").path
+                  ),
+                  let files = try? FileManager.default.contentsOfDirectory(
+                      at: modelDirectory,
+                      includingPropertiesForKeys: [.fileSizeKey]
+                  ) else {
+                return false
+            }
+            return files.contains { file in
+                guard file.pathExtension == "safetensors" else { return false }
+                return (try? file.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0 > 0
+            }
         case .speechAnalyzer:
             return true
         }
+    }
+
+    private static func mlxAudioModelDirectory(for model: SpeechModelDescriptor) -> URL? {
+        guard model.mlxAudioRepository != nil else {
+            return nil
+        }
+        return model.cachePathComponents.reduce(huggingFaceHubCacheDirectory) { partialURL, component in
+            partialURL.appendingPathComponent(component, isDirectory: true)
+        }
+    }
+
+    private static var huggingFaceHubCacheDirectory: URL {
+        let environment = ProcessInfo.processInfo.environment
+        if let hubCache = environment["HF_HUB_CACHE"], hubCache.isEmpty == false {
+            return URL(fileURLWithPath: NSString(string: hubCache).expandingTildeInPath)
+        }
+        if let home = environment["HF_HOME"], home.isEmpty == false {
+            return URL(fileURLWithPath: NSString(string: home).expandingTildeInPath)
+                .appendingPathComponent("hub", isDirectory: true)
+        }
+        if environment["APP_SANDBOX_CONTAINER_ID"] != nil {
+            return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("huggingface/hub", isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache/huggingface/hub", isDirectory: true)
     }
 
     private static var whisperModelsDirectory: URL {

--- a/GhostPepper/Transcription/NemotronStreamingModel.swift
+++ b/GhostPepper/Transcription/NemotronStreamingModel.swift
@@ -1,0 +1,44 @@
+import Foundation
+import MLXAudioSTT
+
+protocol NemotronStreamingModel: AnyObject {
+    func makeSession(language: String?) -> RecordingTranscriptionSession
+}
+
+final class MLXNemotronStreamingModel: NemotronStreamingModel {
+    private let model: NemotronASRModel
+
+    init(model: NemotronASRModel) {
+        self.model = model
+    }
+
+    static func load(repository: String) async throws -> MLXNemotronStreamingModel {
+        let model = try await NemotronASRModel.fromPretrained(repository)
+        return MLXNemotronStreamingModel(model: model)
+    }
+
+    func makeSession(language: String?) -> RecordingTranscriptionSession {
+        NemotronRecordingTranscriptionSession(
+            backend: MLXNemotronStreamSessionBackend(
+                session: model.makeStreamSession(language: language, chunkMs: 1120)
+            )
+        )
+    }
+}
+
+private final class MLXNemotronStreamSessionBackend: NemotronStreamSessionBackend {
+    private let session: NemotronASRStreamSession
+
+    init(session: NemotronASRStreamSession) {
+        self.session = session
+    }
+
+    func step(_ samples: [Float]) {
+        session.step(samples)
+    }
+
+    func finish() -> String {
+        session.finish()
+        return session.text
+    }
+}

--- a/GhostPepper/Transcription/RecordingSessionCoordinator.swift
+++ b/GhostPepper/Transcription/RecordingSessionCoordinator.swift
@@ -10,6 +10,87 @@ protocol RecordingTranscriptionSession: AnyObject {
     func cancel()
 }
 
+protocol NemotronStreamSessionBackend: AnyObject {
+    func step(_ samples: [Float])
+    func finish() -> String
+}
+
+final class NemotronRecordingTranscriptionSession: RecordingTranscriptionSession, @unchecked Sendable {
+    private let backend: NemotronStreamSessionBackend
+    private let stateQueue = DispatchQueue(
+        label: "GhostPepper.NemotronRecordingTranscriptionSession.state"
+    )
+
+    private var isCancelled = false
+    private var isFinishing = false
+    private var appendTask: Task<Void, Never>?
+
+    let allowsBatchFallback = false
+    let supportsConcurrentFinalization = false
+
+    init(backend: NemotronStreamSessionBackend) {
+        self.backend = backend
+    }
+
+    func appendAudioChunk(_ samples: [Float]) {
+        guard samples.isEmpty == false else {
+            return
+        }
+
+        stateQueue.sync {
+            guard isCancelled == false, isFinishing == false else {
+                return
+            }
+
+            let previousTask = appendTask
+            appendTask = Task {
+                _ = await previousTask?.value
+
+                let canProcess = self.stateQueue.sync {
+                    self.isCancelled == false
+                }
+                guard canProcess else {
+                    return
+                }
+
+                self.backend.step(samples)
+            }
+        }
+    }
+
+    func finishTranscription() async -> String? {
+        let finishState = stateQueue.sync { () -> (shouldFinish: Bool, pendingTask: Task<Void, Never>?) in
+            guard isCancelled == false, isFinishing == false else {
+                return (false, nil)
+            }
+
+            isFinishing = true
+            return (true, appendTask)
+        }
+
+        guard finishState.shouldFinish else {
+            return nil
+        }
+
+        _ = await finishState.pendingTask?.value
+
+        guard stateQueue.sync(execute: { isCancelled == false }) else {
+            return nil
+        }
+
+        let transcript = backend.finish()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return transcript.isEmpty ? nil : transcript
+    }
+
+    func cancel() {
+        stateQueue.sync {
+            isCancelled = true
+            isFinishing = true
+        }
+    }
+}
+
 private final class OrderedChunkProcessor {
     private let queue = DispatchQueue(
         label: "GhostPepper.OrderedChunkProcessor.queue",

--- a/GhostPepper/Transcription/SpeechModelCatalog.swift
+++ b/GhostPepper/Transcription/SpeechModelCatalog.swift
@@ -3,6 +3,7 @@ import Foundation
 enum SpeechBackendKind: Equatable {
     case whisperKit
     case fluidAudio
+    case mlxAudio
     case speechAnalyzer
 }
 
@@ -19,6 +20,7 @@ struct SpeechModelDescriptor: Identifiable, Equatable {
     let backend: SpeechBackendKind
     let cachePathComponents: [String]
     let fluidAudioVariant: FluidAudioModelVariant?
+    let mlxAudioRepository: String?
 
     var id: String { name }
 
@@ -31,6 +33,8 @@ struct SpeechModelDescriptor: Identifiable, Equatable {
         case .whisperKit:
             "Whisper \(variantName) (\(pickerTitle.lowercased()))"
         case .fluidAudio:
+            "\(pickerTitle) (\(variantName.lowercased()))"
+        case .mlxAudio:
             "\(pickerTitle) (\(variantName.lowercased()))"
         case .speechAnalyzer:
             pickerTitle
@@ -47,6 +51,10 @@ struct SpeechModelDescriptor: Identifiable, Equatable {
         backend == .speechAnalyzer
     }
 
+    var isEnglishOnly: Bool {
+        name.hasSuffix(".en") || name == SpeechModelCatalog.nemotronSpeechStreamingEnglish.name
+    }
+
     var automaticLanguageLabel: String {
         isSystemManaged ? "System language" : "Auto-detect"
     }
@@ -60,7 +68,8 @@ enum SpeechModelCatalog {
         sizeDescription: "~75 MB",
         backend: .whisperKit,
         cachePathComponents: ["openai", "whisper-tiny.en"],
-        fluidAudioVariant: nil
+        fluidAudioVariant: nil,
+        mlxAudioRepository: nil
     )
 
     static let whisperSmallEnglish = SpeechModelDescriptor(
@@ -70,7 +79,8 @@ enum SpeechModelCatalog {
         sizeDescription: "~466 MB",
         backend: .whisperKit,
         cachePathComponents: ["openai", "whisper-small.en"],
-        fluidAudioVariant: nil
+        fluidAudioVariant: nil,
+        mlxAudioRepository: nil
     )
 
     static let whisperSmallMultilingual = SpeechModelDescriptor(
@@ -80,7 +90,8 @@ enum SpeechModelCatalog {
         sizeDescription: "~466 MB",
         backend: .whisperKit,
         cachePathComponents: ["openai", "whisper-small"],
-        fluidAudioVariant: nil
+        fluidAudioVariant: nil,
+        mlxAudioRepository: nil
     )
 
     static let parakeetV3 = SpeechModelDescriptor(
@@ -90,7 +101,8 @@ enum SpeechModelCatalog {
         sizeDescription: "~1.4 GB",
         backend: .fluidAudio,
         cachePathComponents: ["FluidInference", "parakeet-tdt-0.6b-v3-coreml"],
-        fluidAudioVariant: .parakeetV3
+        fluidAudioVariant: .parakeetV3,
+        mlxAudioRepository: nil
     )
 
     static let qwen3AsrInt8 = SpeechModelDescriptor(
@@ -100,7 +112,36 @@ enum SpeechModelCatalog {
         sizeDescription: "~900 MB",
         backend: .fluidAudio,
         cachePathComponents: [],
-        fluidAudioVariant: .qwen3AsrInt8
+        fluidAudioVariant: .qwen3AsrInt8,
+        mlxAudioRepository: nil
+    )
+
+    static let nemotronSpeechStreamingEnglish = SpeechModelDescriptor(
+        name: "mlx_nemotron-speech-streaming-en-0.6b-8bit",
+        pickerTitle: "Nemotron Speech 0.6B",
+        variantName: "8-bit, English streaming",
+        sizeDescription: "~633 MB",
+        backend: .mlxAudio,
+        cachePathComponents: [
+            "mlx-audio",
+            "animaslabs_nemotron-speech-streaming-en-0.6b-mlx-8bit",
+        ],
+        fluidAudioVariant: nil,
+        mlxAudioRepository: "animaslabs/nemotron-speech-streaming-en-0.6b-mlx-8bit"
+    )
+
+    static let nemotron35Streaming = SpeechModelDescriptor(
+        name: "mlx_nemotron-3.5-asr-streaming-0.6b-8bit",
+        pickerTitle: "Nemotron 3.5 ASR 0.6B",
+        variantName: "8-bit, 40 language-locales",
+        sizeDescription: "~721 MB",
+        backend: .mlxAudio,
+        cachePathComponents: [
+            "mlx-audio",
+            "mlx-community_nemotron-3.5-asr-streaming-0.6b-8bit",
+        ],
+        fluidAudioVariant: nil,
+        mlxAudioRepository: "mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit"
     )
 
     static let speechAnalyzer = SpeechModelDescriptor(
@@ -110,7 +151,8 @@ enum SpeechModelCatalog {
         sizeDescription: "Managed by macOS",
         backend: .speechAnalyzer,
         cachePathComponents: [],
-        fluidAudioVariant: nil
+        fluidAudioVariant: nil,
+        mlxAudioRepository: nil
     )
 
     /// Models that are always selectable on the current OS.
@@ -119,6 +161,8 @@ enum SpeechModelCatalog {
         whisperSmallEnglish,
         whisperSmallMultilingual,
         parakeetV3,
+        nemotronSpeechStreamingEnglish,
+        nemotron35Streaming,
     ]
 
     static var availableModels: [SpeechModelDescriptor] {

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -1333,7 +1333,7 @@ struct SettingsView: View {
                     }
                 }
 
-                if appState.preferredLanguage != "auto" && appState.preferredLanguage != "en" && appState.speechModel.hasSuffix(".en") {
+                if appState.preferredLanguage != "auto" && appState.preferredLanguage != "en" && SpeechModelCatalog.model(named: appState.speechModel)?.isEnglishOnly == true {
                     HStack(spacing: 6) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)

--- a/GhostPepperTests/AnthropicProviderSSETests.swift
+++ b/GhostPepperTests/AnthropicProviderSSETests.swift
@@ -47,7 +47,7 @@ final class AnthropicProviderSSETests: XCTestCase {
         if case .toolUse(let id, let name, let input) = emitted[0] {
             XCTAssertEqual(id, "toolu_abc")
             XCTAssertEqual(name, "grep")
-            XCTAssertEqual(input["pattern"] as? String, "Quinn")
+            XCTAssertEqual(input["pattern"] as? String, "Neville")
         } else {
             XCTFail("Expected .toolUse, got \(emitted[0])")
         }

--- a/GhostPepperTests/CleanupPromptEvalTests.swift
+++ b/GhostPepperTests/CleanupPromptEvalTests.swift
@@ -158,11 +158,15 @@ final class CleanupPromptEvalTests: XCTestCase {
     /// Shared eval runner for any model kind.
     @MainActor
     private func runEvalSuite(modelKind: LocalCleanupModelKind) async throws {
+        guard TextCleanupManager.isModelDownloaded(modelKind) else {
+            throw XCTSkip("Cleanup model \(modelKind.rawValue) not available (not downloaded)")
+        }
+
         let manager = TextCleanupManager(selectedCleanupModelKind: modelKind)
         await manager.loadModel(kind: modelKind)
 
         guard manager.state == .ready else {
-            throw XCTSkip("Cleanup model \(modelKind.rawValue) not available (not downloaded)")
+            throw XCTSkip("Cleanup model \(modelKind.rawValue) could not be loaded")
         }
 
         manager.activeLLM?.seed = 1

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -1290,6 +1290,7 @@ final class GhostPepperTests: XCTestCase {
                 chordBindingStore: ChordBindingStore(defaults: defaults),
                 cleanupSettingsDefaults: defaults
             )
+            appState.loadStoredIntegrationKeysIfNeeded()
 
             XCTAssertTrue(appState.pepperChatEnabled)
         }
@@ -1304,6 +1305,7 @@ final class GhostPepperTests: XCTestCase {
                 chordBindingStore: ChordBindingStore(defaults: defaults),
                 cleanupSettingsDefaults: defaults
             )
+            appState.loadStoredIntegrationKeysIfNeeded()
 
             XCTAssertFalse(appState.pepperChatEnabled)
         }
@@ -1321,6 +1323,7 @@ final class GhostPepperTests: XCTestCase {
                 chordBindingStore: ChordBindingStore(defaults: defaults),
                 cleanupSettingsDefaults: defaults
             )
+            appState.loadStoredIntegrationKeysIfNeeded()
 
             XCTAssertFalse(appState.pepperChatEnabled)
         }

--- a/GhostPepperTests/IndexEntryFileTests.swift
+++ b/GhostPepperTests/IndexEntryFileTests.swift
@@ -73,7 +73,7 @@ final class IndexEntryFileTests: XCTestCase {
         XCTAssertThrowsError(try IndexEntryFile.parse("# Just a heading\n\nNo frontmatter."))
     }
 
-    func testRejectsUnknownIndexType() {
+    func testPreservesUnknownIndexTypeForRemovedCustomWiki() throws {
         let text = """
         ---
         index_type: aliens
@@ -85,7 +85,10 @@ final class IndexEntryFileTests: XCTestCase {
 
         Body
         """
-        XCTAssertThrowsError(try IndexEntryFile.parse(text))
+        let entry = try IndexEntryFile.parse(text)
+
+        XCTAssertEqual(entry.kind.rawValue, "aliens")
+        XCTAssertEqual(entry.kind.displayName, "Aliens")
     }
 
     func testQuotesNamesContainingColons() throws {

--- a/GhostPepperTests/MeetingCardTests.swift
+++ b/GhostPepperTests/MeetingCardTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import GhostPepper
 
+@MainActor
 final class MeetingCardTests: XCTestCase {
     private var tempDir: URL!
 

--- a/GhostPepperTests/MeetingQAToolsTests.swift
+++ b/GhostPepperTests/MeetingQAToolsTests.swift
@@ -48,7 +48,7 @@ final class MeetingQAToolsTests: XCTestCase {
         let result = try await tools.grep(pattern: "Quinn", path: nil, caseInsensitive: true, maxResults: 1)
         let matchLines = result.split(separator: "\n").filter { $0.contains(".md:") }
         XCTAssertEqual(matchLines.count, 1, "Expected exactly 1 match line, got: \(result)")
-        XCTAssertTrue(result.contains("max_results was 1"), "Expected hit-cap meta line: \(result)")
+        XCTAssertTrue(result.contains("max_results hit"), "Expected hit-cap meta line: \(result)")
     }
 
     func testGrepReturnsNoMatchesMessage() async throws {

--- a/GhostPepperTests/ModelManagerTests.swift
+++ b/GhostPepperTests/ModelManagerTests.swift
@@ -30,7 +30,11 @@ final class ModelManagerTests: XCTestCase {
     }
 
     func testDeleteCachedModelNotifiesObserversForInventoryRefresh() throws {
-        let manager = ModelManager(modelName: "openai_whisper-small.en")
+        var deletedModel: SpeechModelDescriptor?
+        let manager = ModelManager(
+            modelName: "openai_whisper-small.en",
+            modelDeletionOverride: { deletedModel = $0 }
+        )
         let expectation = expectation(description: "model manager publishes cache deletion")
         var cancellable: AnyCancellable? = manager.objectWillChange.sink {
             expectation.fulfill()
@@ -40,14 +44,17 @@ final class ModelManagerTests: XCTestCase {
         manager.deleteCachedModel(model)
 
         wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(deletedModel, model)
         withExtendedLifetime(cancellable) {}
         cancellable = nil
     }
 
     func testDeleteCachedCurrentModelResetsReadyState() async throws {
+        var deletedModel: SpeechModelDescriptor?
         let manager = ModelManager(
             modelName: "openai_whisper-small.en",
-            modelLoadOverride: { _ in }
+            modelLoadOverride: { _ in },
+            modelDeletionOverride: { deletedModel = $0 }
         )
 
         await manager.loadModel(name: "openai_whisper-small.en")
@@ -55,6 +62,7 @@ final class ModelManagerTests: XCTestCase {
 
         manager.deleteCachedModel(model)
 
+        XCTAssertEqual(deletedModel, model)
         XCTAssertEqual(manager.state, .idle)
         XCTAssertNil(manager.error)
     }

--- a/GhostPepperTests/ModelManagerTests.swift
+++ b/GhostPepperTests/ModelManagerTests.swift
@@ -194,6 +194,92 @@ final class ModelManagerTests: XCTestCase {
         XCTAssertEqual(manager.state, .ready)
         XCTAssertEqual(manager.modelName, SpeechModelCatalog.speechAnalyzer.id)
     }
+
+    func testNemotronModelLoadsRepositoryAndCreatesStreamingOnlySession() async {
+        let streamingModel = StubNemotronStreamingModel(transcript: "streaming transcript")
+        var requestedRepositories: [String] = []
+        let manager = ModelManager(
+            modelName: SpeechModelCatalog.nemotron35Streaming.id,
+            nemotronModelFactory: { repository in
+                requestedRepositories.append(repository)
+                return streamingModel
+            }
+        )
+
+        await manager.loadModel()
+        let session = manager.makeRecordingTranscriptionSession(language: "de")
+        session?.appendAudioChunk([1, 2, 3])
+        let transcript = await session?.finishTranscription()
+
+        XCTAssertEqual(manager.state, .ready)
+        XCTAssertEqual(
+            requestedRepositories,
+            ["mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit"]
+        )
+        XCTAssertEqual(streamingModel.requestedLanguages, ["de"])
+        XCTAssertEqual(transcript, "streaming transcript")
+        XCTAssertEqual(session?.allowsBatchFallback, false)
+    }
+
+    func testNemotronWholeBufferTranscriptionStillUsesStreamingSession() async {
+        let streamingModel = StubNemotronStreamingModel(transcript: "streamed whole buffer")
+        let manager = ModelManager(
+            modelName: SpeechModelCatalog.nemotronSpeechStreamingEnglish.id,
+            nemotronModelFactory: { _ in streamingModel }
+        )
+        await manager.loadModel()
+
+        let transcript = await manager.transcribe(
+            audioBuffer: [Float](repeating: 0.25, count: 3_000),
+            language: "fr"
+        )
+
+        XCTAssertEqual(transcript, "streamed whole buffer")
+        XCTAssertEqual(streamingModel.requestedLanguages, ["en"])
+        XCTAssertEqual(streamingModel.appendedChunks.map(\.count), [1280, 1280, 440])
+    }
+}
+
+private final class StubNemotronStreamingModel: NemotronStreamingModel {
+    private let transcript: String
+    private(set) var requestedLanguages: [String?] = []
+    private(set) var appendedChunks: [[Float]] = []
+
+    init(transcript: String) {
+        self.transcript = transcript
+    }
+
+    func makeSession(language: String?) -> RecordingTranscriptionSession {
+        requestedLanguages.append(language)
+        return StubNemotronRecordingSession(
+            transcript: transcript,
+            onAppend: { [weak self] samples in
+                self?.appendedChunks.append(samples)
+            }
+        )
+    }
+}
+
+private final class StubNemotronRecordingSession: RecordingTranscriptionSession {
+    let allowsBatchFallback = false
+    let supportsConcurrentFinalization = false
+    private let transcript: String
+    private let onAppend: ([Float]) -> Void
+
+    init(transcript: String, onAppend: @escaping ([Float]) -> Void) {
+        self.transcript = transcript
+        self.onAppend = onAppend
+    }
+
+    func appendAudioChunk(_ samples: [Float]) {
+        onAppend(samples)
+    }
+
+    func finishTranscription() async -> String? {
+        transcript
+    }
+
+    func cancel() {}
 }
 
 @MainActor

--- a/GhostPepperTests/PostPasteLearningCoordinatorTests.swift
+++ b/GhostPepperTests/PostPasteLearningCoordinatorTests.swift
@@ -310,9 +310,11 @@ final class PostPasteLearningCoordinatorTests: XCTestCase {
         }
 
         coordinator.handlePaste(samplePasteSession())
-        while !scheduledCalls.isEmpty {
-            await runNextScheduledCall(&scheduledCalls)
-        }
+        let pollCount = Int(
+            PostPasteLearningCoordinator.observationWindow
+                / PostPasteLearningCoordinator.pollInterval
+        ) + 1
+        await runScheduledCalls(&scheduledCalls, count: pollCount)
         await waitUntil {
             debugMessages.contains(where: { $0.contains("Post-paste learning skipped because the polling window expired without a stable correction") })
         }

--- a/GhostPepperTests/RecordingSessionCoordinatorTests.swift
+++ b/GhostPepperTests/RecordingSessionCoordinatorTests.swift
@@ -306,6 +306,69 @@ final class RecordingSessionCoordinatorTests: XCTestCase {
 
         XCTAssertNil(transcript)
     }
+
+    func testNemotronRecordingTranscriptionSessionStreamsChunksInOrderBeforeFinishing() async {
+        let backend = StubNemotronStreamSessionBackend(finalText: "  stable transcript  ")
+        let session = NemotronRecordingTranscriptionSession(backend: backend)
+
+        session.appendAudioChunk([1, 2])
+        session.appendAudioChunk([3, 4])
+
+        let transcript = await session.finishTranscription()
+
+        XCTAssertEqual(transcript, "stable transcript")
+        XCTAssertEqual(backend.appendedChunks, [[1, 2], [3, 4]])
+        XCTAssertTrue(backend.didFinish)
+        XCTAssertFalse(session.allowsBatchFallback)
+        XCTAssertFalse(session.supportsConcurrentFinalization)
+    }
+
+    func testNemotronRecordingTranscriptionSessionCancelPreventsFinalTranscript() async {
+        let backend = StubNemotronStreamSessionBackend(finalText: "should not be returned")
+        let session = NemotronRecordingTranscriptionSession(backend: backend)
+
+        session.appendAudioChunk([1, 2, 3, 4])
+        session.cancel()
+
+        let transcript = await session.finishTranscription()
+
+        XCTAssertNil(transcript)
+        XCTAssertFalse(backend.didFinish)
+    }
+}
+
+private final class StubNemotronStreamSessionBackend: NemotronStreamSessionBackend, @unchecked Sendable {
+    private let stateQueue = DispatchQueue(
+        label: "RecordingSessionCoordinatorTests.StubNemotronStreamSessionBackend"
+    )
+    private let finalText: String
+    private var storedChunks: [[Float]] = []
+    private var storedDidFinish = false
+
+    var appendedChunks: [[Float]] {
+        stateQueue.sync { storedChunks }
+    }
+
+    var didFinish: Bool {
+        stateQueue.sync { storedDidFinish }
+    }
+
+    init(finalText: String) {
+        self.finalText = finalText
+    }
+
+    func step(_ samples: [Float]) {
+        stateQueue.sync {
+            storedChunks.append(samples)
+        }
+    }
+
+    func finish() -> String {
+        stateQueue.sync {
+            storedDidFinish = true
+        }
+        return finalText
+    }
 }
 
 private actor LockedValue<Value> {

--- a/GhostPepperTests/RecordingSessionCoordinatorTests.swift
+++ b/GhostPepperTests/RecordingSessionCoordinatorTests.swift
@@ -244,7 +244,8 @@ final class RecordingSessionCoordinatorTests: XCTestCase {
         let recordedBuffer = await fullBuffer.get()
         XCTAssertEqual(recordedBuffer, [1, 2, 3, 4])
         let recordedEvents = await events.get()
-        XCTAssertEqual(recordedEvents, ["finish", "batch", "cleanup"])
+        XCTAssertEqual(Set(recordedEvents.dropLast()), Set(["finish", "batch"]))
+        XCTAssertEqual(recordedEvents.last, "cleanup")
     }
 
     func testSlidingWindowRecordingTranscriptionSessionDoesNotFallBackToStreamedTranscriptWhenFullBufferTranscriptionFails() async {
@@ -278,7 +279,8 @@ final class RecordingSessionCoordinatorTests: XCTestCase {
 
         XCTAssertNil(transcript)
         let recordedEvents = await events.get()
-        XCTAssertEqual(recordedEvents, ["finish", "batch", "cleanup"])
+        XCTAssertEqual(Set(recordedEvents.dropLast()), Set(["finish", "batch"]))
+        XCTAssertEqual(recordedEvents.last, "cleanup")
     }
 
     func testSlidingWindowRecordingTranscriptionSessionCancelPreventsFinalTranscript() async {

--- a/GhostPepperTests/RuntimeModelInventoryTests.swift
+++ b/GhostPepperTests/RuntimeModelInventoryTests.swift
@@ -19,6 +19,8 @@ final class RuntimeModelInventoryTests: XCTestCase {
         XCTAssertTrue(rows.map(\.name).contains("Whisper small.en (accuracy)"))
         XCTAssertTrue(rows.map(\.name).contains("Whisper small (multilingual)"))
         XCTAssertTrue(rows.map(\.name).contains("Parakeet v3 (25 languages)"))
+        XCTAssertTrue(rows.map(\.name).contains("Nemotron Speech 0.6B (8-bit, english streaming)"))
+        XCTAssertTrue(rows.map(\.name).contains("Nemotron 3.5 ASR 0.6B (8-bit, 40 language-locales)"))
         XCTAssertTrue(rows.map(\.name).contains("Qwen 3.5 0.8B Q4_K_M (Very fast)"))
         XCTAssertTrue(rows.map(\.name).contains("Qwen 3.5 2B Q4_K_M (Fast)"))
         XCTAssertTrue(rows.map(\.name).contains("Qwen 3.5 4B Q4_K_M (Full)"))
@@ -34,6 +36,12 @@ final class RuntimeModelInventoryTests: XCTestCase {
 
         XCTAssertEqual(row(named: "Parakeet v3 (25 languages)", in: rows)?.status, .notLoaded)
         XCTAssertEqual(row(named: "Parakeet v3 (25 languages)", in: rows)?.isSelected, false)
+
+        XCTAssertEqual(row(named: "Nemotron Speech 0.6B (8-bit, english streaming)", in: rows)?.status, .notLoaded)
+        XCTAssertEqual(row(named: "Nemotron Speech 0.6B (8-bit, english streaming)", in: rows)?.isSelected, false)
+
+        XCTAssertEqual(row(named: "Nemotron 3.5 ASR 0.6B (8-bit, 40 language-locales)", in: rows)?.status, .notLoaded)
+        XCTAssertEqual(row(named: "Nemotron 3.5 ASR 0.6B (8-bit, 40 language-locales)", in: rows)?.isSelected, false)
 
         XCTAssertEqual(row(named: "Qwen 3.5 0.8B Q4_K_M (Very fast)", in: rows)?.status, .loaded)
         XCTAssertEqual(row(named: "Qwen 3.5 0.8B Q4_K_M (Very fast)", in: rows)?.isSelected, false)

--- a/GhostPepperTests/SpeechTranscriberTests.swift
+++ b/GhostPepperTests/SpeechTranscriberTests.swift
@@ -14,12 +14,16 @@ final class SpeechTranscriberTests: XCTestCase {
             "openai_whisper-small.en",
             "openai_whisper-small",
             "fluid_parakeet-v3",
+            "mlx_nemotron-speech-streaming-en-0.6b-8bit",
+            "mlx_nemotron-3.5-asr-streaming-0.6b-8bit",
         ]
         var expectedBackends: [SpeechBackendKind] = [
             .whisperKit,
             .whisperKit,
             .whisperKit,
             .fluidAudio,
+            .mlxAudio,
+            .mlxAudio,
         ]
 
         if #available(macOS 15, iOS 18, *) {
@@ -34,6 +38,30 @@ final class SpeechTranscriberTests: XCTestCase {
         XCTAssertEqual(ids, expectedIDs)
         XCTAssertEqual(backends, expectedBackends)
         XCTAssertEqual(SpeechModelCatalog.defaultModelID, "openai_whisper-small.en")
+    }
+
+    func testNemotronDescriptorsUseMLXStreamingRepositories() {
+        let english = SpeechModelCatalog.nemotronSpeechStreamingEnglish
+        XCTAssertEqual(english.name, "mlx_nemotron-speech-streaming-en-0.6b-8bit")
+        XCTAssertEqual(english.backend, .mlxAudio)
+        XCTAssertEqual(
+            english.mlxAudioRepository,
+            "animaslabs/nemotron-speech-streaming-en-0.6b-mlx-8bit"
+        )
+        XCTAssertTrue(english.isEnglishOnly)
+        XCTAssertFalse(english.supportsSpeakerFiltering)
+        XCTAssertTrue(english.pickerLabel.contains("English streaming"))
+
+        let multilingual = SpeechModelCatalog.nemotron35Streaming
+        XCTAssertEqual(multilingual.name, "mlx_nemotron-3.5-asr-streaming-0.6b-8bit")
+        XCTAssertEqual(multilingual.backend, .mlxAudio)
+        XCTAssertEqual(
+            multilingual.mlxAudioRepository,
+            "mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit"
+        )
+        XCTAssertFalse(multilingual.isEnglishOnly)
+        XCTAssertFalse(multilingual.supportsSpeakerFiltering)
+        XCTAssertTrue(multilingual.pickerLabel.contains("40 language-locales"))
     }
 
     func testSpeechAnalyzerDescriptorIsSystemManagedAndDoesNotFilterSpeakers() {

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -31,21 +31,20 @@ final class TextCleanupManagerTests: XCTestCase {
     }
 
     func testCleanupModelCatalogIncludesVeryFastFastAndFullQwenModels() {
-        XCTAssertEqual(
-            TextCleanupManager.cleanupModels.map(\.kind),
-            [
-                .qwen35_0_8b_q4_k_m,
-                .qwen35_2b_q4_k_m,
-                .qwen35_4b_q4_k_m,
-            ]
+        let modelsByKind = Dictionary(
+            uniqueKeysWithValues: TextCleanupManager.cleanupModels.map { ($0.kind, $0) }
         )
         XCTAssertEqual(
-            TextCleanupManager.cleanupModels.map(\.displayName),
-            [
-                "Qwen 3.5 0.8B Q4_K_M (Very fast)",
-                "Qwen 3.5 2B Q4_K_M (Fast)",
-                "Qwen 3.5 4B Q4_K_M (Full)",
-            ]
+            modelsByKind[.qwen35_0_8b_q4_k_m]?.displayName,
+            "Qwen 3.5 0.8B Q4_K_M (Very fast)"
+        )
+        XCTAssertEqual(
+            modelsByKind[.qwen35_2b_q4_k_m]?.displayName,
+            "Qwen 3.5 2B Q4_K_M (Fast)"
+        )
+        XCTAssertEqual(
+            modelsByKind[.qwen35_4b_q4_k_m]?.displayName,
+            "Qwen 3.5 4B Q4_K_M (Full)"
         )
         XCTAssertEqual(
             TextCleanupManager.recommendedFullModel.fileName,

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -221,8 +221,16 @@ final class TextCleanupManagerTests: XCTestCase {
         }
     }
 
-    func testDeleteCachedModelNotifiesObserversForInventoryRefresh() {
-        let manager = TextCleanupManager()
+    func testDeleteCachedModelRemovesOnlyTheConfiguredCacheFileAndNotifiesObservers() throws {
+        let modelsDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: modelsDirectory) }
+
+        let modelFile = modelsDirectory.appendingPathComponent(TextCleanupManager.compactModel.fileName)
+        try Data("cached model".utf8).write(to: modelFile)
+
+        let manager = TextCleanupManager(modelsDirectory: modelsDirectory)
         let expectation = expectation(description: "cleanup manager publishes cache deletion")
         var cancellable: AnyCancellable? = manager.objectWillChange.sink {
             expectation.fulfill()
@@ -231,6 +239,7 @@ final class TextCleanupManagerTests: XCTestCase {
         manager.deleteCachedModel(kind: .qwen35_0_8b_q4_k_m)
 
         wait(for: [expectation], timeout: 1.0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelFile.path))
         withExtendedLifetime(cancellable) {}
         cancellable = nil
     }

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Ghost Pepper uses open-source models that run entirely on your Mac. Models downl
 | Whisper small (multilingual) | ~466 MB | Multi-language support |
 | Parakeet v3 (25 languages) | ~1.4 GB | Multi-language via [FluidAudio](https://github.com/FluidInference/FluidAudio) |
 | Qwen3-ASR 0.6B int8 (50+ languages) | ~900 MB | Highest multilingual quality, macOS 15+ required |
+| Nemotron Speech Streaming 0.6B 8-bit | ~633 MB | Low-latency English streaming via [MLX Audio](https://github.com/Blaizzy/mlx-audio-swift) |
+| Nemotron 3.5 ASR Streaming 0.6B 8-bit | ~721 MB | Low-latency multilingual streaming via [MLX Audio](https://github.com/Blaizzy/mlx-audio-swift) |
 
 ### Cleanup models
 
@@ -53,7 +55,7 @@ Ghost Pepper uses open-source models that run entirely on your Mac. Models downl
 | Qwen 3.5 2B | ~1.3 GB | Fast (~4-5s) |
 | Qwen 3.5 4B | ~2.8 GB | Full quality (~5-7s) |
 
-Speech models powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit). Cleanup models powered by [LLM.swift](https://github.com/eastriverlee/LLM.swift). All models served by [Hugging Face](https://huggingface.co/).
+Speech models powered by [WhisperKit](https://github.com/argmaxinc/WhisperKit), [FluidAudio](https://github.com/FluidInference/FluidAudio), and [MLX Audio](https://github.com/Blaizzy/mlx-audio-swift). Cleanup models powered by [LLM.swift](https://github.com/eastriverlee/LLM.swift). All models served by [Hugging Face](https://huggingface.co/).
 
 ## Getting started
 
@@ -83,7 +85,7 @@ Every core feature runs 100% on your Mac — verified by AI code review. No trus
 
 | Feature | Status | What was checked |
 |---|---|---|
-| Speech-to-text | :white_check_mark: Local | WhisperKit/FluidAudio inference, no audio sent anywhere |
+| Speech-to-text | :white_check_mark: Local | WhisperKit/FluidAudio/MLX Audio inference, no audio sent anywhere |
 | Text cleanup | :white_check_mark: Local | Qwen LLM runs on-device via LLM.swift |
 | Audio recording | :white_check_mark: Local | AVAudioEngine + ScreenCaptureKit, no streaming |
 | Meeting transcription & storage | :white_check_mark: Local | Chunked transcription, markdown files on disk |

--- a/docs/superpowers/plans/2026-07-26-streaming-nemotron-mlx-models.md
+++ b/docs/superpowers/plans/2026-07-26-streaming-nemotron-mlx-models.md
@@ -1,0 +1,92 @@
+# Streaming Nemotron MLX Models Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task by task.
+
+**Goal:** Add the two NVIDIA Nemotron 0.6B ASR models to GhostPepper as MLX-backed, streaming-only transcription options, including the upstream MLXAudioSwift compatibility needed by the older English checkpoint.
+
+**Architecture:** Keep model execution behind GhostPepper's existing recording-transcription session boundary. MLXAudioSwift owns Nemotron model loading and incremental RNN-T state. GhostPepper selects an immutable Hugging Face repository per catalog entry and feeds resampled 16 kHz audio to a per-recording MLX stream session. The older English checkpoint remains the same runtime path, with narrowly scoped compatibility in MLXAudioSwift for its legacy NeMo config and packed pointwise-convolution layout.
+
+**Tech Stack:** Swift 6, Swift Package Manager, MLX / MLXNN, MLXAudioSwift, XcodeGen, XCTest / Swift Testing, Hugging Face model artifacts.
+
+---
+
+## Task 1: Reproduce legacy Nemotron incompatibility in MLXAudioSwift
+
+**Files:**
+
+- Modify: `/Users/jesse/git/mlx-audio-swift/Tests/MLXAudioSTTTests.swift`
+
+- [ ] Clone `Blaizzy/mlx-audio-swift` into an isolated local checkout, create `agent/support-legacy-nemotron-streaming`, resolve dependencies, and run the existing `NemotronASRTests` as the clean baseline.
+- [ ] Add a focused test that decodes the older checkpoint's real legacy structure: nested `decoder.prednet`, nested `joint.jointnet`, vocabulary under `joint`, absent prompt configuration, and encoder-derived attention context.
+- [ ] Add a focused sanitizer test with synthetic packed 8-bit pointwise-convolution weights, scales, and biases. Assert the output is dequantized, gains the Conv1d singleton kernel dimension, and drops obsolete quantization metadata.
+- [ ] Run `swift test --filter NemotronASRTests` and record the expected failures before changing production code.
+
+## Task 2: Add minimal legacy-checkpoint compatibility
+
+**Files:**
+
+- Modify: `/Users/jesse/git/mlx-audio-swift/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRConfig.swift`
+- Modify: `/Users/jesse/git/mlx-audio-swift/Sources/MLXAudioSTT/Models/NemotronASR/NemotronASRModel.swift`
+- Test: `/Users/jesse/git/mlx-audio-swift/Tests/MLXAudioSTTTests.swift`
+
+- [ ] Decode both current flattened Nemotron 3.5 configuration and the older nested NeMo configuration without changing current defaults.
+- [ ] Make the prompt kernel genuinely optional so the English-only checkpoint does not invent multilingual prompt parameters.
+- [ ] Dequantize only legacy packed pointwise Conv1d weights and reshape them from `[out, in]` to `[out, 1, in]` during weight sanitization.
+- [ ] Run the focused test until it passes, then run the complete MLXAudioSwift test suite and release build.
+- [ ] Commit the tests and compatibility implementation with a detailed root-cause explanation.
+
+## Task 3: Qualify both real Nemotron checkpoints
+
+**Files:**
+
+- Reuse: `/tmp/ghost-pepper-asr-benchmark.LaGrfk`
+- Reuse: local GhostPepper utterance fixtures selected by the existing benchmark harness
+
+- [ ] Load `animaslabs/nemotron-speech-streaming-en-0.6b-mlx-8bit` from the clean patched checkout and transcribe the same local utterances through `NemotronASRStreamSession`.
+- [ ] Load `mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit` and run the same streaming path as a regression check.
+- [ ] Capture exact commit IDs, model revisions, hardware, utterance duration, transcript output, wall time, real-time factor, and peak memory evidence.
+- [ ] Confirm the results are reproducible from the committed checkout rather than the earlier temporary exploratory patch.
+
+## Task 4: Publish the MLXAudioSwift compatibility PR
+
+**Files:**
+
+- Inspect: upstream `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, pull-request template, README, and repository instructions
+
+- [ ] After testing, verify whether the upstream repository permits agent-authored or agent-assisted contributions and obey any disclosure/template requirements.
+- [ ] If permitted, create `obra/mlx-audio-swift`, push the tested branch, and open a draft PR against `Blaizzy/mlx-audio-swift:main`.
+- [ ] Explain the root cause, narrow compatibility behavior, automated tests, real-checkpoint evidence, benchmark timings, hardware, and model revisions.
+- [ ] Identify the author as Codex and state that Codex is happy to have its human partner perform additional work requested by maintainers.
+- [ ] Verify the rendered PR body and report the PR URL and CI state.
+
+## Task 5: Add the MLX Nemotron backend to GhostPepper
+
+**Files:**
+
+- Modify: `project.yml`
+- Modify: `GhostPepper/Transcription/SpeechModelCatalog.swift`
+- Modify: `GhostPepper/Transcription/ModelManager.swift`
+- Modify: `GhostPepper/Transcription/RecordingSessionCoordinator.swift`
+- Test: `GhostPepperTests/SpeechTranscriberTests.swift`
+- Test: `GhostPepperTests/ModelManagerTests.swift`
+- Test: `GhostPepperTests/RuntimeModelInventoryTests.swift`
+
+- [ ] Add failing catalog tests for both streaming-only Nemotron descriptors, exact model repositories, MLX backend identity, availability, and inventory presentation.
+- [ ] Add failing recording-session tests proving MLX selection creates independent incremental sessions, forwards audio chunks, flushes exactly once, and never uses an offline transcription API.
+- [ ] Add the pinned MLXAudioSwift dependency and the smallest backend adapter needed by `ModelManager`.
+- [ ] Route both models exclusively through the recording streaming-session path.
+- [ ] Preserve current WhisperKit, FluidAudio, Qwen, and SpeechAnalyzer behavior.
+- [ ] Run focused tests and commit the catalog/backend integration.
+
+## Task 6: Verify GhostPepper end to end
+
+**Files:**
+
+- Verify: generated `GhostPepper.xcodeproj`
+- Verify: GhostPepper runtime model inventory and recording flow
+
+- [ ] Regenerate the Xcode project with XcodeGen and ensure the resolved MLXAudioSwift revision is reproducible.
+- [ ] Run focused transcription/catalog/inventory tests, then the full GhostPepper test suite.
+- [ ] Build and launch GhostPepper, download each Nemotron model through the normal UI, record real utterances, and verify final transcript delivery for both.
+- [ ] Record runtime timings and memory separately from automated test evidence.
+- [ ] Inspect `git status`, review the complete diff, commit all intended GhostPepper changes, and report any external acceptance boundary still open.

--- a/project.yml
+++ b/project.yml
@@ -12,6 +12,9 @@ packages:
   FluidAudio:
     url: https://github.com/FluidInference/FluidAudio.git
     from: "0.13.6"
+  MLXAudio:
+    url: https://github.com/obra/mlx-audio-swift.git
+    revision: "6361aebbb1e580fffac4e00241413fe018d73b0c"
   LLM.swift:
     url: https://github.com/obra/LLM.swift.git
     branch: main
@@ -40,6 +43,8 @@ targets:
     dependencies:
       - package: WhisperKit
       - package: FluidAudio
+      - package: MLXAudio
+        product: MLXAudioSTT
       - package: LLM.swift
         product: LLM
       - package: Sparkle

--- a/project.yml
+++ b/project.yml
@@ -62,6 +62,9 @@ targets:
   GhostPepperTests:
     type: bundle.unit-test
     platform: macOS
+    configFiles:
+      Debug: Config/Signing.xcconfig
+      Release: Config/Signing.xcconfig
     sources:
       - GhostPepperTests
     dependencies:


### PR DESCRIPTION
## Summary

- add Nemotron Speech Streaming EN 0.6B 8-bit and Nemotron 3.5 ASR Streaming 0.6B 8-bit as MLX-backed, streaming-only transcription options
- feed 16 kHz audio incrementally through a per-recording `NemotronASRStreamSession`, preserving chunk order and preventing finalization races
- integrate model download, cache discovery/deletion, picker metadata, language selection, and runtime inventory presentation
- pin `MLXAudioSTT` to `obra/mlx-audio-swift@6361aebbb1e580fffac4e00241413fe018d73b0c`, the commit proposed upstream in [Blaizzy/mlx-audio-swift#236](https://github.com/Blaizzy/mlx-audio-swift/pull/236)

The English NVIDIA checkpoint uses an older NeMo configuration and packed pointwise-convolution layout that upstream MLXAudio did not load. Dependency PR #236 adds that narrow compatibility while preserving the existing Nemotron 3.5 path. This GhostPepper PR should be repointed to the upstream dependency after that PR merges.

## Test infrastructure repairs

Running the complete hosted suite exposed existing generated-target and isolation problems that prevented meaningful full-suite validation:

- generated project membership had drifted from the checked-in tests
- several tests no longer compiled against current production APIs
- model cache deletion tests could remove real models from the user's Application Support directory
- the hardened v2.4.4 app host and ad-hoc test bundle had mismatched signing teams

The branch restores the complete generated test target, updates those tests to current contracts, isolates destructive cache coverage in temporary directories, and signs the hosted test bundle consistently with the app.

## Validation

Hardware and toolchain:

- Apple M4 Max, 16 cores, 64 GB RAM
- macOS 26.5.2 (25F84)
- Xcode 26.6 (17F113)

GhostPepper:

- rebased onto current `upstream/main` at `c212bcc` (v2.4.4)
- `xcodegen generate` reproduces a clean tree
- complete hosted suite passed: 517 tests, 0 failures, in 134.533 seconds
- focused Qwen 3.5 4B cleanup evaluation passed in 22.170 seconds
- normal arm64 Release build succeeded with hardened runtime enabled and Apple Development signing

The full suite used `ENABLE_HARDENED_RUNTIME=NO` only for the XCTest invocation. With the hardened v2.4.4 host, two long llama.cpp Metal cleanup evaluations reproducibly abort during test-host termination inside `ggml_metal_device_free`; the focused 4B evaluation passes with the test-only override. The committed production app remains hardened, and the normal hardened Release build succeeds.

Dependency:

- 9 focused Nemotron tests passed
- full non-smoke MLXAudio package suite passed: 625 tests across 107 suites
- MLXAudio Release build succeeded

Real-audio streaming benchmark:

- 50 utterances from GhostPepper's local transcription corpus
- 386.844 seconds of audio per pass
- one warm-up plus 3 measured passes
- audio fed in 80 ms increments with a 1,120 ms model chunk

| Model | Load | Aggregate speed | Utterance p50 / p95 | First-text compute p50 | Finalize p50 | Stable across passes |
|---|---:|---:|---:|---:|---:|---:|
| Nemotron Speech Streaming EN 0.6B 8-bit | 249.28 ms | 43.93x realtime | 93.24 / 525.43 ms | 24.21 ms | 15.74 ms | 50/50 files |
| Nemotron 3.5 ASR Streaming 0.6B 8-bit | 282.49 ms | 41.58x realtime | 99.72 / 546.26 ms | 34.45 ms | 17.31 ms | 50/50 files |

As a parity check against the same models in `transcribe.cpp`, normalized output matched exactly on 45/50 English files and 44/50 Nemotron 3.5 files; pairwise word-difference rates were 0.79% and 1.27%, respectively.

## Agent disclosure

I am Codex, an OpenAI coding agent, and I prepared and tested this PR with my human partner, Jesse Vincent. I am happy to have my human partner do more work on this PR if the maintainers want.
