### PR TITLE
Give meeting summaries their own model, context window, and timeout

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		C1949C00F2F721B802EC237E /* PepperChatWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB753C40197FA7255E1DEA29 /* PepperChatWindow.swift */; };
 		C1A07FBD7318A26BA879232A /* ModelInventoryViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B68F46BA90BDD633868A8CE /* ModelInventoryViews.swift */; };
 		C4E8739F267E3096E97FBE71 /* DebugLogStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */; };
+		6ED7D63ECE6340EB988D21F6 /* MeetingSummaryGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0994BF73ABCF4C77BD9B29B3 /* MeetingSummaryGeneratorTests.swift */; };
 		C54F09E5E2BAA930626E855C /* SpeechTranscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2CC027B53AAE03079D78761 /* SpeechTranscriber.swift */; };
 		C5D011A82469050DF1E7F462 /* IndexBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF8311B6325214FE6B40CDE /* IndexBuilder.swift */; };
 		C6EDBC09902D8470DBFD5255 /* IndexSystemPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D736758B588185CCE102504 /* IndexSystemPrompt.swift */; };
@@ -259,6 +260,7 @@
 		1C82FF777F1863DC84525AC2 /* cytoscape.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = cytoscape.min.js; sourceTree = "<group>"; };
 		1DC632CC6DD4F55F2FA05480 /* FrontmostWindowOCRService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmostWindowOCRService.swift; sourceTree = "<group>"; };
 		1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogStoreTests.swift; sourceTree = "<group>"; };
+		0994BF73ABCF4C77BD9B29B3 /* MeetingSummaryGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSummaryGeneratorTests.swift; sourceTree = "<group>"; };
 		207AAC1CBC60052D1493D13D /* SettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindow.swift; sourceTree = "<group>"; };
 		231812B1BF8E3F2D5E0209F3 /* ShortcutCaptureStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCaptureStateTests.swift; sourceTree = "<group>"; };
 		23B813180F29336A298BE44E /* LocalLLMCleanupBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalLLMCleanupBackend.swift; sourceTree = "<group>"; };
@@ -887,6 +889,7 @@
 				AA783B889855B0811E210751 /* CleanupPromptEvalTests.swift */,
 				350AC3A5A34A78F96226831C /* CorrectionStoreTests.swift */,
 				1FE9E126BC8CAD84D453AD72 /* DebugLogStoreTests.swift */,
+				0994BF73ABCF4C77BD9B29B3 /* MeetingSummaryGeneratorTests.swift */,
 				A5F781190896573C3BA687CB /* FluidAudioSpeechSessionTests.swift */,
 				9FBC0D906FF181E91A758F58 /* FocusedElementLocatorTests.swift */,
 				363A3F98CDFC4CCAD927835C /* GhostPepperTests.swift */,
@@ -1244,6 +1247,7 @@
 				E62BA209042B0FA8B53E2C76 /* CleanupPromptEvalTests.swift in Sources */,
 				3512549BBD28CC74C0137FA3 /* CorrectionStoreTests.swift in Sources */,
 				C4E8739F267E3096E97FBE71 /* DebugLogStoreTests.swift in Sources */,
