### PR TITLE
Fix models panel memory spike

### DIFF
--- a/GhostPepper/UI/MeetingTranscriptWindow.swift
+++ b/GhostPepper/UI/MeetingTranscriptWindow.swift
@@ -1360,6 +1360,8 @@ struct GeneratedWikiSidebarFolder: Identifiable, Hashable {
 
 @MainActor
 final class MeetingWindowState: ObservableObject {
+    private var historyRefreshCancellable: AnyCancellable?
+
     var onAskQuestion: ((_ question: String, _ history: [QAHistoryTurn]) -> AsyncThrowingStream<QAEvent, Error>)?
     @Published var pushToTalkDisplay: String = ""
     @Published var tabs: [OpenMeetingTab] = []
@@ -2232,6 +2234,19 @@ final class MeetingWindowState: ObservableObject {
         }
     }
 
+    init() {
+        historyRefreshCancellable = Timer.publish(every: 10, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self, self.showSidebar else { return }
+                self.loadHistory()
+            }
+    }
+
+    deinit {
+        historyRefreshCancellable?.cancel()
+    }
+
     func loadHistory() {
         let dir = MeetingTranscriptSettings.effectiveSaveDirectory()
         historyGroups = MeetingHistory.loadEntries(from: dir)
@@ -2633,9 +2648,6 @@ struct MeetingRootView: View {
             guard shouldRun else { return }
             state.pendingSecondBrainLint = false
             runSecondBrainLint()
-        }
-        .onReceive(Timer.publish(every: 10, on: .main, in: .common).autoconnect()) { _ in
-            if state.showSidebar { state.loadHistory() }
         }
         .overlay {
             if let run = wikiGenerationRun {

--- a/GhostPepper/UI/ModelsSidebarView.swift
+++ b/GhostPepper/UI/ModelsSidebarView.swift
@@ -111,7 +111,7 @@ struct ModelsSidebarView: View {
                 title: "Meeting summary",
                 modelLabel: (cleanupModel?.displayName ?? "—") + " (same as Cleanup)",
                 location: .local,
-                available: cleanupModel.map { TextCleanupManager.isModelDownloaded($0.kind) } ?? false
+                available: cleanupModel.map { cleanupManager.cachedModelKinds.contains($0.kind) } ?? false
             )
 
             FunctionRow(
@@ -134,7 +134,7 @@ struct ModelsSidebarView: View {
 
     /// Cleanup models the user has actually downloaded.
     private var downloadedCleanupModels: [CleanupModelDescriptor] {
-        TextCleanupManager.cleanupModels.filter { TextCleanupManager.isModelDownloaded($0.kind) }
+        TextCleanupManager.cleanupModels.filter { cleanupManager.cachedModelKinds.contains($0.kind) }
     }
 
     // MARK: - Section 2 · Local models
@@ -160,7 +160,7 @@ struct ModelsSidebarView: View {
                 )
             }
             ForEach(TextCleanupManager.cleanupModels, id: \.kind) { desc in
-                let downloaded = TextCleanupManager.isModelDownloaded(desc.kind)
+                let downloaded = cleanupManager.cachedModelKinds.contains(desc.kind)
                 let isActive = desc.kind.rawValue == selectedCleanupModelKindRaw
                 let progress = cleanupRowProgress(for: desc.kind, downloaded: downloaded)
                 LocalModelRow(
@@ -283,7 +283,7 @@ struct ModelsSidebarView: View {
             .qwen35_0_8b_q4_k_m,
         ]
         return preferred.compactMap { kind in
-            TextCleanupManager.cleanupModels.first { $0.kind == kind && TextCleanupManager.isModelDownloaded(kind) }
+            TextCleanupManager.cleanupModels.first { $0.kind == kind && cleanupManager.cachedModelKinds.contains(kind) }
         }.first
     }
 


### PR DESCRIPTION
ModelsSidebarView re-verified local model files via a full SHA-256 hash on every render instead of the existing cheap cachedModelKinds check, and MeetingRootView rebuilt its history-refresh Timer publisher inline in body on every re-render, causing duplicate timers to accumulate. Together these produced runaway memory growth whenever the Models panel was open.

Fixes #163