### PR TITLE
Let users cancel a Google Calendar connection that never completes

### DIFF
--- a/GhostPepper.xcodeproj/project.pbxproj
+++ b/GhostPepper.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		ACC06182C51F75BDF79E571E /* QAAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95A4E9746B97273AFA6904 /* QAAttachment.swift */; };
 		AD56986FFDABBEAF84446A0F /* MeetingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE6E6C11EA04C058C642573 /* MeetingSession.swift */; };
 		AF1DD5FE5059779E1D5D59C2 /* PostPasteLearningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE03E93B2A9E420B2C74CA /* PostPasteLearningCoordinator.swift */; };
+		AF2839BB20621FFD30394735 /* LoopbackOAuthServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FF6D449F93126DEEBCA600 /* LoopbackOAuthServerTests.swift */; };
 		AFAAFB58F0A76F5213F67C45 /* FluidAudioSpeechSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F781190896573C3BA687CB /* FluidAudioSpeechSessionTests.swift */; };
 		B060F5F4210612DF33732FDF /* PepperChatSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A797BF8671DD4D44E9B1188 /* PepperChatSession.swift */; };
 		B0E4A139001EF2DF0E809935 /* TextCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBAB39218D09F11336C4F684 /* TextCleaner.swift */; };
@@ -244,6 +245,7 @@
 		01A8B88DFD046F1EC74E5CD6 /* TranscriptionLabStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionLabStore.swift; sourceTree = "<group>"; };
 		0267B716FEB381C08F172EE6 /* UsageReportView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageReportView.swift; sourceTree = "<group>"; };
 		029E36727193D8502C69FB38 /* sprite_frame_2@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "sprite_frame_2@2x.png"; sourceTree = "<group>"; };
+		04FF6D449F93126DEEBCA600 /* LoopbackOAuthServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoopbackOAuthServerTests.swift; sourceTree = "<group>"; };
 		09095C80171572F5C5B3ECDA /* MeetingCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingCard.swift; sourceTree = "<group>"; };
 		0D91666EEE2CF7B4B78E3061 /* ChordBindingStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChordBindingStore.swift; sourceTree = "<group>"; };
 		0EDE03E93B2A9E420B2C74CA /* PostPasteLearningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPasteLearningCoordinator.swift; sourceTree = "<group>"; };
@@ -897,6 +899,7 @@
 				5588D5D8742520186BBD4970 /* IndexManifestTests.swift */,
 				AF04305B5AE9665D25C23A2C /* IndexSystemPromptTests.swift */,
 				0F634CFD724E29ECA57C0BB6 /* KeyChordTests.swift */,
+				04FF6D449F93126DEEBCA600 /* LoopbackOAuthServerTests.swift */,
 				D2703FAF4A3B8D55B84100BA /* MarkdownArchivePathsTests.swift */,
 				5C926BF4341F8D3448FE7096 /* MeetingCardTests.swift */,
 				B00B029C7A13483CD703B723 /* MeetingChunkerTests.swift */,
@@ -1017,7 +1020,6 @@
 				};
 			};
 			buildConfigurationList = 4DD304029FEB6147483470FD /* Build configuration list for PBXProject "GhostPepper" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -1034,6 +1036,7 @@
 				E56E28037799FE95D6CB5F71 /* XCRemoteSwiftPackageReference "WhisperKit" */,
 			);
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 3705D6F7BCD01CB7D37DF812 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -1254,6 +1257,7 @@
 				3653237D6C0C44E3AFF33800 /* IndexManifestTests.swift in Sources */,
 				5A4D2E405B6F7A519BA6F6F0 /* IndexSystemPromptTests.swift in Sources */,
 				AB0AC6DC19EC0DB440F5B123 /* KeyChordTests.swift in Sources */,
+				AF2839BB20621FFD30394735 /* LoopbackOAuthServerTests.swift in Sources */,
 				EA0A1ECE203067342B2E2CF6 /* MarkdownArchivePathsTests.swift in Sources */,
 				E7165BCC53E626252EC92C98 /* MeetingCardTests.swift in Sources */,
 				160D6AB39F87C2045BE156F4 /* MeetingChunkerTests.swift in Sources */,

