### PR TITLE
Add Settings… menu item so Cmd+, actually does something

### DIFF
--- a/GhostPepper/GhostPepperApp.swift
+++ b/GhostPepper/GhostPepperApp.swift
@@ -76,5 +76,13 @@ struct GhostPepperApp: App {
                 appState.prepareForTermination()
             }
         }
+        .commands {
+            CommandGroup(replacing: .appSettings) {
+                Button("Settings…") {
+                    appState.showSettings()
+                }
+                .keyboardShortcut(",", modifiers: .command)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Ghost Pepper is LSUIElement (menu bar only, no Dock icon), so SwiftUI
  never populates the standard `appSettings` menu placement — no
  `Settings` scene means no "Settings…" item, so Cmd+, was silently
  doing nothing.
- Adds a `CommandGroup(replacing: .appSettings)` in `GhostPepperApp.swift`
  so "Settings…" shows up in the app menu at Cmd+, and calls the
  existing `appState.showSettings()` — the same path the menu-bar
  dropdown's own "Settings..." item already used, so no new
  window-management code.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] Confirmed via osascript/System Events that both the app-menu item
      and the Cmd+, keystroke open the Settings window (there's no UI
      test harness for menu commands here, so this was manual — took
      longer to verify than to write)

---
🤖 Drafted by Claude Code, reviewed and approved by me before opening.