### PR TITLE
Fix meeting summary generation failures (prompt bug + debug logging)

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		C1949C00F2F721B802EC237E /* PepperChatWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB753C40197FA7255E1DEA29 /* PepperChatWindow.swift */; };
 		C1A07FBD7318A26BA879232A /* ModelInventoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B68F46BA90BDD633868A8CE /* ModelInventoryViews.swift */; };
 		C4E8739F267E3096E97FBE71 /* DebugLogStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */; };
+		6ED7D63ECE6340EB988D21F6 /* MeetingSummaryGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0994BF73ABCF4C77BD9B29B3 /* MeetingSummaryGeneratorTests.swift */; };
 		C54F09E5E2BAA930626E855C /* SpeechTranscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CC027B53AAE03079D78761 /* SpeechTranscriber.swift */; };
 		C5D011A82469050DF1E7F462 /* IndexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8311B6325214FE6B40CDE /* IndexBuilder.swift */; };
 		C6EDBC09902D8470DBFD5255 /* IndexSystemPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D736758B588185CCE102504 /* IndexSystemPrompt.swift */; };
@@ -259,6 +260,7 @@
 		1C82FF777F1863DC84525AC2 /* cytoscape.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = cytoscape.min.js; sourceTree = "<group>"; };
 		1DC632CC6DD4F55F2FA05480 /* FrontmostWindowOCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmostWindowOCRService.swift; sourceTree = "<group>"; };
 		1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogStoreTests.swift; sourceTree = "<group>"; };
+		0994BF73ABCF4C77BD9B29B3 /* MeetingSummaryGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSummaryGeneratorTests.swift; sourceTree = "<group>"; };
 		207AAC1CBC60052D1493D13D /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		231812B1BF8E3F2D5E0209F3 /* ShortcutCaptureStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureStateTests.swift; sourceTree = "<group>"; };
 		23B813180F29336A298BE44E /* LocalLLMCleanupBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLLMCleanupBackend.swift; sourceTree = "<group>"; };
@@ -887,6 +889,7 @@
 				AA783B889855B0811E210751 /* CleanupPromptEvalTests.swift */,
 				350AC3A5A34A78F96226831C /* CorrectionStoreTests.swift */,
 				1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */,
+				0994BF73ABCF4C77BD9B29B3 /* MeetingSummaryGeneratorTests.swift */,
 				A5F781190896573C3BA687CB /* FluidAudioSpeechSessionTests.swift */,
 				9FBC0D906FF181E91A758F58 /* FocusedElementLocatorTests.swift */,
 				363A3F98CDFC4CCAD927835C /* GhostPepperTests.swift */,
@@ -1244,6 +1247,7 @@
 				E62BA209042B0FA8B53E2C76 /* CleanupPromptEvalTests.swift in Sources */,
 				3512549BBD28CC74C0137FA3 /* CorrectionStoreTests.swift in Sources */,
 				C4E8739F267E3096E97FBE71 /* DebugLogStoreTests.swift in Sources */,
+				6ED7D63ECE6340EB988D21F6 /* MeetingSummaryGeneratorTests.swift in Sources */,
 				AFAAFB58F0A76F5213F67C45 /* FluidAudioSpeechSessionTests.swift in Sources */,
 				F0598B5D027A5B31EF1B7664 /* FocusedElementLocatorTests.swift in Sources */,
 				FC6AACB283BD40C4FBA78F3D /* GhostPepperTests.swift in Sources */,

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1289,8 +1289,8 @@ class AppState: ObservableObject {
                 await self?.finishMeetingSession(session, logPrefix: "Meeting stopped")
             }
         }