--- a/GhostPepper/Calendar/GoogleCalendarService.swift
+++ b/GhostPepper/Calendar/GoogleCalendarService.swift
@@ -112,19 +112,17 @@ final class GoogleCalendarService: ObservableObject {
 
     /// Start the OAuth sign-in flow — starts a loopback server and opens the browser.
     func signIn() {
+        // Abandon any attempt still in flight so retrying can't strand the UI or leak a listener.
+        cancelSignIn()
         authError = nil
-        isLoading = true
-        defer {
-            if activeServer == nil {
-                isLoading = false
-            }
-        }
 
         guard Self.isConfigured else {
             authError = "Google Calendar OAuth is not configured in this build."
             calendarLog.error("OAuth client is not configured")
             return
         }
+
+        isLoading = true
 
         let verifier = generateCodeVerifier()
         codeVerifier = verifier
@@ -135,15 +133,15 @@ final class GoogleCalendarService: ObservableObject {
         // Start loopback server on a random port (127.0.0.1 only, not network-accessible)
         let server = LoopbackOAuthServer { [weak self] callback in
             Task { @MainActor [weak self] in
-                guard let self, let verifier = self.codeVerifier, callback.state == self.oauthState else {
-                    self?.codeVerifier = nil
-                    self?.oauthState = nil
-                    self?.activeServer = nil
+                guard let self else { return }
+                let pendingVerifier = self.codeVerifier
+                let expectedState = self.oauthState
+                self.cancelSignIn()
+                guard let verifier = pendingVerifier, callback.state == expectedState else {
+                    self.authError = "Google sign-in could not be completed. Please try connecting again."
+                    calendarLog.error("Discarded OAuth callback with unexpected state")
                     return
                 }
-                self.codeVerifier = nil
-                self.oauthState = nil
-                self.activeServer = nil
                 self.isLoading = true
                 await self.exchangeCodeForToken(code: callback.code, verifier: verifier)
                 self.isLoading = false
@@ -153,7 +151,7 @@ final class GoogleCalendarService: ObservableObject {
         guard let port = server.start() else {
             authError = "Could not start the local Google sign-in callback. Check the app sandbox network server entitlement."
             calendarLog.error("Failed to start loopback OAuth server")
-            activeServer = nil
+            cancelSignIn()
             return
         }
         loopbackPort = port
@@ -176,14 +174,26 @@ final class GoogleCalendarService: ObservableObject {
         guard let url = components.url else {
             authError = "Could not create the Google sign-in URL."
             calendarLog.error("Failed to create Google OAuth URL")
-            activeServer = nil
+            cancelSignIn()
             return
         }
         if !NSWorkspace.shared.open(url) {
             authError = "Could not open the Google sign-in page."
             calendarLog.error("NSWorkspace failed to open Google OAuth URL")
-            activeServer = nil
+            cancelSignIn()
         }
+    }
+
+    /// Abandon an in-flight sign-in and drop back to the disconnected state.
+    /// Google never calls back when the user closes the browser tab or signs in with the
+    /// wrong account, so without this the loading flag stays set, the Connect button stays
+    /// replaced by a spinner, and the loopback listener stays bound until the app is quit.
+    func cancelSignIn() {
+        activeServer?.stop()
+        activeServer = nil
+        codeVerifier = nil
+        oauthState = nil
+        isLoading = false
     }
 
     /// Sign out — clear stored tokens.
@@ -656,26 +666,52 @@ final class GoogleCalendarService: ObservableObject {
 /// Listens on a random port, accepts one request (the Google OAuth redirect),
 /// extracts the auth code, sends a "success" page, and shuts down immediately.
 /// This is Google's officially recommended approach for desktop OAuth apps.
-private class LoopbackOAuthServer {
+final class LoopbackOAuthServer {
     struct Callback {
         let code: String
         let state: String?
     }
 
     private let onCode: (Callback) -> Void
+    private let lock = NSLock()
     private var serverSocket: Int32 = -1
+    private var stopped = false
 
     init(onCode: @escaping (Callback) -> Void) {
         self.onCode = onCode
     }
 
+    deinit {
+        stop()
+    }
+
+    /// Close the listening socket, releasing the port and unblocking the waiting `accept`.
+    /// Safe to call from any thread and more than once.
+    func stop() {
+        lock.lock()
+        let socketToClose = serverSocket
+        serverSocket = -1
+        stopped = true
+        lock.unlock()
+
+        if socketToClose >= 0 {
+            close(socketToClose)
+        }
+    }
+
+    private var isStopped: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return stopped
+    }
+
     /// Start listening. Returns the assigned port, or nil on failure.
     func start() -> UInt16? {
-        serverSocket = socket(AF_INET, SOCK_STREAM, 0)
-        guard serverSocket >= 0 else { return nil }
+        let listeningSocket = socket(AF_INET, SOCK_STREAM, 0)
+        guard listeningSocket >= 0 else { return nil }
 
         var yes: Int32 = 1
-        setsockopt(serverSocket, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
+        setsockopt(listeningSocket, SOL_SOCKET, SO_REUSEADDR, &yes, socklen_t(MemoryLayout<Int32>.size))
 
         var addr = sockaddr_in()
         addr.sin_family = sa_family_t(AF_INET)
@@ -683,24 +719,32 @@ private class LoopbackOAuthServer {
         addr.sin_addr.s_addr = inet_addr("127.0.0.1")
 
         let bindResult = withUnsafePointer(to: &addr) { ptr in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { bind(serverSocket, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) }
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { bind(listeningSocket, $0, socklen_t(MemoryLayout<sockaddr_in>.size)) }
         }
-        guard bindResult == 0 else { close(serverSocket); return nil }
-        guard listen(serverSocket, 1) == 0 else { close(serverSocket); return nil }
+        guard bindResult == 0 else { close(listeningSocket); return nil }
+        guard listen(listeningSocket, 1) == 0 else { close(listeningSocket); return nil }
 
         // Get the assigned port
         var assignedAddr = sockaddr_in()
         var len = socklen_t(MemoryLayout<sockaddr_in>.size)
         withUnsafeMutablePointer(to: &assignedAddr) { ptr in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(serverSocket, $0, &len) }
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(listeningSocket, $0, &len) }
         }
         let port = UInt16(bigEndian: assignedAddr.sin_port)
 
-        // Accept one connection in background
+        lock.lock()
+        serverSocket = listeningSocket
+        lock.unlock()
+
+        // Accept one connection in background. `stop()` closes the listening socket, which
+        // unblocks this `accept` so the flow can be abandoned without leaking the port.
         DispatchQueue.global(qos: .userInitiated).async { [self] in
-            let client = accept(serverSocket, nil, nil)
-            defer { close(client); close(serverSocket) }
-            guard client >= 0 else { return }
+            let client = accept(listeningSocket, nil, nil)
+            defer {
+                if client >= 0 { close(client) }
+                stop()
+            }
+            guard client >= 0, !isStopped else { return }
 
             var buffer = [UInt8](repeating: 0, count: 4096)
             let bytesRead = read(client, &buffer, buffer.count)

--- a/GhostPepper/UI/SettingsWindow.swift
+++ b/GhostPepper/UI/SettingsWindow.swift
@@ -2660,7 +2660,17 @@ struct SettingsView: View {
                                 Text("Connecting...")
                                     .font(.callout)
                                     .foregroundStyle(.secondary)
+                                Spacer()
+                                Button("Cancel") {
+                                    calendarService.cancelSignIn()
+                                }
+                                .buttonStyle(.plain)
+                                .foregroundColor(.red)
+                                .font(.caption)
                             }
+                            Text("Finish signing in on the browser tab that just opened, or cancel to start again with a different account.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
                         } else {
                             Text("Connect Google Calendar to automatically populate meeting titles and attendees when recording.")
                                 .font(.caption)

--- a/GhostPepperTests/LoopbackOAuthServerTests.swift
+++ b/GhostPepperTests/LoopbackOAuthServerTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import GhostPepper
+
+/// The loopback server backs the Google Calendar OAuth redirect. It used to have no way to
+/// stop, so abandoning sign-in left the port bound and the accept thread blocked for the
+/// lifetime of the app.
+final class LoopbackOAuthServerTests: XCTestCase {
+
+    func testDeliversAuthorizationCodeFromRedirect() throws {
+        let received = expectation(description: "callback delivered")
+        var callback: LoopbackOAuthServer.Callback?
+
+        let server = LoopbackOAuthServer {
+            callback = $0
+            received.fulfill()
+        }
+        defer { server.stop() }
+
+        let port = try XCTUnwrap(server.start(), "server should bind a port")
+        let client = try XCTUnwrap(Self.connect(toPort: port), "redirect should be accepted")
+        defer { close(client) }
+
+        let request = "GET /?code=test-auth-code&state=test-state HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n"
+        _ = request.withCString { write(client, $0, strlen($0)) }
+
+        wait(for: [received], timeout: 5)
+        XCTAssertEqual(callback?.code, "test-auth-code")
+        XCTAssertEqual(callback?.state, "test-state")
+    }
+
+    func testStopReleasesListeningPort() throws {
+        let server = LoopbackOAuthServer { _ in
+            XCTFail("callback should not fire after the flow is abandoned")
+        }
+
+        let port = try XCTUnwrap(server.start(), "server should bind a port")
+        server.stop()
+
+        XCTAssertNil(Self.connect(toPort: port), "port should be released once the flow is abandoned")
+    }
+
+    func testStopIsIdempotent() throws {
+        let server = LoopbackOAuthServer { _ in }
+        _ = try XCTUnwrap(server.start(), "server should bind a port")
+
+        server.stop()
+        server.stop()
+    }
+
+    /// Opens a TCP connection to 127.0.0.1 on `port`, returning the socket or nil if refused.
+    private static func connect(toPort port: UInt16) -> Int32? {
+        let client = socket(AF_INET, SOCK_STREAM, 0)
+        guard client >= 0 else { return nil }
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        addr.sin_addr.s_addr = inet_addr("127.0.0.1")
+
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                Darwin.connect(client, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard result == 0 else {
+            close(client)
+            return nil
+        }
+        return client
+    }
+}


### PR DESCRIPTION
## The bug

Settings → Meeting Transcript → **Connect Google Calendar** becomes a permanent loading wheel if you don't finish the browser flow. Quitting and relaunching the app is the only way to get the button back.

Repro:
1. Settings → Meeting Transcript → Connect Google Calendar.
2. The browser opens on the wrong Google account (or you just change your mind). Close the tab without granting access.
3. Return to Settings. The Connect button is gone, replaced by a "Connecting..." spinner that never resolves.
4. Only a relaunch clears it.

## Root cause

`GoogleCalendarService.signIn()` sets `isLoading = true` and only ever clears it from the `LoopbackOAuthServer` callback — which Google fires only on a successful redirect. Every abandonment path leaves the flag set:

```swift
isLoading = true
defer {
    if activeServer == nil {   // server started fine, so this never runs
        isLoading = false
    }
}
```

`SettingsWindow` renders the spinner *instead of* the Connect button whenever `isLoading` is set, so the stuck flag makes the row unrecoverable. The flag is in-memory only, which is why relaunching works.

Two related defects on the same path:

- The state-mismatch branch of the callback cleared `activeServer` but left `isLoading` set — the same permanent spinner, and it failed silently.
- `LoopbackOAuthServer` had no way to shut down. An abandoned flow left the listening socket bound and its `accept()` thread blocked for the lifetime of the app.

## The fix

- Add `cancelSignIn()`, and a **Cancel** button beside the "Connecting..." spinner so the flow is recoverable in place.
- `signIn()` now starts by cancelling any attempt still in flight, making retries idempotent. The meeting window's own Connect button doesn't gate on `isLoading` and could previously start a second listener.
- Clear the loading state on the state-mismatch path, and surface an error rather than failing silently.
- Give `LoopbackOAuthServer` a `stop()`, called from every abandonment and error path. It closes the listening socket, which releases the port and unblocks the waiting `accept()`.

## Tests

New `LoopbackOAuthServerTests` covers the redirect round-trip, port release on `stop()`, and `stop()` idempotency.

```
Test Case '-[GhostPepperTests.LoopbackOAuthServerTests testDeliversAuthorizationCodeFromRedirect]' passed (0.003 seconds).
Test Case '-[GhostPepperTests.LoopbackOAuthServerTests testStopIsIdempotent]' passed (0.001 seconds).
Test Case '-[GhostPepperTests.LoopbackOAuthServerTests testStopReleasesListeningPort]' passed (0.001 seconds).
** TEST SUCCEEDED **
```

I checked these fail against the old behaviour: stubbing `stop()` out to a no-op makes `testStopReleasesListeningPort` fail with `XCTAssertNil failed: "9" - port should be released once the flow is abandoned`.

`LoopbackOAuthServer` changed from `private` to internal so the tests can reach it via `@testable import`. `project.pbxproj` is the `xcodegen generate` output for the added test file.