+				6ED7D63ECE6340EB988D21F6 /* MeetingSummaryGeneratorTests.swift in Sources */,
 				AFAAFB58F0A76F5213F67C45 /* FluidAudioSpeechSessionTests.swift in Sources */,
 				F0598B5D027A5B31EF1B7664 /* FocusedElementLocatorTests.swift in Sources */,
 				FC6AACB283BD40C4FBA78F3D /* GhostPepperTests.swift in Sources */,

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1875,6 +1875,17 @@ class AppState: ObservableObject {
     func generateMeetingSummary(for transcript: MeetingTranscript, modelKind: LocalCleanupModelKind? = nil) async {
         guard !transcript.segments.isEmpty else { return }
         transcript.isGeneratingSummary = true
+        let effectiveModelKind = modelKind ?? textCleanupManager.selectedMeetingSummaryModelKind
+        guard textCleanupManager.isModelDownloaded(effectiveModelKind) else {
+            let modelName = TextCleanupManager.cleanupModels.first(where: { $0.kind == effectiveModelKind })?.displayName
+                ?? effectiveModelKind.rawValue
+            debugLogStore.record(
+                category: .model,
+                message: "Meeting summary skipped for \(transcript.meetingName): selected summarization model \(modelName) isn't downloaded yet. Download it in Settings → Models."
+            )
+            transcript.isGeneratingSummary = false
+            return
+        }
         let generator = MeetingSummaryGenerator(cleanupManager: textCleanupManager)
         generator.debugLogger = debugLogStore.record
         let result = await generator.generateSummary(

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1289,8 +1289,8 @@ class AppState: ObservableObject {
                 await self?.finishMeetingSession(session, logPrefix: "Meeting stopped")
             }
         }
-        controller.onGenerateSummary = { [weak self] transcript in
-            Task { await self?.generateMeetingSummary(for: transcript) }
+        controller.onGenerateSummary = { [weak self] transcript, modelKind in
+            Task { await self?.generateMeetingSummary(for: transcript, modelKind: modelKind) }
         }
         controller.onLoadSpeakerReviewItems = { [weak self] transcript in
             self?.meetingSpeakerReviewItems(for: transcript) ?? []
@@ -1872,7 +1872,7 @@ class AppState: ObservableObject {
         }
     }
 
-    func generateMeetingSummary(for transcript: MeetingTranscript) async {
+    func generateMeetingSummary(for transcript: MeetingTranscript, modelKind: LocalCleanupModelKind? = nil) async {
         guard !transcript.segments.isEmpty else { return }
         transcript.isGeneratingSummary = true
         let generator = MeetingSummaryGenerator(cleanupManager: textCleanupManager)
@@ -1880,7 +1880,8 @@ class AppState: ObservableObject {
         let result = await generator.generateSummary(
             transcript: transcript,
             chunkPrompt: MeetingSummaryGenerator.defaultPrompt,
-            finalPrompt: meetingSummaryPrompt
+            finalPrompt: meetingSummaryPrompt,
+            modelKind: modelKind
         )
         transcript.summary = result
         transcript.isGeneratingSummary = false

--- a/GhostPepper/AppState.swift
+++ b/GhostPepper/AppState.swift
@@ -1876,6 +1876,7 @@ class AppState: ObservableObject {
         guard !transcript.segments.isEmpty else { return }
         transcript.isGeneratingSummary = true
         let generator = MeetingSummaryGenerator(cleanupManager: textCleanupManager)
+        generator.debugLogger = debugLogStore.record
         let result = await generator.generateSummary(
             transcript: transcript,
             chunkPrompt: MeetingSummaryGenerator.defaultPrompt,

--- a/GhostPepper/Cleanup/CleanupBackend.swift
+++ b/GhostPepper/Cleanup/CleanupBackend.swift
@@ -8,6 +8,7 @@ enum CleanupBackendError: Error, Equatable {
     case unavailable
     case unsupportedRuntime(String)
     case unusableOutput(rawOutput: String)
+    case timedOut(seconds: TimeInterval)
 }
 
 extension CleanupBackendError: LocalizedError {
@@ -19,6 +20,8 @@ extension CleanupBackendError: LocalizedError {
             return message
         case .unusableOutput:
             return "The selected local model returned unusable output."
+        case .timedOut(let seconds):
+            return "The local model timed out after \(Int(seconds))s."
         }
     }
 }

--- a/GhostPepper/Cleanup/TextCleaner.swift
+++ b/GhostPepper/Cleanup/TextCleaner.swift
@@ -179,7 +179,7 @@ final class TextCleaner {
             let postProcessDuration = Date().timeIntervalSince(postProcessStart)
 
             switch error {
-            case .unavailable, .unsupportedRuntime:
+            case .unavailable, .unsupportedRuntime, .timedOut:
                 debugLogger?(.cleanup, "Cleanup backend unavailable, returning raw transcription.")
                 return TextCleanerResult(
                     text: text,

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -16,6 +16,16 @@ private extension CleanupModelProbeThinkingMode {
     }
 }
 
+enum CleanupPurpose {
+    case realtime
+    case summarization
+}
+
+struct CleanupPurposeConfig {
+    let maxTokenCount: Int32
+    let timeoutSeconds: TimeInterval
+}
+
 enum CleanupModelState: Equatable {
     case idle
     case downloading(kind: LocalCleanupModelKind, progress: Double)
@@ -255,6 +265,15 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         }
 
         return .qwen35_4b_q4_k_m
+    }
+
+    static func config(for purpose: CleanupPurpose) -> CleanupPurposeConfig {
+        switch purpose {
+        case .realtime:
+            return CleanupPurposeConfig(maxTokenCount: 4096, timeoutSeconds: 15.0)
+        case .summarization:
+            return CleanupPurposeConfig(maxTokenCount: 16384, timeoutSeconds: 90.0)
+        }
     }
 
     var isReady: Bool { state == .ready }

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -401,6 +401,12 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
             case .modelUnavailable:
                 throw CleanupBackendError.unavailable
             }
+        } catch is CancellationError {
+            debugLogger?(
+                .cleanup,
+                "Local cleanup probe failed before producing usable output: timed out after \(Int(Self.timeoutSeconds))s."
+            )
+            throw CleanupBackendError.timedOut(seconds: Self.timeoutSeconds)
         } catch {
             debugLogger?(
                 .cleanup,

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -292,7 +292,6 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         isModelAvailable(selectedCleanupModelKind)
     }
 
-    private static let timeoutSeconds: TimeInterval = 15.0
     private static let selectedCleanupModelDefaultsKey = "selectedCleanupModelKind"
     private static let selectedMeetingSummaryModelDefaultsKey = "selectedMeetingSummaryModelKind"
     private static let systemPromptSentinel = "<|ghost-pepper-system-prefill-split|>"
@@ -398,9 +397,22 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         objectWillChange.send()
     }
 
+    /// Satisfies `TextCleaningManaging`'s exact 3-parameter signature: a
+    /// witness with an extra parameter — even a defaulted `purpose` — can't
+    /// stand in for the protocol requirement, so this forwards to the real
+    /// implementation below with the default purpose.
     func clean(text: String, prompt: String? = nil, modelKind: LocalCleanupModelKind? = nil) async throws -> String {
+        try await clean(text: text, prompt: prompt, modelKind: modelKind, purpose: .realtime)
+    }
+
+    func clean(
+        text: String,
+        prompt: String? = nil,
+        modelKind: LocalCleanupModelKind? = nil,
+        purpose: CleanupPurpose = .realtime
+    ) async throws -> String {
         let requestedModelKind = modelKind ?? selectedCleanupModelKind
-        await loadModel(kind: requestedModelKind)
+        await loadModel(kind: requestedModelKind, contextTokenCount: Self.config(for: purpose).maxTokenCount)
 
         guard model(for: requestedModelKind) != nil else {
             debugLogger?(
@@ -416,7 +428,8 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
                 text: text,
                 prompt: activePrompt,
                 modelKind: requestedModelKind,
-                thinkingMode: .suppressed
+                thinkingMode: .suppressed,
+                purpose: purpose
             )
             let cleaned = result.rawOutput.trimmingCharacters(in: .whitespacesAndNewlines)
             if cleaned.isEmpty || cleaned == "..." {
@@ -438,11 +451,12 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
                 throw CleanupBackendError.unavailable
             }
         } catch is CancellationError {
+            let timeoutSeconds = Self.config(for: purpose).timeoutSeconds
             debugLogger?(
                 .cleanup,
-                "Local cleanup probe failed before producing usable output: timed out after \(Int(Self.timeoutSeconds))s."
+                "Local cleanup probe failed before producing usable output: timed out after \(Int(timeoutSeconds))s."
             )
-            throw CleanupBackendError.timedOut(seconds: Self.timeoutSeconds)
+            throw CleanupBackendError.timedOut(seconds: timeoutSeconds)
         } catch {
             debugLogger?(
                 .cleanup,
@@ -540,13 +554,14 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         text: String,
         prompt: String,
         modelKind: LocalCleanupModelKind,
-        thinkingMode: CleanupModelProbeThinkingMode
+        thinkingMode: CleanupModelProbeThinkingMode,
+        purpose: CleanupPurpose
     ) async throws -> CleanupModelProbeRawResult {
         await probeExecutionGate.acquire()
         do {
             if let probeExecutionOverride {
                 let result = try await probeExecutionOverride(text, prompt, modelKind, thinkingMode)
-                logTokenBudget(text: text, prompt: prompt, modelKind: modelKind, rawOutput: result.rawOutput, elapsed: result.elapsed)
+                logTokenBudget(text: text, prompt: prompt, modelKind: modelKind, purpose: purpose, rawOutput: result.rawOutput, elapsed: result.elapsed)
                 await probeExecutionGate.release()
                 return result
             }
@@ -561,6 +576,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
             }
 
             let start = Date()
+            let timeoutSeconds = Self.config(for: purpose).timeoutSeconds
             do {
                 let preparedCompletionInput: String?
                 if let preparedPromptContext,
@@ -577,7 +593,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
 
                 let rawOutput: String
                 if let preparedCompletionInput {
-                    rawOutput = try await withTimeout(seconds: Self.timeoutSeconds) { [self] in
+                    rawOutput = try await withTimeout(seconds: timeoutSeconds) { [self] in
                         await generateFromPreparedContext(
                             llm: llm,
                             completionInput: preparedCompletionInput,
@@ -585,7 +601,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
                         )
                     }
                 } else {
-                    rawOutput = try await withTimeout(seconds: Self.timeoutSeconds) {
+                    rawOutput = try await withTimeout(seconds: timeoutSeconds) {
                         llm.useResolvedTemplate(systemPrompt: prompt)
                         llm.history = []
                         await llm.respond(to: text, thinking: thinkingMode.llmThinkingMode)
@@ -593,7 +609,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
                     }
                 }
                 let elapsed = Date().timeIntervalSince(start)
-                logTokenBudget(text: text, prompt: prompt, modelKind: modelKind, rawOutput: rawOutput, elapsed: elapsed)
+                logTokenBudget(text: text, prompt: prompt, modelKind: modelKind, purpose: purpose, rawOutput: rawOutput, elapsed: elapsed)
                 await probeExecutionGate.release()
                 return CleanupModelProbeRawResult(
                     modelKind: modelKind,
@@ -863,15 +879,16 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         text: String,
         prompt: String,
         modelKind: LocalCleanupModelKind,
+        purpose: CleanupPurpose,
         rawOutput: String,
         elapsed: TimeInterval
     ) {
         let promptTokens = Self.estimatedTokenCount(text) + Self.estimatedTokenCount(prompt)
         let outputTokens = Self.estimatedTokenCount(rawOutput)
-        let maxTokens = Int(descriptor(for: modelKind).maxTokenCount)
+        let maxTokens = Int(min(Self.config(for: purpose).maxTokenCount, descriptor(for: modelKind).maxTokenCount))
         debugLogger?(
             .cleanup,
-            "Local cleanup finished in \(String(format: "%.2f", elapsed))s using \(descriptor(for: modelKind).displayName) — ~\(promptTokens) prompt + ~\(outputTokens) output of \(maxTokens) max tokens."
+            "Local cleanup finished in \(String(format: "%.2f", elapsed))s using \(descriptor(for: modelKind).displayName) — ~\(promptTokens) prompt + ~\(outputTokens) output of \(maxTokens) max tokens (\(purpose))."
         )
     }
 

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -177,6 +177,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
 
     private(set) var activeLLM: LLM?
     private(set) var activeLoadedModelKind: LocalCleanupModelKind?
+    private(set) var activeLoadedContextTokenCount: Int32?
 
     static let compactModel = CleanupModelDescriptor(
         kind: .qwen35_0_8b_q4_k_m,
@@ -388,6 +389,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         if activeLoadedModelKind == kind {
             activeLLM = nil
             activeLoadedModelKind = nil
+            activeLoadedContextTokenCount = nil
             state = .idle
             errorMessage = nil
             return
@@ -647,8 +649,10 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         await loadModel()
     }
 
-    func loadModel(kind: LocalCleanupModelKind) async {
-        if activeLoadedModelKind == kind && activeLLM != nil {
+    func loadModel(kind: LocalCleanupModelKind, contextTokenCount: Int32) async {
+        let requestedContext = min(contextTokenCount, descriptor(for: kind).maxTokenCount)
+
+        if activeLoadedModelKind == kind && activeLoadedContextTokenCount == requestedContext && activeLLM != nil {
             state = .ready
             errorMessage = nil
             return
@@ -656,7 +660,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
 
         if case .loadingModel = state {
             await waitForActiveLoad()
-            if activeLoadedModelKind == kind && activeLLM != nil {
+            if activeLoadedModelKind == kind && activeLoadedContextTokenCount == requestedContext && activeLLM != nil {
                 state = .ready
                 errorMessage = nil
                 return
@@ -687,8 +691,6 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
             do {
                 try await downloadModel(kind: kind, url: descriptor.url, to: path)
             } catch {
-                // User-initiated cancellation should drop the row back to
-                // "not downloaded" without surfacing a scary red error.
                 let nsError = error as NSError
                 let isCancelled = error is CancellationError
                     || nsError.code == NSURLErrorCancelled
@@ -716,9 +718,10 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         state = .loadingModel(kind: kind)
         activeLLM = nil
         activeLoadedModelKind = nil
+        activeLoadedContextTokenCount = nil
 
         let loadedModel = await Task.detached { () -> LLM? in
-            guard let llm = LLM(from: path, maxTokenCount: descriptor.maxTokenCount) else {
+            guard let llm = LLM(from: path, maxTokenCount: requestedContext) else {
                 return nil
             }
             llm.useResolvedTemplate(systemPrompt: TextCleaner.defaultPrompt)
@@ -737,9 +740,14 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         loadedModel.postprocess = { (_: String) in }
         activeLLM = loadedModel
         activeLoadedModelKind = kind
+        activeLoadedContextTokenCount = requestedContext
         state = .ready
         errorMessage = nil
         debugLogger?(.model, "Local cleanup model ready: \(descriptor.displayName).")
+    }
+
+    func loadModel(kind: LocalCleanupModelKind) async {
+        await loadModel(kind: kind, contextTokenCount: descriptor(for: kind).maxTokenCount)
     }
 
     /// Kicks off a tracked `loadModel(kind:)` so callers can later cancel it
@@ -782,6 +790,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
     func unloadModel() {
         activeLLM = nil
         activeLoadedModelKind = nil
+        activeLoadedContextTokenCount = nil
         state = .idle
         errorMessage = nil
         debugLogger?(.model, "Unloaded local cleanup models.")

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -170,7 +170,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         url: "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_K_M.gguf",
         expectedSHA256: "bd258782e35f7f458f8aced1adc053e6e92e89bc735ba3be89d38a06121dc517",
         expectedByteCount: 532_517_120,
-        maxTokenCount: 4096,
+        maxTokenCount: 16_384,
         recommendation: .veryFast
     )
 
@@ -182,7 +182,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         url: "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/f6d5376be1edb4d416d56da11e5397a961aca8ae/Qwen3.5-2B-Q4_K_M.gguf",
         expectedSHA256: "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223",
         expectedByteCount: 1_280_835_840,
-        maxTokenCount: 4096,
+        maxTokenCount: 16_384,
         recommendation: .fast
     )
 
@@ -194,7 +194,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         url: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/e87f176479d0855a907a41277aca2f8ee7a09523/Qwen3.5-4B-Q4_K_M.gguf",
         expectedSHA256: "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4",
         expectedByteCount: 2_740_937_888,
-        maxTokenCount: 8192,
+        maxTokenCount: 16_384,
         recommendation: .full
     )
 
@@ -510,6 +510,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         do {
             if let probeExecutionOverride {
                 let result = try await probeExecutionOverride(text, prompt, modelKind, thinkingMode)
+                logTokenBudget(text: text, prompt: prompt, modelKind: modelKind, rawOutput: result.rawOutput, elapsed: result.elapsed)
                 await probeExecutionGate.release()
                 return result
             }
@@ -556,10 +557,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
                     }
                 }
                 let elapsed = Date().timeIntervalSince(start)
-                debugLogger?(
-                    .cleanup,
-                    "Local cleanup finished in \(String(format: "%.2f", elapsed))s using \(descriptor(for: modelKind).displayName)."
-                )
+                logTokenBudget(text: text, prompt: prompt, modelKind: modelKind, rawOutput: rawOutput, elapsed: elapsed)
                 await probeExecutionGate.release()
                 return CleanupModelProbeRawResult(
                     modelKind: modelKind,
@@ -811,6 +809,31 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
 
     private func descriptor(for modelKind: LocalCleanupModelKind) -> CleanupModelDescriptor {
         Self.cleanupModels.first(where: { $0.kind == modelKind })!
+    }
+
+    /// Logs an estimated token budget (~4 chars/token) so a completion that's
+    /// suspiciously short relative to the model's context window — the
+    /// signature of hitting `maxTokenCount` mid-generation rather than an
+    /// error — is visible in the debug log rather than looking like a normal
+    /// success.
+    private func logTokenBudget(
+        text: String,
+        prompt: String,
+        modelKind: LocalCleanupModelKind,
+        rawOutput: String,
+        elapsed: TimeInterval
+    ) {
+        let promptTokens = Self.estimatedTokenCount(text) + Self.estimatedTokenCount(prompt)
+        let outputTokens = Self.estimatedTokenCount(rawOutput)
+        let maxTokens = Int(descriptor(for: modelKind).maxTokenCount)
+        debugLogger?(
+            .cleanup,
+            "Local cleanup finished in \(String(format: "%.2f", elapsed))s using \(descriptor(for: modelKind).displayName) — ~\(promptTokens) prompt + ~\(outputTokens) output of \(maxTokens) max tokens."
+        )
+    }
+
+    private static func estimatedTokenCount(_ text: String) -> Int {
+        max(1, Int(ceil(Double(text.count) / 4.0)))
     }
 
     private func availabilityOverride(for modelKind: LocalCleanupModelKind) -> Bool? {

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -689,7 +689,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
 
         let descriptor = descriptor(for: kind)
         let path = modelPath(for: descriptor.fileName)
-        debugLogger?(.model, "Loading local cleanup model \(descriptor.displayName).")
+        debugLogger?(.model, "Loading local cleanup model \(descriptor.displayName) with \(requestedContext) context.")
 
         if FileManager.default.fileExists(atPath: path.path), !Self.isVerifiedModelFile(path, descriptor: descriptor) {
             try? FileManager.default.removeItem(at: path)
@@ -754,7 +754,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         activeLoadedContextTokenCount = requestedContext
         state = .ready
         errorMessage = nil
-        debugLogger?(.model, "Local cleanup model ready: \(descriptor.displayName).")
+        debugLogger?(.model, "Local cleanup model ready: \(descriptor.displayName) with \(requestedContext) context.")
     }
 
     func loadModel(kind: LocalCleanupModelKind, purpose: CleanupPurpose = .realtime) async {

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -412,15 +412,6 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         purpose: CleanupPurpose = .realtime
     ) async throws -> String {
         let requestedModelKind = modelKind ?? selectedCleanupModelKind
-        await loadModel(kind: requestedModelKind, contextTokenCount: Self.config(for: purpose).maxTokenCount)
-
-        guard model(for: requestedModelKind) != nil else {
-            debugLogger?(
-                .cleanup,
-                "Skipped local cleanup because model \(requestedModelKind.rawValue) was not ready."
-            )
-            throw CleanupBackendError.unavailable
-        }
 
         let activePrompt = prompt ?? TextCleaner.defaultPrompt
         do {
@@ -480,7 +471,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         thinkingMode: ThinkingMode = .suppressed
     ) async throws -> AsyncStream<String> {
         let requestedModelKind = modelKind ?? selectedCleanupModelKind
-        await loadModel(kind: requestedModelKind)
+        await loadModel(kind: requestedModelKind, contextTokenCount: descriptor(for: requestedModelKind).maxTokenCount)
         let requestedDescriptor = descriptor(for: requestedModelKind)
 
         if case .mlxRepository = requestedDescriptor.runtime {
@@ -559,6 +550,8 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
     ) async throws -> CleanupModelProbeRawResult {
         await probeExecutionGate.acquire()
         do {
+            await loadModel(kind: modelKind, contextTokenCount: Self.config(for: purpose).maxTokenCount)
+
             if let probeExecutionOverride {
                 let result = try await probeExecutionOverride(text, prompt, modelKind, thinkingMode)
                 logTokenBudget(text: text, prompt: prompt, modelKind: modelKind, purpose: purpose, rawOutput: result.rawOutput, elapsed: result.elapsed)
@@ -707,6 +700,8 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
             do {
                 try await downloadModel(kind: kind, url: descriptor.url, to: path)
             } catch {
+                // User-initiated cancellation should drop the row back to
+                // "not downloaded" without surfacing a scary red error.
                 let nsError = error as NSError
                 let isCancelled = error is CancellationError
                     || nsError.code == NSURLErrorCancelled
@@ -762,8 +757,8 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         debugLogger?(.model, "Local cleanup model ready: \(descriptor.displayName).")
     }
 
-    func loadModel(kind: LocalCleanupModelKind) async {
-        await loadModel(kind: kind, contextTokenCount: descriptor(for: kind).maxTokenCount)
+    func loadModel(kind: LocalCleanupModelKind, purpose: CleanupPurpose = .realtime) async {
+        await loadModel(kind: kind, contextTokenCount: Self.config(for: purpose).maxTokenCount)
     }
 
     /// Kicks off a tracked `loadModel(kind:)` so callers can later cancel it

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -333,9 +333,16 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         self.selectedCleanupModelKind = initialKind
         defaults.set(initialKind.rawValue, forKey: Self.selectedCleanupModelDefaultsKey)
 
+        // New users only auto-download `initialKind` (via onboarding); Full
+        // is never auto-downloaded. Defaulting summarization to Full only
+        // when it's already present means a fresh install needs exactly one
+        // download, and an existing user needs zero.
+        let smartSummaryDefault = Self.isModelDownloaded(Self.meetingSummaryModelFallback, in: self.modelsDirectory)
+            ? Self.meetingSummaryModelFallback
+            : initialKind
         let storedSummaryKind = LocalCleanupModelKind(
             rawValue: defaults.string(forKey: Self.selectedMeetingSummaryModelDefaultsKey) ?? ""
-        ) ?? .qwen35_4b_q4_k_m
+        ) ?? smartSummaryDefault
         let initialSummaryKind = selectedMeetingSummaryModelKind ?? storedSummaryKind
         self.selectedMeetingSummaryModelKind = initialSummaryKind
         defaults.set(initialSummaryKind.rawValue, forKey: Self.selectedMeetingSummaryModelDefaultsKey)
@@ -370,10 +377,21 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         return appSupport.appendingPathComponent("GhostPepper/models", isDirectory: true)
     }
 
-    static func isModelDownloaded(_ kind: LocalCleanupModelKind) -> Bool {
+    /// Single source of truth for the meeting-summary preference's
+    /// last-resort fallback — referenced here and by
+    /// `MeetingTranscriptWindow`'s `@AppStorage` default, so the two never
+    /// drift apart the way `selectedCleanupModelKind`'s coincidental
+    /// UserDefaults sharing once did (ghost-pepper#158).
+    static let meetingSummaryModelFallback: LocalCleanupModelKind = .qwen35_4b_q4_k_m
+
+    static func isModelDownloaded(_ kind: LocalCleanupModelKind, in directory: URL) -> Bool {
         guard let desc = cleanupModels.first(where: { $0.kind == kind }) else { return false }
-        let path = modelsDirectory.appendingPathComponent(desc.fileName)
+        let path = directory.appendingPathComponent(desc.fileName)
         return isVerifiedModelFile(path, descriptor: desc)
+    }
+
+    static func isModelDownloaded(_ kind: LocalCleanupModelKind) -> Bool {
+        isModelDownloaded(kind, in: modelsDirectory)
     }
 
     func isModelDownloaded(_ kind: LocalCleanupModelKind) -> Bool {

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -167,6 +167,12 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         }
     }
 
+    @Published var selectedMeetingSummaryModelKind: LocalCleanupModelKind {
+        didSet {
+            defaults.set(selectedMeetingSummaryModelKind.rawValue, forKey: Self.selectedMeetingSummaryModelDefaultsKey)
+        }
+    }
+
     var debugLogger: ((DebugLogCategory, String) -> Void)?
 
     private(set) var activeLLM: LLM?
@@ -287,6 +293,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
 
     private static let timeoutSeconds: TimeInterval = 15.0
     private static let selectedCleanupModelDefaultsKey = "selectedCleanupModelKind"
+    private static let selectedMeetingSummaryModelDefaultsKey = "selectedMeetingSummaryModelKind"
     private static let systemPromptSentinel = "<|ghost-pepper-system-prefill-split|>"
     private static let userInputSentinel = "<|ghost-pepper-user-prefill-split|>"
     private static let repositoryDownloadMarkerFileName = ".ghostpepper-model-cache-complete"
@@ -307,6 +314,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
     init(
         defaults: UserDefaults = .standard,
         selectedCleanupModelKind: LocalCleanupModelKind? = nil,
+        selectedMeetingSummaryModelKind: LocalCleanupModelKind? = nil,
         cleanupModelAvailabilityOverrides: [LocalCleanupModelKind: Bool] = [:],
         probeExecutionOverride: CleanupModelProbeExecutionOverride? = nil,
         backendShutdownOverride: (() -> Void)? = nil,
@@ -324,6 +332,13 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         let initialKind = selectedCleanupModelKind ?? storedKind
         self.selectedCleanupModelKind = initialKind
         defaults.set(initialKind.rawValue, forKey: Self.selectedCleanupModelDefaultsKey)
+
+        let storedSummaryKind = LocalCleanupModelKind(
+            rawValue: defaults.string(forKey: Self.selectedMeetingSummaryModelDefaultsKey) ?? ""
+        ) ?? .qwen35_4b_q4_k_m
+        let initialSummaryKind = selectedMeetingSummaryModelKind ?? storedSummaryKind
+        self.selectedMeetingSummaryModelKind = initialSummaryKind
+        defaults.set(initialSummaryKind.rawValue, forKey: Self.selectedMeetingSummaryModelDefaultsKey)
     }
 
     func selectedModelKind(wordCount: Int, isQuestion: Bool) -> LocalCleanupModelKind? {

--- a/GhostPepper/Cleanup/TextCleanupManager.swift
+++ b/GhostPepper/Cleanup/TextCleanupManager.swift
@@ -154,7 +154,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         }
     }
 
-    private struct PreparedPromptContext {
+    struct PreparedPromptContext {
         let modelKind: LocalCleanupModelKind
         let plan: CleanupPromptPrefillPlan
     }
@@ -305,7 +305,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
     private let modelsDirectory: URL
     private let probeExecutionGate = CleanupProbeExecutionGate()
     private var promptPrefillTask: Task<Void, Never>?
-    private var preparedPromptContext: PreparedPromptContext?
+    private(set) var preparedPromptContext: PreparedPromptContext?
     /// Tracks the in-flight download/load Task so the UI can cancel it. We
     /// only allow one load at a time (the manager has a single `activeLLM`
     /// slot), so a Task? is sufficient.
@@ -376,6 +376,14 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return appSupport.appendingPathComponent("GhostPepper/models", isDirectory: true)
     }
+
+    /// Context window for streamCompletion callers (the local agent tool
+    /// loop, Wiki generation, the Settings model probe) — deliberately its
+    /// own constant rather than a model's catalog `maxTokenCount`, so
+    /// raising that ceiling to give the summarization purpose headroom on
+    /// every model doesn't silently inflate KV-cache reservation for these
+    /// unrelated, non-purpose-scoped callers.
+    static let streamCompletionContextTokenCount: Int32 = 16384
 
     /// Single source of truth for the meeting-summary preference's
     /// last-resort fallback — referenced here and by
@@ -489,7 +497,7 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         thinkingMode: ThinkingMode = .suppressed
     ) async throws -> AsyncStream<String> {
         let requestedModelKind = modelKind ?? selectedCleanupModelKind
-        await loadModel(kind: requestedModelKind, contextTokenCount: descriptor(for: requestedModelKind).maxTokenCount)
+        await loadModel(kind: requestedModelKind, contextTokenCount: Self.streamCompletionContextTokenCount)
         let requestedDescriptor = descriptor(for: requestedModelKind)
 
         if case .mlxRepository = requestedDescriptor.runtime {
@@ -748,6 +756,12 @@ final class TextCleanupManager: ObservableObject, TextCleaningManaging {
         activeLLM = nil
         activeLoadedModelKind = nil
         activeLoadedContextTokenCount = nil
+        // A prepared prompt context was primed (llm.core.prepareContext)
+        // against the LLM instance being discarded here — it's keyed only
+        // on model kind, not instance identity, so a stale plan must not
+        // survive a reload, even a same-kind reload triggered purely by a
+        // context-size change.
+        preparedPromptContext = nil
 
         let loadedModel = await Task.detached { () -> LLM? in
             guard let llm = LLM(from: path, maxTokenCount: requestedContext) else {

--- a/GhostPepper/Meeting/MeetingSummaryGenerator.swift
+++ b/GhostPepper/Meeting/MeetingSummaryGenerator.swift
@@ -44,7 +44,8 @@ final class MeetingSummaryGenerator {
     func generateSummary(
         transcript: MeetingTranscript,
         chunkPrompt: String = MeetingSummaryGenerator.defaultPrompt,
-        finalPrompt: String = MeetingSummaryGenerator.finalSummaryPrompt
+        finalPrompt: String = MeetingSummaryGenerator.finalSummaryPrompt,
+        modelKind: LocalCleanupModelKind? = nil
     ) async -> String? {
         let segments = transcript.segments
         guard !segments.isEmpty else { return nil }
@@ -70,7 +71,7 @@ final class MeetingSummaryGenerator {
             // Short meeting — summarize directly with the final prompt
             let input = "\(notesPrefix)Meeting transcript:\n\n\(chunks[0])"
             do {
-                return try await runLLM(text: input, prompt: finalPrompt)
+                return try await runLLM(text: input, prompt: finalPrompt, modelKind: modelKind)
             } catch {
                 debugLogger?(
                     .model,
@@ -85,7 +86,7 @@ final class MeetingSummaryGenerator {
         for (i, chunk) in chunks.enumerated() {
             let input = "Meeting transcript (part \(i + 1) of \(chunks.count)):\n\n\(chunk)"
             do {
-                let summary = try await runLLM(text: input, prompt: chunkPrompt)
+                let summary = try await runLLM(text: input, prompt: chunkPrompt, modelKind: modelKind)
                 chunkSummaries.append(summary)
             } catch {
                 debugLogger?(
@@ -109,7 +110,7 @@ final class MeetingSummaryGenerator {
 
         let finalInput = "\(notesPrefix)Combined meeting notes:\n\n\(combined)"
         do {
-            return try await runLLM(text: finalInput, prompt: finalPrompt)
+            return try await runLLM(text: finalInput, prompt: finalPrompt, modelKind: modelKind)
         } catch {
             debugLogger?(
                 .model,
@@ -143,8 +144,8 @@ final class MeetingSummaryGenerator {
         return chunks
     }
 
-    private func runLLM(text: String, prompt: String) async throws -> String {
-        let result = try await cleanupManager.clean(text: text, prompt: prompt)
+    private func runLLM(text: String, prompt: String, modelKind: LocalCleanupModelKind?) async throws -> String {
+        let result = try await cleanupManager.clean(text: text, prompt: prompt, modelKind: modelKind)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/GhostPepper/Meeting/MeetingSummaryGenerator.swift
+++ b/GhostPepper/Meeting/MeetingSummaryGenerator.swift
@@ -8,6 +8,7 @@ import Foundation
 @MainActor
 final class MeetingSummaryGenerator {
     private let cleanupManager: TextCleanupManager
+    var debugLogger: ((DebugLogCategory, String) -> Void)?
 
     /// Maximum characters per chunk sent to the LLM (~1500 tokens ≈ 6000 chars).
     private let chunkCharLimit = 5000
@@ -56,6 +57,11 @@ final class MeetingSummaryGenerator {
         // Split into chunks
         let chunks = splitIntoChunks(fullText)
 
+        debugLogger?(
+            .model,
+            "Meeting summary: starting for \(transcript.meetingName) (\(segments.count) segments, \(chunks.count) chunk(s))."
+        )
+
         // Include user notes if available
         let notesText = transcript.notes.trimmingCharacters(in: .whitespacesAndNewlines)
         let notesPrefix = notesText.isEmpty ? "" : "User's notes during the meeting:\n\n\(notesText)\n\n"
@@ -63,17 +69,36 @@ final class MeetingSummaryGenerator {
         if chunks.count == 1 {
             // Short meeting — summarize directly with the final prompt
             let input = "\(notesPrefix)Meeting transcript:\n\n\(chunks[0])"
-            return await runLLM(text: input, prompt: finalPrompt)
+            do {
+                return try await runLLM(text: input, prompt: finalPrompt)
+            } catch {
+                debugLogger?(
+                    .model,
+                    "Meeting summary: final combine step failed (\(error.localizedDescription))."
+                )
+                return nil
+            }
         }
 
         // Multi-chunk: summarize each chunk, then combine
         var chunkSummaries: [String] = []
         for (i, chunk) in chunks.enumerated() {
             let input = "Meeting transcript (part \(i + 1) of \(chunks.count)):\n\n\(chunk)"
-            if let summary = await runLLM(text: input, prompt: chunkPrompt) {
+            do {
+                let summary = try await runLLM(text: input, prompt: chunkPrompt)
                 chunkSummaries.append(summary)
+            } catch {
+                debugLogger?(
+                    .model,
+                    "Meeting summary: chunk \(i + 1)/\(chunks.count) failed (\(error.localizedDescription)) — dropped from summary."
+                )
             }
         }
+
+        debugLogger?(
+            .model,
+            "Meeting summary: chunk summarization complete — \(chunkSummaries.count)/\(chunks.count) chunks succeeded."
+        )
 
         guard !chunkSummaries.isEmpty else { return nil }
 
@@ -83,7 +108,15 @@ final class MeetingSummaryGenerator {
         }.joined(separator: "\n\n")
 
         let finalInput = "\(notesPrefix)Combined meeting notes:\n\n\(combined)"
-        return await runLLM(text: finalInput, prompt: finalPrompt)
+        do {
+            return try await runLLM(text: finalInput, prompt: finalPrompt)
+        } catch {
+            debugLogger?(
+                .model,
+                "Meeting summary: final combine step failed (\(error.localizedDescription)) — \(chunkSummaries.count)/\(chunks.count) chunk summaries discarded."
+            )
+            return nil
+        }
     }
 
     // MARK: - Private
@@ -110,15 +143,9 @@ final class MeetingSummaryGenerator {
         return chunks
     }
 
-    private func runLLM(text: String, prompt: String) async -> String? {
-        do {
-            let fullPrompt = "\(prompt)\n\n\(text)"
-            let result = try await cleanupManager.clean(text: fullPrompt, prompt: nil)
-            let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        } catch {
-            print("MeetingSummaryGenerator: LLM failed — \(error.localizedDescription)")
-            return nil
-        }
+    private func runLLM(text: String, prompt: String) async throws -> String {
+        let fullPrompt = "\(prompt)\n\n\(text)"
+        let result = try await cleanupManager.clean(text: fullPrompt, prompt: nil)
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/GhostPepper/Meeting/MeetingSummaryGenerator.swift
+++ b/GhostPepper/Meeting/MeetingSummaryGenerator.swift
@@ -144,8 +144,7 @@ final class MeetingSummaryGenerator {
     }
 
     private func runLLM(text: String, prompt: String) async throws -> String {
-        let fullPrompt = "\(prompt)\n\n\(text)"
-        let result = try await cleanupManager.clean(text: fullPrompt, prompt: nil)
+        let result = try await cleanupManager.clean(text: text, prompt: prompt)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/GhostPepper/Meeting/MeetingSummaryGenerator.swift
+++ b/GhostPepper/Meeting/MeetingSummaryGenerator.swift
@@ -50,6 +50,8 @@ final class MeetingSummaryGenerator {
         let segments = transcript.segments
         guard !segments.isEmpty else { return nil }
 
+        let effectiveModelKind = modelKind ?? cleanupManager.selectedMeetingSummaryModelKind
+
         // Build the full transcript text
         let fullText = segments.map { segment in
             "[\(segment.formattedTimestamp)] \(segment.speaker.displayName): \(segment.text)"
@@ -71,7 +73,7 @@ final class MeetingSummaryGenerator {
             // Short meeting — summarize directly with the final prompt
             let input = "\(notesPrefix)Meeting transcript:\n\n\(chunks[0])"
             do {
-                return try await runLLM(text: input, prompt: finalPrompt, modelKind: modelKind)
+                return try await runLLM(text: input, prompt: finalPrompt, modelKind: effectiveModelKind)
             } catch {
                 debugLogger?(
                     .model,
@@ -86,7 +88,7 @@ final class MeetingSummaryGenerator {
         for (i, chunk) in chunks.enumerated() {
             let input = "Meeting transcript (part \(i + 1) of \(chunks.count)):\n\n\(chunk)"
             do {
-                let summary = try await runLLM(text: input, prompt: chunkPrompt, modelKind: modelKind)
+                let summary = try await runLLM(text: input, prompt: chunkPrompt, modelKind: effectiveModelKind)
                 chunkSummaries.append(summary)
             } catch {
                 debugLogger?(
@@ -110,7 +112,7 @@ final class MeetingSummaryGenerator {
 
         let finalInput = "\(notesPrefix)Combined meeting notes:\n\n\(combined)"
         do {
-            return try await runLLM(text: finalInput, prompt: finalPrompt, modelKind: modelKind)
+            return try await runLLM(text: finalInput, prompt: finalPrompt, modelKind: effectiveModelKind)
         } catch {
             debugLogger?(
                 .model,
@@ -144,8 +146,8 @@ final class MeetingSummaryGenerator {
         return chunks
     }
 
-    private func runLLM(text: String, prompt: String, modelKind: LocalCleanupModelKind?) async throws -> String {
-        let result = try await cleanupManager.clean(text: text, prompt: prompt, modelKind: modelKind)
+    private func runLLM(text: String, prompt: String, modelKind: LocalCleanupModelKind) async throws -> String {
+        let result = try await cleanupManager.clean(text: text, prompt: prompt, modelKind: modelKind, purpose: .summarization)
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/GhostPepper/UI/MeetingTranscriptWindow.swift
+++ b/GhostPepper/UI/MeetingTranscriptWindow.swift
@@ -1084,7 +1084,7 @@ final class MeetingTranscriptWindowController: NSObject, NSWindowDelegate {
     var onOpenSettings: (() -> Void)?
     var onStartRecording: ((_ name: String, _ detectedMeeting: DetectedMeeting?) throws -> MeetingSession)?
     var onStopRecording: ((MeetingSession) -> Void)?
-    var onGenerateSummary: ((MeetingTranscript) -> Void)?
+    var onGenerateSummary: ((MeetingTranscript, LocalCleanupModelKind) -> Void)?
     var onLoadSpeakerReviewItems: ((MeetingTranscript) -> [MeetingSpeakerReviewItem])?
     var onUpdateSpeakerLabel: ((_ transcript: MeetingTranscript, _ currentDisplayName: String, _ newDisplayName: String) throws -> Void)?
     var onAskQuestion: ((_ question: String, _ history: [QAHistoryTurn]) -> AsyncThrowingStream<QAEvent, Error>)?
@@ -1377,7 +1377,7 @@ final class MeetingWindowState: ObservableObject {
     var onOpenSettings: (() -> Void)?
     var onStartRecording: ((_ name: String, _ detectedMeeting: DetectedMeeting?) throws -> MeetingSession)?
     var onStopRecording: ((MeetingSession) -> Void)?
-    var onGenerateSummary: ((MeetingTranscript) -> Void)?
+    var onGenerateSummary: ((MeetingTranscript, LocalCleanupModelKind) -> Void)?
     var onLoadSpeakerReviewItems: ((MeetingTranscript) -> [MeetingSpeakerReviewItem])?
     var onUpdateSpeakerLabel: ((_ transcript: MeetingTranscript, _ currentDisplayName: String, _ newDisplayName: String) throws -> Void)?
     var onMakeIndexBuilder: ((IndexKind) -> (any IndexBuilding)?)?
@@ -9562,7 +9562,8 @@ struct MeetingTabContentView: View {
     // MARK: - Status Bar
 
     private func regenerateSummary() {
-        state.onGenerateSummary?(tab.transcript)
+        let modelKind = LocalCleanupModelKind(rawValue: selectedModelKind) ?? .qwen35_0_8b_q4_k_m
+        state.onGenerateSummary?(tab.transcript, modelKind)
     }
 
     private var statusBar: some View {

--- a/GhostPepper/UI/MeetingTranscriptWindow.swift
+++ b/GhostPepper/UI/MeetingTranscriptWindow.swift
@@ -8927,7 +8927,7 @@ struct MeetingTabContentView: View {
     @State private var speakerLabelDrafts: [String: String] = [:]
     @State private var speakerReviewError: String?
     @AppStorage("meetingSummaryPrompt") private var summaryPrompt: String = MeetingSummaryGenerator.finalSummaryPrompt
-    @AppStorage("selectedCleanupModelKind") private var selectedModelKind: String = LocalCleanupModelKind.qwen35_0_8b_q4_k_m.rawValue
+    @AppStorage("selectedMeetingSummaryModelKind") private var selectedModelKind: String = LocalCleanupModelKind.qwen35_4b_q4_k_m.rawValue
     @FocusState private var searchFocused: Bool
 
     var body: some View {
@@ -9562,7 +9562,7 @@ struct MeetingTabContentView: View {
     // MARK: - Status Bar
 
     private func regenerateSummary() {
-        let modelKind = LocalCleanupModelKind(rawValue: selectedModelKind) ?? .qwen35_0_8b_q4_k_m
+        let modelKind = LocalCleanupModelKind(rawValue: selectedModelKind) ?? .qwen35_4b_q4_k_m
         state.onGenerateSummary?(tab.transcript, modelKind)
     }
 

--- a/GhostPepper/UI/MeetingTranscriptWindow.swift
+++ b/GhostPepper/UI/MeetingTranscriptWindow.swift
@@ -8927,7 +8927,7 @@ struct MeetingTabContentView: View {
     @State private var speakerLabelDrafts: [String: String] = [:]
     @State private var speakerReviewError: String?
     @AppStorage("meetingSummaryPrompt") private var summaryPrompt: String = MeetingSummaryGenerator.finalSummaryPrompt
-    @AppStorage("selectedMeetingSummaryModelKind") private var selectedModelKind: String = LocalCleanupModelKind.qwen35_4b_q4_k_m.rawValue
+    @AppStorage("selectedMeetingSummaryModelKind") private var selectedModelKind: String = TextCleanupManager.meetingSummaryModelFallback.rawValue
     @FocusState private var searchFocused: Bool
 
     var body: some View {
@@ -9562,7 +9562,7 @@ struct MeetingTabContentView: View {
     // MARK: - Status Bar
 
     private func regenerateSummary() {
-        let modelKind = LocalCleanupModelKind(rawValue: selectedModelKind) ?? .qwen35_4b_q4_k_m
+        let modelKind = LocalCleanupModelKind(rawValue: selectedModelKind) ?? TextCleanupManager.meetingSummaryModelFallback
         state.onGenerateSummary?(tab.transcript, modelKind)
     }
 

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -1345,10 +1345,10 @@ struct SettingsView: View {
                 }
             }
 
-            SettingsCard("Cleanup model") {
-                SettingsField("Active cleanup model") {
+            SettingsCard("Realtime cleanup model") {
+                SettingsField("Active realtime cleanup model") {
                     Picker(
-                        "Cleanup model",
+                        "Realtime cleanup model",
                         selection: Binding(
                             get: { appState.textCleanupManager.selectedCleanupModelKind },
                             set: { appState.textCleanupManager.selectedCleanupModelKind = $0 }
@@ -1367,7 +1367,30 @@ struct SettingsView: View {
                     }
                 }
 
-                Text("Recommended cleanup models are marked Very fast, Fast, and Full.")
+                Text("Recommended realtime cleanup models are marked Very fast, Fast, and Full. Used for live dictation cleanup — keep this small and fast.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            SettingsCard("Meeting summarization model") {
+                SettingsField("Active meeting summarization model") {
+                    Picker(
+                        "Meeting summarization model",
+                        selection: Binding(
+                            get: { appState.textCleanupManager.selectedMeetingSummaryModelKind },
+                            set: { appState.textCleanupManager.selectedMeetingSummaryModelKind = $0 }
+                        )
+                    ) {
+                        ForEach(TextCleanupManager.cleanupGenerationModels, id: \.kind) { model in
+                            Text(model.displayName).tag(model.kind)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(maxWidth: 360, alignment: .leading)
+                }
+
+                Text("Used for meeting summary generation. This runs once after a meeting ends, so a bigger, slower model with more context is fine here.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/GhostPepperTests/GhostPepperTests.swift
+++ b/GhostPepperTests/GhostPepperTests.swift
@@ -976,6 +976,49 @@ final class GhostPepperTests: XCTestCase {
         XCTAssertNotNil(session.transcript.endDate)
     }
 
+    func testGenerateMeetingSummarySkipsGenerationAndLogsWhenSelectedModelIsNotDownloaded() async throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: #function))
+        defaults.removePersistentDomain(forName: #function)
+        // deepseek_r1_qwen_7b_q4_k_m is a real catalog GGUF model that is
+        // never downloaded by this test suite's other fixtures, so
+        // isModelDownloaded(_:) genuinely returns false for it without
+        // touching any real cached model files on disk.
+        let cleanupManager = TextCleanupManager(
+            defaults: defaults,
+            selectedMeetingSummaryModelKind: .deepseek_r1_qwen_7b_q4_k_m
+        )
+        let debugLogStore = DebugLogStore(
+            storageURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(UUID().uuidString).json")
+        )
+        let appState = AppState(
+            hotkeyMonitor: FakeHotkeyMonitor(),
+            chordBindingStore: ChordBindingStore(defaults: defaults),
+            cleanupSettingsDefaults: defaults,
+            textCleanupManager: cleanupManager,
+            debugLogStore: debugLogStore
+        )
+        let transcript = MeetingTranscript(meetingName: "Undownloaded Model Meeting")
+        transcript.appendSegment(
+            TranscriptSegment(
+                id: UUID(),
+                speaker: .remote(name: "Eric"),
+                startTime: 0,
+                endTime: 10,
+                text: "Some meeting content."
+            )
+        )
+
+        await appState.generateMeetingSummary(for: transcript)
+
+        XCTAssertNil(transcript.summary)
+        XCTAssertFalse(transcript.isGeneratingSummary)
+        XCTAssertTrue(debugLogStore.entries.contains {
+            $0.message.contains("DeepSeek R1 Distill Qwen 7B Q4_K_M") &&
+            $0.message.contains("Settings")
+        })
+    }
+
     func testAppStateWaitsForPepperChatTranscriptionBeforeReloadingSpeechAnalyzer() async throws {
         guard #available(macOS 26, *) else {
             throw XCTSkip("SpeechAnalyzer requires macOS 26 or later.")

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -142,6 +142,31 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         })
     }
 
+    func testGenerateSummaryPassesSummaryPromptAsSystemPromptNotDefaultCleanupPrompt() async {
+        let transcript = makeSingleChunkTranscript()
+        var capturedPrompt: String?
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, prompt, modelKind, _ in
+                capturedPrompt = prompt
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Final summary",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertEqual(summary, "Final summary")
+        XCTAssertEqual(capturedPrompt, MeetingSummaryGenerator.finalSummaryPrompt)
+        XCTAssertNotEqual(capturedPrompt, TextCleaner.defaultPrompt)
+    }
+
     func testGenerateSummarySingleChunkCombineFailureHasNoRollupLine() async {
         let transcript = makeSingleChunkTranscript()
         let cleanupManager = TextCleanupManager(

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -167,6 +167,33 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         XCTAssertNotEqual(capturedPrompt, TextCleaner.defaultPrompt)
     }
 
+    func testGenerateSummaryUsesExplicitModelKindOverrideNotTheManagersDefault() async {
+        let transcript = makeSingleChunkTranscript()
+        var capturedModelKind: LocalCleanupModelKind?
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_0_8b_q4_k_m: true,
+                .qwen35_4b_q4_k_m: true
+            ],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                capturedModelKind = modelKind
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Final summary",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+
+        let summary = await generator.generateSummary(transcript: transcript, modelKind: .qwen35_4b_q4_k_m)
+
+        XCTAssertEqual(summary, "Final summary")
+        XCTAssertEqual(capturedModelKind, .qwen35_4b_q4_k_m)
+    }
+
     func testGenerateSummarySingleChunkCombineFailureHasNoRollupLine() async {
         let transcript = makeSingleChunkTranscript()
         let cleanupManager = TextCleanupManager(

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @MainActor
 final class MeetingSummaryGeneratorTests: XCTestCase {
     private func makeMultiChunkTranscript(chunkCount: Int) -> MeetingTranscript {
-        let transcript = MeetingTranscript(meetingName: "Job Interview with Eric Brengle")
+        let transcript = MeetingTranscript(meetingName: "Long Meeting")
         // ~6000 chars: bigger than the 5000-char chunk limit on its own,
         // so each segment becomes exactly one chunk.
         let oversizedText = String(repeating: "word ", count: 1200)

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import GhostPepper
+
+@MainActor
+final class MeetingSummaryGeneratorTests: XCTestCase {
+    private func makeMultiChunkTranscript(chunkCount: Int) -> MeetingTranscript {
+        let transcript = MeetingTranscript(meetingName: "Job Interview with Eric Brengle")
+        // ~6000 chars: bigger than the 5000-char chunk limit on its own,
+        // so each segment becomes exactly one chunk.
+        let oversizedText = String(repeating: "word ", count: 1200)
+        for i in 0..<chunkCount {
+            transcript.appendSegment(
+                TranscriptSegment(
+                    id: UUID(),
+                    speaker: .remote(name: "Eric"),
+                    startTime: TimeInterval(i * 60),
+                    endTime: TimeInterval(i * 60 + 30),
+                    text: "\(oversizedText) segment \(i)"
+                )
+            )
+        }
+        return transcript
+    }
+
+    private func makeSingleChunkTranscript() -> MeetingTranscript {
+        let transcript = MeetingTranscript(meetingName: "Quick Sync")
+        transcript.appendSegment(
+            TranscriptSegment(
+                id: UUID(),
+                speaker: .remote(name: "Eric"),
+                startTime: 0,
+                endTime: 30,
+                text: "Short meeting transcript."
+            )
+        )
+        return transcript
+    }
+
+    func testGenerateSummarySucceedsLogsStartAndRollup() async {
+        let transcript = makeMultiChunkTranscript(chunkCount: 3)
+        var callCount = 0
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                callCount += 1
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Summary for call \(callCount)",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+        var logged: [(DebugLogCategory, String)] = []
+        generator.debugLogger = { logged.append(($0, $1)) }
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNotNil(summary)
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("starting for") && $0.1.contains("3 chunk(s)")
+        })
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("chunk summarization complete — 3/3 chunks succeeded")
+        })
+        XCTAssertFalse(logged.contains { $0.1.contains("failed") })
+    }
+
+    func testGenerateSummaryLogsChunkFailureAndStillSucceeds() async {
+        let transcript = makeMultiChunkTranscript(chunkCount: 3)
+        var callCount = 0
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                callCount += 1
+                if callCount == 2 {
+                    return CleanupModelProbeRawResult(
+                        modelKind: modelKind,
+                        modelDisplayName: "test",
+                        rawOutput: "...",
+                        elapsed: 0.01
+                    )
+                }
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Summary for call \(callCount)",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+        var logged: [(DebugLogCategory, String)] = []
+        generator.debugLogger = { logged.append(($0, $1)) }
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNotNil(summary)
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("chunk 2/3 failed") &&
+            $0.1.contains("returned unusable output") &&
+            $0.1.contains("dropped from summary")
+        })
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("chunk summarization complete — 2/3 chunks succeeded")
+        })
+    }
+
+    func testGenerateSummaryLogsFinalCombineFailureAndDiscardsChunkSummaries() async {
+        let transcript = makeMultiChunkTranscript(chunkCount: 3)
+        var callCount = 0
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                callCount += 1
+                if callCount == 4 {
+                    throw CancellationError()
+                }
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Summary for call \(callCount)",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+        var logged: [(DebugLogCategory, String)] = []
+        generator.debugLogger = { logged.append(($0, $1)) }
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNil(summary)
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("final combine step failed") &&
+            $0.1.contains("timed out after 15s") &&
+            $0.1.contains("3/3 chunk summaries discarded")
+        })
+    }
+
+    func testGenerateSummarySingleChunkCombineFailureHasNoRollupLine() async {
+        let transcript = makeSingleChunkTranscript()
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, _, _ in
+                throw CancellationError()
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+        var logged: [(DebugLogCategory, String)] = []
+        generator.debugLogger = { logged.append(($0, $1)) }
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNil(summary)
+        XCTAssertFalse(logged.contains { $0.1.contains("chunk summarization complete") })
+        XCTAssertTrue(logged.contains {
+            $0.1.contains("final combine step failed") &&
+            $0.1.contains("timed out after 15s")
+        })
+    }
+}

--- a/GhostPepperTests/MeetingSummaryGeneratorTests.swift
+++ b/GhostPepperTests/MeetingSummaryGeneratorTests.swift
@@ -41,7 +41,10 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         var callCount = 0
         let cleanupManager = TextCleanupManager(
             selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
-            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_0_8b_q4_k_m: true,
+                .qwen35_4b_q4_k_m: true
+            ],
             probeExecutionOverride: { _, _, modelKind, _ in
                 callCount += 1
                 return CleanupModelProbeRawResult(
@@ -73,7 +76,10 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         var callCount = 0
         let cleanupManager = TextCleanupManager(
             selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
-            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_0_8b_q4_k_m: true,
+                .qwen35_4b_q4_k_m: true
+            ],
             probeExecutionOverride: { _, _, modelKind, _ in
                 callCount += 1
                 if callCount == 2 {
@@ -114,7 +120,10 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         var callCount = 0
         let cleanupManager = TextCleanupManager(
             selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
-            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_0_8b_q4_k_m: true,
+                .qwen35_4b_q4_k_m: true
+            ],
             probeExecutionOverride: { _, _, modelKind, _ in
                 callCount += 1
                 if callCount == 4 {
@@ -137,7 +146,7 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         XCTAssertNil(summary)
         XCTAssertTrue(logged.contains {
             $0.1.contains("final combine step failed") &&
-            $0.1.contains("timed out after 15s") &&
+            $0.1.contains("timed out after 90s") &&
             $0.1.contains("3/3 chunk summaries discarded")
         })
     }
@@ -147,7 +156,10 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         var capturedPrompt: String?
         let cleanupManager = TextCleanupManager(
             selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
-            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_0_8b_q4_k_m: true,
+                .qwen35_4b_q4_k_m: true
+            ],
             probeExecutionOverride: { _, prompt, modelKind, _ in
                 capturedPrompt = prompt
                 return CleanupModelProbeRawResult(
@@ -198,7 +210,10 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         let transcript = makeSingleChunkTranscript()
         let cleanupManager = TextCleanupManager(
             selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
-            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_0_8b_q4_k_m: true,
+                .qwen35_4b_q4_k_m: true
+            ],
             probeExecutionOverride: { _, _, _, _ in
                 throw CancellationError()
             }
@@ -213,7 +228,35 @@ final class MeetingSummaryGeneratorTests: XCTestCase {
         XCTAssertFalse(logged.contains { $0.1.contains("chunk summarization complete") })
         XCTAssertTrue(logged.contains {
             $0.1.contains("final combine step failed") &&
-            $0.1.contains("timed out after 15s")
+            $0.1.contains("timed out after 90s")
         })
+    }
+
+    func testGenerateSummaryDefaultsToSelectedMeetingSummaryModelWhenNoOverrideGiven() async {
+        let transcript = makeSingleChunkTranscript()
+        var capturedModelKind: LocalCleanupModelKind?
+        let cleanupManager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            selectedMeetingSummaryModelKind: .qwen35_4b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_0_8b_q4_k_m: true,
+                .qwen35_4b_q4_k_m: true
+            ],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                capturedModelKind = modelKind
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: "test",
+                    rawOutput: "Summary",
+                    elapsed: 0.01
+                )
+            }
+        )
+        let generator = MeetingSummaryGenerator(cleanupManager: cleanupManager)
+
+        let summary = await generator.generateSummary(transcript: transcript)
+
+        XCTAssertNotNil(summary)
+        XCTAssertEqual(capturedModelKind, .qwen35_4b_q4_k_m)
     }
 }

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -221,6 +221,25 @@ final class TextCleanupManagerTests: XCTestCase {
         }
     }
 
+    func testCleanupThrowsTimedOutWhenProbeIsCancelled() async {
+        let manager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_2b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_2b_q4_k_m: true
+            ],
+            probeExecutionOverride: { _, _, _, _ in
+                throw CancellationError()
+            }
+        )
+
+        await XCTAssertThrowsErrorAsync(try await manager.clean(text: "hello", prompt: "unused")) { error in
+            XCTAssertEqual(
+                error as? CleanupBackendError,
+                .timedOut(seconds: 15.0)
+            )
+        }
+    }
+
     func testDeleteCachedModelRemovesOnlyTheConfiguredCacheFileAndNotifiesObservers() throws {
         let modelsDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -307,6 +307,20 @@ final class TextCleanupManagerTests: XCTestCase {
         XCTAssertEqual(restored.selectedMeetingSummaryModelKind, .qwen35_2b_q4_k_m)
     }
 
+    func testLoadModelReloadsWhenContextTokenCountChangesForSameKind() async {
+        let manager = TextCleanupManager(
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true]
+        )
+
+        await manager.loadModel(kind: .qwen35_0_8b_q4_k_m, contextTokenCount: 4096)
+        XCTAssertEqual(manager.activeLoadedModelKind, .qwen35_0_8b_q4_k_m)
+        XCTAssertEqual(manager.activeLoadedContextTokenCount, 4096)
+
+        await manager.loadModel(kind: .qwen35_0_8b_q4_k_m, contextTokenCount: 16384)
+        XCTAssertEqual(manager.activeLoadedModelKind, .qwen35_0_8b_q4_k_m)
+        XCTAssertEqual(manager.activeLoadedContextTokenCount, 16384)
+    }
+
     func testDeleteCachedModelRemovesOnlyTheConfiguredCacheFileAndNotifiesObservers() throws {
         let modelsDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -282,6 +282,31 @@ final class TextCleanupManagerTests: XCTestCase {
         )
     }
 
+    func testDefaultMeetingSummaryModelSelectionUsesFullModel() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let manager = TextCleanupManager(defaults: defaults)
+
+        XCTAssertEqual(manager.selectedMeetingSummaryModelKind, .qwen35_4b_q4_k_m)
+    }
+
+    func testMeetingSummaryModelSelectionPersistsIndependentlyOfRealtimeModel() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let manager = TextCleanupManager(
+            defaults: defaults,
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            selectedMeetingSummaryModelKind: .qwen35_2b_q4_k_m
+        )
+
+        XCTAssertEqual(manager.selectedCleanupModelKind, .qwen35_0_8b_q4_k_m)
+        XCTAssertEqual(manager.selectedMeetingSummaryModelKind, .qwen35_2b_q4_k_m)
+
+        let restored = TextCleanupManager(defaults: defaults)
+        XCTAssertEqual(restored.selectedCleanupModelKind, .qwen35_0_8b_q4_k_m)
+        XCTAssertEqual(restored.selectedMeetingSummaryModelKind, .qwen35_2b_q4_k_m)
+    }
+
     func testDeleteCachedModelRemovesOnlyTheConfiguredCacheFileAndNotifiesObservers() throws {
         let modelsDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -240,6 +240,16 @@ final class TextCleanupManagerTests: XCTestCase {
         }
     }
 
+    func testCleanupPurposeConfigProvidesDistinctContextAndTimeoutPerPurpose() {
+        let realtime = TextCleanupManager.config(for: .realtime)
+        let summarization = TextCleanupManager.config(for: .summarization)
+
+        XCTAssertEqual(realtime.maxTokenCount, 4096)
+        XCTAssertEqual(realtime.timeoutSeconds, 15.0)
+        XCTAssertEqual(summarization.maxTokenCount, 16384)
+        XCTAssertEqual(summarization.timeoutSeconds, 90.0)
+    }
+
     func testGGUFCleanupModelsUseSixteenKContextWindow() {
         XCTAssertEqual(TextCleanupManager.compactModel.maxTokenCount, 16384)
         XCTAssertEqual(TextCleanupManager.recommendedFastModel.maxTokenCount, 16384)

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -240,6 +240,38 @@ final class TextCleanupManagerTests: XCTestCase {
         }
     }
 
+    func testGGUFCleanupModelsUseSixteenKContextWindow() {
+        XCTAssertEqual(TextCleanupManager.compactModel.maxTokenCount, 16384)
+        XCTAssertEqual(TextCleanupManager.recommendedFastModel.maxTokenCount, 16384)
+        XCTAssertEqual(TextCleanupManager.recommendedFullModel.maxTokenCount, 16384)
+    }
+
+    func testCleanupLogsEstimatedTokenBudgetForPromptAndOutput() async throws {
+        var loggedMessages: [String] = []
+        let manager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_2b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_2b_q4_k_m: true
+            ],
+            probeExecutionOverride: { _, _, _, _ in
+                CleanupModelProbeRawResult(
+                    modelKind: .qwen35_2b_q4_k_m,
+                    modelDisplayName: TextCleanupManager.recommendedFastModel.displayName,
+                    rawOutput: "short output",
+                    elapsed: 1.23
+                )
+            }
+        )
+        manager.debugLogger = { _, message in loggedMessages.append(message) }
+
+        _ = try await manager.clean(text: "some transcript text", prompt: "summarize this")
+
+        XCTAssertTrue(
+            loggedMessages.contains { $0.contains("prompt") && $0.contains("output") && $0.contains("of 16384 max tokens") },
+            "Expected a debug log entry reporting the estimated token budget, got: \(loggedMessages)"
+        )
+    }
+
     func testDeleteCachedModelRemovesOnlyTheConfiguredCacheFileAndNotifiesObservers() throws {
         let modelsDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -277,7 +277,9 @@ final class TextCleanupManagerTests: XCTestCase {
         _ = try await manager.clean(text: "some transcript text", prompt: "summarize this")
 
         XCTAssertTrue(
-            loggedMessages.contains { $0.contains("prompt") && $0.contains("output") && $0.contains("of 16384 max tokens") },
+            loggedMessages.contains {
+                $0.contains("prompt") && $0.contains("output") && $0.contains("of 4096 max tokens (realtime)")
+            },
             "Expected a debug log entry reporting the estimated token budget, got: \(loggedMessages)"
         )
     }
@@ -319,6 +321,48 @@ final class TextCleanupManagerTests: XCTestCase {
         await manager.loadModel(kind: .qwen35_0_8b_q4_k_m, contextTokenCount: 16384)
         XCTAssertEqual(manager.activeLoadedModelKind, .qwen35_0_8b_q4_k_m)
         XCTAssertEqual(manager.activeLoadedContextTokenCount, 16384)
+    }
+
+    func testCleanUsesDistinctContextPerPurposeForSameModelKind() async throws {
+        let manager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { _, _, modelKind, _ in
+                CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: TextCleanupManager.compactModel.displayName,
+                    rawOutput: "cleaned",
+                    elapsed: 0.01
+                )
+            }
+        )
+
+        _ = try await manager.clean(text: "hi", prompt: "unused", modelKind: .qwen35_0_8b_q4_k_m, purpose: .realtime)
+        XCTAssertEqual(manager.activeLoadedContextTokenCount, 4096)
+
+        _ = try await manager.clean(text: "hi", prompt: "unused", modelKind: .qwen35_0_8b_q4_k_m, purpose: .summarization)
+        XCTAssertEqual(manager.activeLoadedContextTokenCount, 16384)
+    }
+
+    func testCleanupUsesSummarizationTimeoutWhenPurposeIsSummarization() async {
+        let manager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_2b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [
+                .qwen35_2b_q4_k_m: true
+            ],
+            probeExecutionOverride: { _, _, _, _ in
+                throw CancellationError()
+            }
+        )
+
+        await XCTAssertThrowsErrorAsync(
+            try await manager.clean(text: "hello", prompt: "unused", purpose: .summarization)
+        ) { error in
+            XCTAssertEqual(
+                error as? CleanupBackendError,
+                .timedOut(seconds: 90.0)
+            )
+        }
     }
 
     func testDeleteCachedModelRemovesOnlyTheConfiguredCacheFileAndNotifiesObservers() throws {

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -30,6 +30,10 @@ final class TextCleanupManagerTests: XCTestCase {
         }
     }
 
+    private final class WeakManagerBox {
+        weak var manager: TextCleanupManager?
+    }
+
     func testCleanupModelCatalogIncludesVeryFastFastAndFullQwenModels() {
         let modelsByKind = Dictionary(
             uniqueKeysWithValues: TextCleanupManager.cleanupModels.map { ($0.kind, $0) }
@@ -321,6 +325,82 @@ final class TextCleanupManagerTests: XCTestCase {
         await manager.loadModel(kind: .qwen35_0_8b_q4_k_m, contextTokenCount: 16384)
         XCTAssertEqual(manager.activeLoadedModelKind, .qwen35_0_8b_q4_k_m)
         XCTAssertEqual(manager.activeLoadedContextTokenCount, 16384)
+    }
+
+    func testPlainLoadModelWrapperDefaultsToRealtimeContextNotCatalogCeiling() async {
+        // Preload paths (Settings/Onboarding/ModelsSidebar, the no-arg
+        // convenience, startLoad, and prefillPromptContext) all call this
+        // plain wrapper. It must request realtime's context (4096) by
+        // default so a subsequent realtime `clean()` call doesn't find a
+        // context mismatch and force an unnecessary reload.
+        let manager = TextCleanupManager(
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true]
+        )
+
+        await manager.loadModel(kind: .qwen35_0_8b_q4_k_m)
+
+        XCTAssertEqual(manager.activeLoadedModelKind, .qwen35_0_8b_q4_k_m)
+        XCTAssertEqual(manager.activeLoadedContextTokenCount, 4096)
+    }
+
+    func testPlainLoadModelWrapperHonorsExplicitSummarizationPurpose() async {
+        let manager = TextCleanupManager(
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true]
+        )
+
+        await manager.loadModel(kind: .qwen35_0_8b_q4_k_m, purpose: .summarization)
+
+        XCTAssertEqual(manager.activeLoadedModelKind, .qwen35_0_8b_q4_k_m)
+        XCTAssertEqual(manager.activeLoadedContextTokenCount, 16384)
+    }
+
+    func testCleanKeepsCorrectContextPerCallWhenPurposesInterleaveOnSameModelKind() async throws {
+        // Regression test for moving the load call inside probeExecutionGate:
+        // an interleaved summarization + realtime `clean()` call on the same
+        // model kind must never observe the OTHER call's context while its
+        // own probe is running, because the load now happens under the same
+        // gate as the probe itself.
+        actor CapturedContexts {
+            private(set) var values: [Int32?] = []
+            func record(_ value: Int32?) { values.append(value) }
+        }
+        let captured = CapturedContexts()
+        let box = WeakManagerBox()
+        let manager = TextCleanupManager(
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m,
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true],
+            probeExecutionOverride: { [weak box] _, _, modelKind, _ in
+                await captured.record(box?.manager?.activeLoadedContextTokenCount)
+                try? await Task.sleep(nanoseconds: 20_000_000)
+                return CleanupModelProbeRawResult(
+                    modelKind: modelKind,
+                    modelDisplayName: TextCleanupManager.compactModel.displayName,
+                    rawOutput: "cleaned",
+                    elapsed: 0.01
+                )
+            }
+        )
+        box.manager = manager
+
+        async let summarization = manager.clean(
+            text: "long meeting text",
+            prompt: "unused",
+            modelKind: .qwen35_0_8b_q4_k_m,
+            purpose: .summarization
+        )
+        async let realtime = manager.clean(
+            text: "short",
+            prompt: "unused",
+            modelKind: .qwen35_0_8b_q4_k_m,
+            purpose: .realtime
+        )
+
+        let results = try await [summarization, realtime]
+        XCTAssertEqual(results, ["cleaned", "cleaned"])
+
+        let values = await captured.values
+        XCTAssertEqual(values.count, 2)
+        XCTAssertEqual(Set(values.compactMap { $0 }), Set<Int32>([16384, 4096]))
     }
 
     func testCleanUsesDistinctContextPerPurposeForSameModelKind() async throws {

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -350,6 +350,55 @@ final class TextCleanupManagerTests: XCTestCase {
         XCTAssertEqual(manager.activeLoadedContextTokenCount, 16384)
     }
 
+    func testLoadModelClearsPreparedPromptContextOnContextMismatchReload() async throws {
+        // preparedPromptContext is primed (llm.core.prepareContext) against
+        // one specific LLM instance. A same-kind reload triggered purely by
+        // a context-size change discards that instance — the stale plan
+        // must not survive, or a later probe() could run generation against
+        // an unprimed KV cache using a plan built for a different instance.
+        let manager = TextCleanupManager(
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true]
+        )
+
+        manager.startPromptPrefill(systemPromptPrefix: "You are a helpful assistant.", modelKind: .qwen35_0_8b_q4_k_m)
+
+        var attempts = 0
+        while manager.preparedPromptContext == nil, attempts < 200 {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            attempts += 1
+        }
+        XCTAssertNotNil(manager.preparedPromptContext, "Expected prompt prefill to finish and populate preparedPromptContext")
+
+        // Prefill primes at realtime's context (4096); reload the same kind
+        // at a different (summarization-sized) context.
+        await manager.loadModel(kind: .qwen35_0_8b_q4_k_m, contextTokenCount: 16384)
+
+        XCTAssertNil(manager.preparedPromptContext)
+    }
+
+    func testStreamCompletionContextIsADedicatedConstantNotTheCatalogCeiling() {
+        // Asserted as its own value, independent of any CleanupModelDescriptor,
+        // so a future change to a model's catalog maxTokenCount (e.g. lowering
+        // compactModel's ceiling to save RAM on realtime cleanup) can't
+        // silently change what the agent loop / Wiki generation request too.
+        XCTAssertEqual(TextCleanupManager.streamCompletionContextTokenCount, 16384)
+    }
+
+    func testStreamCompletionUsesDedicatedContextNotCatalogCeiling() async throws {
+        let manager = TextCleanupManager(
+            cleanupModelAvailabilityOverrides: [.qwen35_0_8b_q4_k_m: true]
+        )
+
+        let stream = try await manager.streamCompletion(prompt: "hi", modelKind: .qwen35_0_8b_q4_k_m)
+
+        XCTAssertEqual(manager.activeLoadedContextTokenCount, TextCleanupManager.streamCompletionContextTokenCount)
+
+        // Drain to completion rather than abandoning it mid-generation —
+        // leaving the AsyncStream unconsumed tears down the llama.cpp/Metal
+        // backend mid-flight and trips a GGML_ASSERT on process exit.
+        for await _ in stream {}
+    }
+
     func testPlainLoadModelWrapperDefaultsToRealtimeContextNotCatalogCeiling() async {
         // Preload paths (Settings/Onboarding/ModelsSidebar, the no-arg
         // convenience, startLoad, and prefillPromptContext) all call this

--- a/GhostPepperTests/TextCleanupManagerTests.swift
+++ b/GhostPepperTests/TextCleanupManagerTests.swift
@@ -288,12 +288,35 @@ final class TextCleanupManagerTests: XCTestCase {
         )
     }
 
-    func testDefaultMeetingSummaryModelSelectionUsesFullModel() {
+    /// Relies on the Full model actually being downloaded in this dev
+    /// environment, matching the convention already used by tests like
+    /// `testCleanupSuppressesThinkingForProductionCleanupCalls`.
+    func testDefaultMeetingSummaryModelSelectionUsesFullModelWhenFullIsDownloaded() {
         let defaults = UserDefaults(suiteName: #function)!
         defaults.removePersistentDomain(forName: #function)
-        let manager = TextCleanupManager(defaults: defaults)
+        let manager = TextCleanupManager(
+            defaults: defaults,
+            selectedCleanupModelKind: .qwen35_0_8b_q4_k_m
+        )
 
         XCTAssertEqual(manager.selectedMeetingSummaryModelKind, .qwen35_4b_q4_k_m)
+    }
+
+    func testDefaultMeetingSummaryModelFallsBackToRealtimeModelWhenFullIsNotDownloaded() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let manager = TextCleanupManager(
+            defaults: defaults,
+            selectedCleanupModelKind: .qwen35_2b_q4_k_m,
+            modelsDirectory: tempDirectory
+        )
+
+        XCTAssertEqual(manager.selectedMeetingSummaryModelKind, .qwen35_2b_q4_k_m)
     }
 
     func testMeetingSummaryModelSelectionPersistsIndependentlyOfRealtimeModel() {


### PR DESCRIPTION
Title: Give meeting summaries their own model, context window, and timeout

**Stacked on #159** — this branch forks from `feature/meeting-summary-debug-logging`,
not `main`, so this diff includes everything in #159 until that one merges.
GitHub will show the combined diff; the commits from `ea9ac46` onward are
the actual new work here. Rebasing this onto `main` once #159 lands is on
me, not a reviewer chore.

Fixes matthartman/ghost-pepper#160

`TextCleanupManager` used to have one model preference and one hardcoded
15-second timeout, shared by every local-LLM call — live dictation
cleanup and meeting summarization alike. That's what caused #160: the
combine step (the biggest single call in the pipeline, since it
concatenates every chunk summary at once) would silently truncate
mid-sentence whenever it hit the model's context ceiling, with no error
surfaced.

Uniformly raising the context window for everyone would "fix" it but
waste KV-cache RAM on every tiny live-dictation call, which never needed
the headroom. So this adds a `CleanupPurpose` enum (`.realtime` /
`.summarization`) with its own (context window, timeout) profile —
realtime stays at 4096 tokens/15s (unchanged), summarization gets 16384
tokens/90s — plus a second, independent model preference
("Meeting Summarization Model", separate from "Realtime Cleanup Model")
so you can run something small/fast for dictation and something
bigger/slower for summaries.

**What's in here:**

1. `CleanupPurpose` enum + per-purpose config on `TextCleanupManager`, threaded through `clean()`/`probe()`. The model-load cache is now keyed on `(kind, context)`, not just `kind`.
2. A second persisted preference, `selectedMeetingSummaryModelKind`, independent of the realtime cleanup preference. Settings now shows two picker cards instead of one.
3. `MeetingSummaryGenerator` defaults to the new summarization preference (not the realtime one) and tags every LLM call it makes `purpose: .summarization`.
4. The Summary tab's "Customize" panel now persists to the summarization-specific key instead of coincidentally sharing a UserDefaults key with the realtime preference — same shape of bug as #158, caught before it shipped.
5. A final whole-branch review (before this PR) caught two real bugs the per-task reviews couldn't see: the model-load call used to happen *before* `probe()`'s serialization gate, so a realtime call could reload the model out from under a summarization call still waiting on the gate and silently truncate it — closed by moving the load inside the gate. Separately, every eager-preload path (including the one that warms the KV cache before you start dictating) was requesting the model's full catalog ceiling regardless of purpose, so the first real dictation call forced an immediate reload and threw away the prefill work — closed by making preload purpose-aware too.
6. The default summarization model (Full, ~2.8GB) may not be downloaded for an existing user. Added a guard so a missing model skips generation with a clear debug-log message instead of silently kicking off a multi-gigabyte background download.

**Caveats:**

- Only exercised against the Qwen 3.5 models on my own machine, same as #159.
- Two follow-up items noted by the final review, deliberately left out of scope here: `streamCompletion` (the Wiki/agent path) still loads its model before acquiring its own gate — same class of race as the one fixed above, but pre-existing and outside this PR's problem. And `probe()`'s prompt-prefill reuse check compares only model kind, not context size, which is now slightly more reachable since preload and summarization can warm the same model at different contexts.

**Test plan**
- [x] Full app test suite: 537/537 passing
- [x] New/updated: `TextCleanupManagerTests`, `MeetingSummaryGeneratorTests`, `GhostPepperTests` (AppState-level)
- [x] Manually reviewed the full diff via Hunk before opening this PR

🤖 Drafted and implemented with [Claude Code](https://claude.com/claude-code); I reviewed and tested every change myself.