-        controller.onGenerateSummary = { [weak self] transcript in
-            Task { await self?.generateMeetingSummary(for: transcript) }
+        controller.onGenerateSummary = { [weak self] transcript, modelKind in
+            Task { await self?.generateMeetingSummary(for: transcript, modelKind: modelKind) }
         }
         controller.onLoadSpeakerReviewItems = { [weak self] transcript in
             self?.meetingSpeakerReviewItems(for: transcript) ?? []
@@ -1872,7 +1872,7 @@ class AppState: ObservableObject {
         }
     }
 
-    func generateMeetingSummary(for transcript: MeetingTranscript) async {
+    func generateMeetingSummary(for transcript: MeetingTranscript, modelKind: LocalCleanupModelKind? = nil) async {
         guard !transcript.segments.isEmpty else { return }
         transcript.isGeneratingSummary = true
         let generator = MeetingSummaryGenerator(cleanupManager: textCleanupManager)
@@ -1880,7 +1880,8 @@ class AppState: ObservableObject {
         let result = await generator.generateSummary(
             transcript: transcript,
             chunkPrompt: MeetingSummaryGenerator.defaultPrompt,
-            finalPrompt: meetingSummaryPrompt
+            finalPrompt: meetingSummaryPrompt,
+            modelKind: modelKind
         )
         transcript.summary = result
         transcript.isGeneratingSummary = false

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1876,6 +1876,7 @@ class AppState: ObservableObject {
         guard !transcript.segments.isEmpty else { return }
         transcript.isGeneratingSummary = true
         let generator = MeetingSummaryGenerator(cleanupManager: textCleanupManager)
+        generator.debugLogger = debugLogStore.record
         let result = await generator.generateSummary(
             transcript: transcript,
             chunkPrompt: MeetingSummaryGenerator.defaultPrompt,

--- a/GhostPepper/Cleanup/CleanupBackend.swift
+++ b/GhostPepper/Cleanup/CleanupBackend.swift
@@ -8,6 +8,7 @@ enum CleanupBackendError: Error, Equatable {
     case unavailable
     case unsupportedRuntime(String)
     case unusableOutput(rawOutput: String)
+    case timedOut(seconds: TimeInterval)
 }
 
 extension CleanupBackendError: LocalizedError {
@@ -19,6 +20,8 @@ extension CleanupBackendError: LocalizedError {
             return message
         case .unusableOutput:
             return "The selected local model returned unusable output."
+        case .timedOut(let seconds):
+            return "The local model timed out after \(Int(seconds))s."
         }
     }
 }

--- a/GhostPepper/Cleanup/TextCleaner.swift
+++ b/GhostPepper/Cleanup/TextCleaner.swift
@@ -179,7 +179,7 @@ final class TextCleaner {
             let postProcessDuration = Date().timeIntervalSince(postProcessStart)
 
             switch error {
-            case .unavailable, .unsupportedRuntime:
+            case .unavailable, .unsupportedRuntime, .timedOut:
                 debugLogger?(.cleanup, "Cleanup backend unavailable, returning raw transcription.")
                 return TextCleanerResult(
                     text: text,

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -401,6 +401,12 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
             case .modelUnavailable:
                 throw CleanupBackendError.unavailable
             }
+        } catch is CancellationError {
+            debugLogger?(
+                .cleanup,
+                "Local cleanup probe failed before producing usable output: timed out after \(Int(Self.timeoutSeconds))s."
+            )
+            throw CleanupBackendError.timedOut(seconds: Self.timeoutSeconds)
         } catch {
             debugLogger?(
                 .cleanup,

--- a/GhostPepper/Meeting/MeetingSummaryGenerator.swift
+++ b/GhostPepper/Meeting/MeetingSummaryGenerator.swift
@@ -44,7 +44,8 @@ final class MeetingSummaryGenerator {
     func generateSummary(
         transcript: MeetingTranscript,
         chunkPrompt: String = MeetingSummaryGenerator.defaultPrompt,
-        finalPrompt: String = MeetingSummaryGenerator.finalSummaryPrompt
+        finalPrompt: String = MeetingSummaryGenerator.finalSummaryPrompt,
+        modelKind: LocalCleanupModelKind? = nil
     ) async -> String? {
         let segments = transcript.segments
         guard !segments.isEmpty else { return nil }
@@ -70,7 +71,7 @@ final class MeetingSummaryGenerator {
             // Short meeting — summarize directly with the final prompt
             let input = "\(notesPrefix)Meeting transcript:\n\n\(chunks[0])"
             do {
-                return try await runLLM(text: input, prompt: finalPrompt)
+                return try await runLLM(text: input, prompt: finalPrompt, modelKind: modelKind)
             } catch {
                 debugLogger?(
                     .model,
@@ -85,7 +86,7 @@ final class MeetingSummaryGenerator {
         for (i, chunk) in chunks.enumerated() {
             let input = "Meeting transcript (part \(i + 1) of \(chunks.count)):\n\n\(chunk)"
             do {
-                let summary = try await runLLM(text: input, prompt: chunkPrompt)
+                let summary = try await runLLM(text: input, prompt: chunkPrompt, modelKind: modelKind)
                 chunkSummaries.append(summary)
             } catch {
                 debugLogger?(
@@ -109,7 +110,7 @@ final class MeetingSummaryGenerator {
 
         let finalInput = "\(notesPrefix)Combined meeting notes:\n\n\(combined)"
         do {
-            return try await runLLM(text: finalInput, prompt: finalPrompt)
+            return try await runLLM(text: finalInput, prompt: finalPrompt, modelKind: modelKind)
         } catch {
             debugLogger?(
                 .model,
@@ -143,8 +144,8 @@ final class MeetingSummaryGenerator {
         return chunks
     }
 
-    private func runLLM(text: String, prompt: String) async throws -> String {
-        let result = try await cleanupManager.clean(text: text, prompt: prompt)
+    private func runLLM(text: String, prompt: String, modelKind: LocalCleanupModelKind?) async throws -> String {
+        let result = try await cleanupManager.clean(text: text, prompt: prompt, modelKind: modelKind)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/GhostPepper/Meeting/MeetingSummaryGenerator.swift
+++ b/GhostPepper/Meeting/MeetingSummaryGenerator.swift
@@ -8,6 +8,7 @@ import Foundation
 @MainActor
 final class MeetingSummaryGenerator {
     private let cleanupManager: TextCleanupManager
+    var debugLogger: ((DebugLogCategory, String) -> Void)?
 
     /// Maximum characters per chunk sent to the LLM (~1500 tokens ≈ 6000 chars).
     private let chunkCharLimit = 5000
@@ -56,6 +57,11 @@ final class MeetingSummaryGenerator {
         // Split into chunks
         let chunks = splitIntoChunks(fullText)
 
+        debugLogger?(
+            .model,
+            "Meeting summary: starting for \(transcript.meetingName) (\(segments.count) segments, \(chunks.count) chunk(s))."
+        )
+
         // Include user notes if available
         let notesText = transcript.notes.trimmingCharacters(in: .whitespacesAndNewlines)
         let notesPrefix = notesText.isEmpty ? "" : "User's notes during the meeting:\n\n\(notesText)\n\n"
@@ -63,17 +69,36 @@ final class MeetingSummaryGenerator {
         if chunks.count == 1 {
             // Short meeting — summarize directly with the final prompt
             let input = "\(notesPrefix)Meeting transcript:\n\n\(chunks[0])"
-            return await runLLM(text: input, prompt: finalPrompt)
+            do {
+                return try await runLLM(text: input, prompt: finalPrompt)
+            } catch {
+                debugLogger?(
+                    .model,
+                    "Meeting summary: final combine step failed (\(error.localizedDescription))."
+                )
+                return nil
+            }
         }
 
         // Multi-chunk: summarize each chunk, then combine
         var chunkSummaries: [String] = []
         for (i, chunk) in chunks.enumerated() {
             let input = "Meeting transcript (part \(i + 1) of \(chunks.count)):\n\n\(chunk)"
-            if let summary = await runLLM(text: input, prompt: chunkPrompt) {
+            do {
+                let summary = try await runLLM(text: input, prompt: chunkPrompt)
                 chunkSummaries.append(summary)
+            } catch {
+                debugLogger?(
+                    .model,
+                    "Meeting summary: chunk \(i + 1)/\(chunks.count) failed (\(error.localizedDescription)) — dropped from summary."
+                )
             }
         }
+
+        debugLogger?(
+            .model,
+            "Meeting summary: chunk summarization complete — \(chunkSummaries.count)/\(chunks.count) chunks succeeded."
+        )
 
         guard !chunkSummaries.isEmpty else { return nil }
 
@@ -83,7 +108,15 @@ final class MeetingSummaryGenerator {
         }.joined(separator: "\n\n")
 
         let finalInput = "\(notesPrefix)Combined meeting notes:\n\n\(combined)"
-        return await runLLM(text: finalInput, prompt: finalPrompt)
+        do {
+            return try await runLLM(text: finalInput, prompt: finalPrompt)
+        } catch {
+            debugLogger?(
+                .model,
+                "Meeting summary: final combine step failed (\(error.localizedDescription)) — \(chunkSummaries.count)/\(chunks.count) chunk summaries discarded."
+            )
+            return nil
+        }
     }
 
     // MARK: - Private
@@ -110,15 +143,9 @@ final class MeetingSummaryGenerator {
         return chunks
     }
 
-    private func runLLM(text: String, prompt: String) async -> String? {
-        do {
-            let fullPrompt = "\(prompt)\n\n\(text)"
-            let result = try await cleanupManager.clean(text: fullPrompt, prompt: nil)
-            let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        } catch {
-            print("MeetingSummaryGenerator: LLM failed — \(error.localizedDescription)")
-            return nil
-        }
+    private func runLLM(text: String, prompt: String) async throws -> String {
+        let fullPrompt = "\(prompt)\n\n\(text)"
+        let result = try await cleanupManager.clean(text: fullPrompt, prompt: nil)
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/GhostPepper/Meeting/MeetingSummaryGenerator.swift
+++ b/GhostPepper/Meeting/MeetingSummaryGenerator.swift
@@ -144,8 +144,7 @@ final class MeetingSummaryGenerator {
     }
 
     private func runLLM(text: String, prompt: String) async throws -> String {
-        let fullPrompt = "\(prompt)\n\n\(text)"
-        let result = try await cleanupManager.clean(text: fullPrompt, prompt: nil)
+        let result = try await cleanupManager.clean(text: text, prompt: prompt)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/GhostPepper/UI/MeetingTranscriptWindow.swift
+++ b/GhostPepper/UI/MeetingTranscriptWindow.swift
@@ -1084,7 +1084,7 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
     var onOpenSettings: (() -> Void)?
     var onStartRecording: ((_ name: String, _ detectedMeeting: DetectedMeeting?) throws -> MeetingSession)?
     var onStopRecording: ((MeetingSession) -> Void)?
-    var onGenerateSummary: ((MeetingTranscript) -> Void)?
+    var onGenerateSummary: ((MeetingTranscript, LocalCleanupModelKind) -> Void)?
     var onLoadSpeakerReviewItems: ((MeetingTranscript) -> [MeetingSpeakerReviewItem])?
     var onUpdateSpeakerLabel: ((_ transcript: MeetingTranscript, _ currentDisplayName: String, _ newDisplayName: String) throws -> Void)?
     var onAskQuestion: ((_ question: String, _ history: [QAHistoryTurn]) -> AsyncThrowingStream<QAEvent, Error>)?
@@ -1377,7 +1377,7 @@ final class MeetingWindowState: ObservableObject {
     var onOpenSettings: (() -> Void)?
     var onStartRecording: ((_ name: String, _ detectedMeeting: DetectedMeeting?) throws -> MeetingSession)?
     var onStopRecording: ((MeetingSession) -> Void)?
-    var onGenerateSummary: ((MeetingTranscript) -> Void)?
+    var onGenerateSummary: ((MeetingTranscript, LocalCleanupModelKind) -> Void)?
     var onLoadSpeakerReviewItems: ((MeetingTranscript) -> [MeetingSpeakerReviewItem])?
     var onUpdateSpeakerLabel: ((_ transcript: MeetingTranscript, _ currentDisplayName: String, _ newDisplayName: String) throws -> Void)?
     var onMakeIndexBuilder: ((IndexKind) -> (any IndexBuilding)?)?
@@ -9562,7 +9562,8 @@ struct MeetingTabContentView: View {
     // MARK: - Status Bar
 
     private func regenerateSummary() {
-        state.onGenerateSummary?(tab.transcript)
+        let modelKind = LocalCleanupModelKind(rawValue: selectedModelKind) ?? .qwen35_0_8b_q4_k_m
+        state.onGenerateSummary?(tab.transcript, modelKind)
     }
 
     private var statusBar: some View {

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -142,6 +142,31 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         })
     }
 
+    func testGenerateSummaryPassesSummaryPromptAsSystemPromptNotDefaultCleanupPrompt() async {
+        let transcript = makeSingleChunkTranscript()
+        var capturedPrompt: String?
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, prompt, modelKind, _ in
+                capturedPrompt = prompt
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Final summary",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertEqual(summary, "Final summary")
+        XCTAssertEqual(capturedPrompt, MeetingSummaryGenerator.finalSummaryPrompt)
+        XCTAssertNotEqual(capturedPrompt, TextCleaner.defaultPrompt)
+    }
+
     func testGenerateSummarySingleChunkCombineFailureHasNoRollupLine() async {
         let transcript = makeSingleChunkTranscript()
         let cleanupManager = TextCleanupManager(

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -167,6 +167,33 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         XCTAssertNotEqual(capturedPrompt, TextCleaner.defaultPrompt)
     }
 
+    func testGenerateSummaryUsesExplicitModelKindOverrideNotTheManagersDefault() async {
+        let transcript = makeSingleChunkTranscript()
+        var capturedModelKind: LocalCleanupModelKind?
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_0_8b_q4_k_m: true,
+                .qwen35_4b_q4_k_m: true
+            ],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                capturedModelKind = modelKind
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Final summary",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+
+        let summary = await generator.generateSummary(transcript: transcript, modelKind: .qwen35_4b_q4_k_m)
+
+        XCTAssertEqual(summary, "Final summary")
+        XCTAssertEqual(capturedModelKind, .qwen35_4b_q4_k_m)
+    }
+
     func testGenerateSummarySingleChunkCombineFailureHasNoRollupLine() async {
         let transcript = makeSingleChunkTranscript()
         let cleanupManager = TextCleanupManager(

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @MainActor
 final class MeetingSummaryGeneratorTests: XCTestCase {
     private func makeMultiChunkTranscript(chunkCount: Int) -> MeetingTranscript {
-        let transcript = MeetingTranscript(meetingName: "Job Interview with Eric Brengle")
+        let transcript = MeetingTranscript(meetingName: "Long Meeting")
         // ~6000 chars: bigger than the 5000-char chunk limit on its own,
         // so each segment becomes exactly one chunk.
         let oversizedText = String(repeating: "word ", count: 1200)

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class MeetingSummaryGeneratorTests: XCTestCase {
+    private func makeMultiChunkTranscript(chunkCount: Int) -> MeetingTranscript {
+        let transcript = MeetingTranscript(meetingName: "Job Interview with Eric Brengle")
+        // ~6000 chars: bigger than the 5000-char chunk limit on its own,
+        // so each segment becomes exactly one chunk.
+        let oversizedText = String(repeating: "word ", count: 1200)
+        for i in 0..<chunkCount {
+            transcript.appendSegment(
+                TranscriptSegment(
+                    id: UUID(),
+                    speaker: .remote(name: "Eric"),
+                    startTime: TimeInterval(i * 60),
+                    endTime: TimeInterval(i * 60 + 30),
+                    text: "\(oversizedText) segment \(i)"
+                )
+            )
+        }
+        return transcript
+    }
+
+    private func makeSingleChunkTranscript() -> MeetingTranscript {
+        let transcript = MeetingTranscript(meetingName: "Quick Sync")
+        transcript.appendSegment(
+            TranscriptSegment(
+                id: UUID(),
+                speaker: .remote(name: "Eric"),
+                startTime: 0,
+                endTime: 30,
+                text: "Short meeting transcript."
+            )
+        )
+        return transcript
+    }
+
+    func testGenerateSummarySucceedsLogsStartAndRollup() async {
+        let transcript = makeMultiChunkTranscript(chunkCount: 3)
+        var callCount = 0
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                callCount += 1
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Summary for call \(callCount)",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+        var logged: [(DebugLogCategory, String)] = []
+        generator.debugLogger = { logged.append(($0, $1)) }
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNotNil(summary)
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("starting for") && $0.1.contains("3 chunk(s)")
+        })
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("chunk summarization complete — 3/3 chunks succeeded")
+        })
+        XCTAssertFalse(logged.contains { $0.1.contains("failed") })
+    }
+
+    func testGenerateSummaryLogsChunkFailureAndStillSucceeds() async {
+        let transcript = makeMultiChunkTranscript(chunkCount: 3)
+        var callCount = 0
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                callCount += 1
+                if callCount == 2 {
+                    return CleanupModelProbeRawResult(
+                        modelKind: modelKind,
+                        modelDisplayName: "test",
+                        rawOutput: "...",
+                        elapsed: 0.01
+                    )
+                }
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Summary for call \(callCount)",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+        var logged: [(DebugLogCategory, String)] = []
+        generator.debugLogger = { logged.append(($0, $1)) }
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNotNil(summary)
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("chunk 2/3 failed") &&
+            $0.1.contains("returned unusable output") &&
+            $0.1.contains("dropped from summary")
+        })
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("chunk summarization complete — 2/3 chunks succeeded")
+        })
+    }
+
+    func testGenerateSummaryLogsFinalCombineFailureAndDiscardsChunkSummaries() async {
+        let transcript = makeMultiChunkTranscript(chunkCount: 3)
+        var callCount = 0
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                callCount += 1
+                if callCount == 4 {
+                    throw CancellationError()
+                }
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Summary for call \(callCount)",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+        var logged: [(DebugLogCategory, String)] = []
+        generator.debugLogger = { logged.append(($0, $1)) }
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNil(summary)
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("final combine step failed") &&
+            $0.1.contains("timed out after 15s") &&
+            $0.1.contains("3/3 chunk summaries discarded")
+        })
+    }
+
+    func testGenerateSummarySingleChunkCombineFailureHasNoRollupLine() async {
+        let transcript = makeSingleChunkTranscript()
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, _, _ in
+                throw CancellationError()
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+        var logged: [(DebugLogCategory, String)] = []
+        generator.debugLogger = { logged.append(($0, $1)) }
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNil(summary)
+        XCTAssertFalse(logged.contains { $0.1.contains("chunk summarization complete") })
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("final combine step failed") &&
+            $0.1.contains("timed out after 15s")
+        })
+    }
+}

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -221,6 +221,25 @@ final class TextCleanupManagerTests: XCTestCase {
         }
     }
 
+    func testCleanupThrowsTimedOutWhenProbeIsCancelled() async {
+        let manager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_2b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_2b_q4_k_m: true
+            ],
+            probeExecutionOverride: { _, _, _, _ in
+                throw CancellationError()
+            }
+        )
+
+        await XCTAssertThrowsErrorAsync(try await manager.clean(text: "hello", prompt: "unused")) { error in
+            XCTAssertEqual(
+                error as? CleanupBackendError,
+                .timedOut(seconds: 15.0)
+            )
+        }
+    }
+
     func testDeleteCachedModelRemovesOnlyTheConfiguredCacheFileAndNotifiesObservers() throws {
         let modelsDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
Meeting summary generation was failing on me in a way the debug log couldn't explain — a run of successful chunk summaries followed by one opaque failure, no indication why. This PR adds the logging that would've told me, then uses it to find and fix two separate bugs underneath.

Fixes matthartman/ghost-pepper#157
Fixes matthartman/ghost-pepper#158

**What's in here:**

1. `TextCleanupManager.clean()`'s 15-second timeout was indistinguishable from "model not available" — both collapsed into the same generic `CleanupBackendError.unavailable`. Added a proper `.timedOut(seconds:)` case so the real reason surfaces.
2. `MeetingSummaryGenerator` now logs the pipeline start, a per-chunk success/failure roll-up, and the specific reason for any chunk/combine failure — counts and reasons only, never transcript or summary content.
3. **#157:** `runLLM` was folding the summarisation instructions into the user text and calling `clean(prompt: nil)`, which silently defaults to `TextCleaner.defaultPrompt` — the live-dictation "do NOT summarise, reproduce everything" persona. So every chunk *and* the combine call ran under a system prompt contradicting the instruction sitting in the user message. Small per-chunk inputs apparently tolerated the confusion; a 10-chunk combine didn't, and returned a literal `"..."`. `chunkPrompt`/`finalPrompt` now flow through as the real system prompt.
4. **#158:** the Summary tab's "Customize" model picker did nothing — it wrote to a local `@AppStorage` variable nothing downstream ever read, while generation quietly kept using the app's global default model. The picked model now threads through as an explicit per-regeneration override; it doesn't touch your global default.

I've only exercised this against the Qwen 3.5 models on my own machine — no read on whether the prompt bug behaved the same way against the MLX-backed models, since I haven't tested those paths.

**Test plan**
- [x] Full app test suite: 524/524 passing
- [x] New/updated: `TextCleanupManagerTests`, `MeetingSummaryGeneratorTests` (7 cases)
- [x] Manually reproduced both bugs in-app before fixing, retested after

🤖 Drafted and implemented with [Claude Code](https://claude.com/claude-code); I reviewed and tested every change myself.